### PR TITLE
aircrack-ng-beta: updated

### DIFF
--- a/packages/aircrack-ng-beta/PKGBUILD
+++ b/packages/aircrack-ng-beta/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=aircrack-ng-beta
 pkgver=1.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A key cracker for the 802.11 WEP and WPA-PSK protocols"
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
 url="http://www.aircrack-ng.org"
@@ -12,16 +12,16 @@ depends=('openssl' 'sqlite' 'iw' 'net-tools' 'wireless_tools')
 conflicts=('aircrack-ng-scripts')
 replaces=('aircrack-ng-scripts')
 provides=('aircrack-ng-scripts')
-source=("http://download.aircrack-ng.org/aircrack-ng-$pkgver-beta1.tar.gz")
-md5sums=('f1cc7e19563bd64964f3584048a1031b')
+source=("http://download.aircrack-ng.org/aircrack-ng-$pkgver-beta2.tar.gz")
+md5sums=('f1c0f1d5e7eb063e40e109283599356b')
 
 build() {
-  cd "$srcdir/aircrack-ng-$pkgver-beta1"
+  cd "$srcdir/aircrack-ng-$pkgver-beta2"
   make SQLITE=true UNSTABLE=true
 }
 
 package() {
-  cd "$srcdir/aircrack-ng-$pkgver-beta1"
+  cd "$srcdir/aircrack-ng-$pkgver-beta2"
   make DESTDIR="$pkgdir" SQLITE=true UNSTABLE=true \
     bindir=/usr/bin sbindir=/usr/bin mandir=/usr/share/man/man1 install
 }


### PR DESCRIPTION
updated aircrack-ng-beta to use latest release (beta2)
