### PR TITLE
Updated metasploit dependencies

### DIFF
--- a/packages/metasploit/PKGBUILD
+++ b/packages/metasploit/PKGBUILD
@@ -27,7 +27,7 @@ package_metasploit() {
 
   pkgdesc='An open source platform that supports vulnerability research, exploit development and the creation of custom security tools representing the largest collection of quality-assured exploits.'
   depends=('ruby' 'ruby-bundler' 'java-environment' 'postgresql' 'libpcap'
-           'make' 'tigervnc')
+           'make' 'tigervnc' 'libxslt')
   optdepends=('dradis: dradis database system'
               'metasploit-msfupdate: In order to use the msfupdate tool.')
 


### PR DESCRIPTION
Metasploit binary package fails to install correctly unless libxslt is present, added the dependency to PKGBUILD.