### PR TITLE
updated zaproxy pkgbuild for latest release

### DIFF
--- a/packages/zaproxy/PKGBUILD
+++ b/packages/zaproxy/PKGBUILD
@@ -2,27 +2,24 @@
 # See COPYING for license details.
 
 pkgname=zaproxy
-pkgver=2.1.0
-pkgrel=6
+pkgver=2.2.2
+pkgrel=1
 groups=('blackarch' 'blackarch-fuzzer' 'blackarch-webapp')
-pkgdesc="An integrated penetration testing tool for finding vulnerabilities in web applications"
+pkgdesc="A local intercepting proxy with integrated penetration testing tool for finding vulnerabilities in web applications"
 arch=('any')
-url='http://code.google.com/p/zaproxy/'
+url="http://code.google.com/p/zaproxy/"
 license=('Apache')
 depends=('java-environment')
-source=("http://zaproxy.googlecode.com/files/ZAP_${pkgver}_Linux.tar.gz"
-        zap.sh)
-md5sums=('352505dd3a68639a77c3144b21372a1a'
-         'e0b842647bd2d79d9885dfaf3e939615')
+source=("http://zaproxy.googlecode.com/files/ZAP_${pkgver}_Linux.tar.gz")
+md5sums=('479c3e4ba3fa713c4e007cda585166a6')
 
 package() {
-  cd "$srcdir/ZAP_$pkgver"
+  install -dm=755 ${pkgdir}/usr/bin
+  install -dm=755 ${pkgdir}/usr/share/${pkgname}
 
-  # Make base directories.
-  install -dm755 "$pkgdir/usr/bin"
-  install -dm755 "$pkgdir/usr/share/zaproxy"
+  cp -r ${srcdir}/ZAP_${pkgver}/* ${pkgdir}/usr/share/${pkgname}
 
-  cp --no-preserve=ownership -R * "$pkgdir/usr/share/zaproxy"
-
-  install -Dm755 "$srcdir/zap.sh" "$pkgdir/usr/bin/zaproxy"
+  echo "#!/bin/sh" > ${pkgdir}/usr/bin/${pkgname}
+  echo "/usr/share/${pkgname}/zap.sh" >> ${pkgdir}/usr/bin/${pkgname}
+  chmod +x ${pkgdir}/usr/bin/${pkgname}
 }

--- a/packages/zaproxy/zap.sh
+++ b/packages/zaproxy/zap.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/share/zaproxy/zap.sh


### PR DESCRIPTION
Updated zaproxy pkgbuild to use version 2.2.2. Also, removed the need for an external binary file which can be done within the pkgbuild.
