### PR TITLE
Updating to 0.50 due to CVE-2014-0476.

### DIFF
--- a/packages/chkrootkit/PKGBUILD
+++ b/packages/chkrootkit/PKGBUILD
@@ -2,15 +2,15 @@
 # See COPYING for license details.
 
 pkgname='chkrootkit'
-pkgver='0.49'
-pkgrel=4
+pkgver='0.50'
+pkgrel=5
 groups=('blackarch' 'blackarch-defensive' 'blackarch-forensic')
 pkgdesc="Checks for rootkits on a system"
 url="http://www.chkrootkit.org/"
 arch=('any')
 license=('GPL2')
-source=("ftp://ftp.pangeia.com.br/pub/seg/pac/chkrootkit.tar.gz")
-sha1sums=('cec1a3c482b95b20d3a946b07fffb23290abc4a6')
+source=("ftp://ftp.pangeia.com.br/pub/seg/pac/chkrootkit-0.50.tar.gz")
+sha1sums=('0c3f40b2919d25421a90533c2fe6cca81321232c')
 
 build(){
   cd "$srcdir/chkrootkit-$pkgver"


### PR DESCRIPTION
Also, will now get the specified version, because simply fetching "chkrootkit.tar.gz" would invalidate the sha1sum check.
