### PR TITLE
snort: update pkgbuild

### DIFF
--- a/packages/snort/PKGBUILD
+++ b/packages/snort/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=snort
-pkgver=2.9.5.6
+pkgver=2.9.6.0
 pkgrel=1
 pkgdesc="A lightweight network intrusion detection system."
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
@@ -22,8 +22,8 @@ source=("http://www.snort.org/dl/snort-current/snort-${pkgver}.tar.gz"
         'snort'
         'snort.conf.d'
         'snort.service')
-md5sums=('e993c97c1710d68a7b67813fe98c09a4'
-         'd650155c6ba88960c0d6f2bc815428e5'
+md5sums=('18111f6de3989ca89add36077a7c2659'
+         '69094bbcda469278b32528192cb10386'
          '361b8b9e40b9af0164f6b3e3da2e8277'
          'b4fb8a68490589cd34df93de7609bfac'
          '0d898dfe906fe45ad8562c500c36facb')


### PR DESCRIPTION
update pkgbuild to use latest release (2.9.6.0)
