### PR TITLE
Remove the netlib python module from the pathod package

### DIFF
--- a/packages/pathod/PKGBUILD
+++ b/packages/pathod/PKGBUILD
@@ -16,7 +16,7 @@ sha1sums=('699983f0580538ca4810278c9f791009026dac4d')
 build() {
   cd "$srcdir/pathod-$pkgver"
 
-  rm -rf ./netlib
+  rm -r ./netlib
   python2 setup.py build
 }
 

--- a/packages/pathod/PKGBUILD
+++ b/packages/pathod/PKGBUILD
@@ -16,6 +16,7 @@ sha1sums=('699983f0580538ca4810278c9f791009026dac4d')
 build() {
   cd "$srcdir/pathod-$pkgver"
 
+  rm -rf ./netlib
   python2 setup.py build
 }
 


### PR DESCRIPTION
The pathod release tarballs include the python2-netlib module which we
have packaged separately.