### PR TITLE
Fix xplico blackarch groups and $PKGVER

### DIFF
--- a/xplico/PKGBUILD
+++ b/xplico/PKGBUILD
@@ -5,6 +5,7 @@ pkgname='xplico'
 pkgver='1.1.0'
 pkgrel=1
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
+groups=('blackarch' 'blackarch-forensic' 'blackarch-windows')
 pkgdesc='Internet Traffic Decoder. Network Forensic Analysis Tool (NFAT)'
 url='http://www.xplico.org/'
 license=('GPL')
@@ -21,7 +22,7 @@ sha1sums=('SKIP')
 pkgver() {
   cd "$srcdir/xplico"
 
-  echo $(git tag)
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
 }
 
 build() {


### PR DESCRIPTION
This seems to be the best way to accomplish this:
`echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)`

Note: This is still not ready for testing, needs complete install file still.
