### PR TITLE
Update PKGBUILD for msvpwn

### DIFF
--- a/packages/msvpwn/PKGBUILD
+++ b/packages/msvpwn/PKGBUILD
@@ -12,19 +12,19 @@ source=("$pkgname::git+https://bitbucket.org/mrabault/msvpwn.git")
 md5sums=('SKIP')
 
 pkgver() {
-  cd "$srcdir/$pkgname"
-  # Number of revisions since beginning of the history according to
-  # the VCS PKGBUILD Guidelines for Git
-  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  cd "$pkgname"
+  git describe | sed -r 's/([^-]*-g)/r\1/;s/-/./g' | sed -r 's/v//g'
 }
 
 build() {
-  cd "$srcdir/$pkgname"
+  cd "$pkgname"
   make
 }
 
 package() {
-  cd "$srcdir/$pkgname"
+  cd "$pkgname"
   make PREFIX="$pkgdir/usr" install
+  mkdir -p "$pkgdir"/usr/share/licenses/msvpwn
+  install -m 755 LICENSE "$pkgdir"/usr/share/licenses/msvpwn/LICENSE
 }
 


### PR DESCRIPTION
Hello,

I updated the `PKGBUILD` for `msvpwn`, with the following changes:
- Fix pkgver() to include the tag and drop the "v" prefix according to the Arch packaging standards
- Reflect upstream changes

Could you pull the changes in ? Thanks in advance
