### PR TITLE
Forgot copy extide directory to /usr/share/maltego in PKGBUILD

### DIFF
--- a/packages/maltego/PKGBUILD
+++ b/packages/maltego/PKGBUILD
@@ -22,7 +22,7 @@ package() {
   mkdir -p "$pkgdir/usr/share/doc/maltego"
   mkdir -p "$pkgdir/usr/bin"
 
-  cp -aR bin etc groovy ide java maltego maltego-core-platform maltego-ui \
+  cp -aR bin extide etc groovy ide java maltego maltego-core-platform maltego-ui \
     platform "$pkgdir/usr/share/maltego"
 
   install -Dm644 "$srcdir/M3GuideGUI.pdf" \


### PR DESCRIPTION
Extide directory is need for maltego and you are forgot to copy that directory in PKGBUILD file