### PR TITLE
zaproxy: patch, updated pkgbuild

### DIFF
--- a/packages/zaproxy/PKGBUILD
+++ b/packages/zaproxy/PKGBUILD
@@ -10,8 +10,10 @@ arch=('any')
 url="http://code.google.com/p/zaproxy/"
 license=('Apache')
 depends=('java-environment' 'bash')
-source=("http://zaproxy.googlecode.com/files/ZAP_${pkgver}_Linux.tar.gz")
-md5sums=('479c3e4ba3fa713c4e007cda585166a6')
+source=("http://zaproxy.googlecode.com/files/ZAP_${pkgver}_Linux.tar.gz"
+	'patchfile')
+md5sums=('479c3e4ba3fa713c4e007cda585166a6'
+	 'efdc294928281e2589bcb4fd1c9c2e3a')
 
 package() {
   install -dm755 "$pkgdir/usr/bin"
@@ -19,12 +21,13 @@ package() {
 
   cp -r "$srcdir/ZAP_$pkgver"/* "$pkgdir/usr/share/zaproxy"
 
+  # workaround for version parse error when _JAVA_OPTIONS is set
+  # NOTE: this will be fixed in next stable release
+  cd "$pkgdir/usr/share/zaproxy"
+  patch -p0 < "$srcdir/patchfile"
+
   cat > "$pkgdir/usr/bin/zaproxy" <<EOF
 #!/bin/sh
-# zap.sh parses the output of java -version for version information. If
-# _JAVA_OPTIONS is set, the parsing breaks.
-# TODO: patch zap.sh?
-unset _JAVA_OPTIONS
 exec /usr/share/zaproxy/zap.sh
 EOF
   chmod +x "$pkgdir/usr/bin/zaproxy"

--- a/packages/zaproxy/patchfile
+++ b/packages/zaproxy/patchfile
@@ -1,0 +1,16 @@
+--- zap.sh	2013-09-27 02:12:50.000000000 -0700
++++ myzap.sh	2014-02-22 19:01:53.582573304 -0800
+@@ -1,7 +1,12 @@
+ #!/usr/bin/env bash
+ 
+ #Check the java version (min java 7)
+-JAVAV=`java -version 2>&1 |awk 'NR==1{ gsub(/"/,""); print $3 }'`
++if [ $_JAVA_OPTIONS ]; then
++  #if options are set, awk skips first line of output
++  JAVAV=`java -version 2>&1 |awk 'NR>1{ gsub(/"/,""); print $3 }'`
++else
++  JAVAV=`java -version 2>&1 |awk 'NR==1{ gsub(/"/,""); print $3 }'`
++fi
+ 
+ if [[ $JAVAV == 1.[78]* ]]; then
+     # OK


### PR DESCRIPTION
zaproxy: wrote a patch for zap.sh to workaround parse error and updated pkgbuild to reflect changes.
