### PR TITLE
libdaq-static: update pkgbuild

### DIFF
--- a/packages/libdaq-static/PKGBUILD
+++ b/packages/libdaq-static/PKGBUILD
@@ -2,8 +2,8 @@
 # See COPYING for license details.
 
 pkgname=libdaq-static
-pkgver=2.0.1
-pkgrel=1
+pkgver=2.0.2
+pkgrel=2
 pkgdesc='Data Acquisition library for packet I/O.'
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
 url='http://www.snort.org/'
@@ -14,7 +14,7 @@ options=('staticlibs' '!makeflags')
 provides=('libdaq')
 conflicts=('libdaq')
 source=("http://www.snort.org/dl/snort-current/daq-${pkgver}.tar.gz")
-md5sums=('044aa3663d44580d005293eeb8ccf175')
+md5sums=('865bf9b750a2a2ca632591a3c70b0ea0')
 
 build() {
   cd "${srcdir}/daq-${pkgver}"


### PR DESCRIPTION
updated pkgbuild to use latest release (2.0.2)
