### PR TITLE
Add msvpwn to the packages

### DIFF
--- a/packages/msvpwn/PKGBUILD
+++ b/packages/msvpwn/PKGBUILD
@@ -1,0 +1,30 @@
+pkgname=msvpwn-git
+pkgver=1
+pkgrel=1
+pkgdesc="Bypass Windows' authentication via binary patching"
+arch=('i686', 'x86_64')
+url="https://bitbucket.org/mrabault/msvpwn"
+license=('MIT')
+depends=('openssl')
+makedepends=('git')
+provides=('msvpwn')
+source=("$pkgname::git+https://bitbucket.org/mrabault/msvpwn.git")
+md5sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/$pkgname"
+  # Number of revisions since beginning of the history according to
+  # the VCS PKGBUILD Guidelines for Git
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  cd "$srcdir/$pkgname"
+  make
+}
+
+package() {
+  cd "$srcdir/$pkgname"
+  make PREFIX="$pkgdir/usr" install
+}
+


### PR DESCRIPTION
Hello,

This pull request adds `msvpwn` to the packages.  `msvpwn` is a tool which patches `msv1_0.dll` from Windows (in `C:\Windows\System32\msv1_0.dll` usually) to allow the attacker to log in with every password. There are no heuristics, I have reversed several versions of this DLL and hard-coded the patches (in such a way as it becomes trivial to add one). This is an offline attack, because you need physical access in order to log in (this will not work over the network).

I don't know if you will be interested in this though. You can check out the project's homepage [here](https://bitbucket.org/mrabault/msvpwn/overview) if you want more details, or i'll be pleased to answer any of your questions. This is a git-based PKGBUILD because if I add another patch, it will be a pain to re-generate a tarball and update the PKGBUILD.

Thanks in advance for you reply and please accept my apologies for any English error I might've made, as English is my second language.
