### PR TITLE
Fix for issue #798. Modification of logging and caching filenames to adapt to upstream changes.

### DIFF
--- a/packages/wpscan/PKGBUILD
+++ b/packages/wpscan/PKGBUILD
@@ -36,9 +36,9 @@ package() {
 exec ruby-1.9 /usr/share/wpscan/wpscan.rb "\$@"
 EOF
 
-  sed -i "s/ROOT_DIR, 'log.txt'/ENV['HOME'], 'log.txt'/" "$pkgdir/usr/share/wpscan/lib/common/common_helper.rb"
+  sed -i "s/ROOT_DIR, 'log.txt'/ENV['HOME'], 'wpscan.log'/" "$pkgdir/usr/share/wpscan/lib/common/common_helper.rb"
 
-  sed -i "s/ROOT_DIR, 'cache'/ENV['HOME'], 'cache'/" "$pkgdir/usr/share/wpscan/lib/common/common_helper.rb"
+  sed -i "s/ROOT_DIR, 'cache'/ENV['HOME'], '.wpscan-cache'/" "$pkgdir/usr/share/wpscan/lib/common/common_helper.rb"
 
   chmod +x "$pkgdir/usr/bin/wpscan"
 }


### PR DESCRIPTION
Logging is now in ~/wpscan.log and caching to ~/.wpscan-cache/
