### PR TITLE
Fix extremely dangerous failing post-install script.

### DIFF
--- a/packages/nsia/PKGBUILD
+++ b/packages/nsia/PKGBUILD
@@ -36,6 +36,7 @@ package() {
   unset _JAVA_OPTIONS
 
   mkdir -p "$pkgdir/usr/bin"
+  mkdir -p "$pkgdir/var/lib/nsia/var"
 
   install -Dm644 nsia.tmpfiles.conf "$pkgdir/usr/lib/tmpfiles.d/nsia.conf"
   install -Dm644 -t "$pkgdir/usr/share/nsia/doc" doc/"Quick Start Guide.pdf" \

--- a/packages/nsia/nsia.install
+++ b/packages/nsia/nsia.install
@@ -7,7 +7,8 @@ post_upgrade() {
 post_install() {
   post_upgrade
 
-  cd /var/lib/nsia/var
+  mkdir -p /var/lib/nsia/var
+  cd /var/lib/nsia/var || exit 1
 
   java -Xbootclasspath/p:../lib/rhino.jar -jar /usr/share/nsia/bin/nsia.jar --install root root root || true
 


### PR DESCRIPTION
The strangely named /var/lib/nsia/var directory was not created by the PKGBUILD's package() function, and the post-install script runs recursive group and mode changes on the root directory, destroying existing installations. These changes correct this oversight.