### PR TITLE
hamster: Patch for launching ferret from within hamster.

### DIFF
--- a/packages/hamster/PKGBUILD
+++ b/packages/hamster/PKGBUILD
@@ -11,6 +11,11 @@ makedepends=(unzip)
 source=(http://www.clshack.it/nopaste/hamster-2.0.0.zip)
 md5sums=('0f302f3890225d9698bd9b964888d577')
 
+prepare() {
+  # execvp looks for commands in PATH
+  sed -i 's/execv/execvp/g' "${srcdir}/hamster/src/pixie.c"
+}
+
 build() {
   cd "${srcdir}/hamster/build/gcc4"
   make


### PR DESCRIPTION
Hamster was using 'execv' for launching ferret, which only works if
ferret is in the PWD. Replacing 'execv' with 'exevp' fixes this, as
'execvp' searches the PATH.
