### PR TITLE
winexe: fix for gnutls > 3.0.0

### DIFF
--- a/packages/winexe/PKGBUILD
+++ b/packages/winexe/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname='winexe'
 pkgver='1.00'
-pkgrel=3
+pkgrel=4
 pkgdesc='Remotely execute commands on Windows NT/2000/XP/2003 systems.'
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
 url='http://sourceforge.net/projects/winexe/'
@@ -17,8 +17,8 @@ source=("http://downloads.sourceforge.net/project/winexe/winexe-$pkgver.tar.gz"
         "pidl.patch")
 sha1sums=('bdb598745953fcad3a9b6bba8f728c2b714a7aeb'
           '72f1ff7536e4245b3c085beef69d5760ef463cec'
-          '933978541c8efd523bb5ea46639b5c2e77dfe5fd'
-          'f3e733496dbf90bc2ebfa853cb1b1da9c9de4bba')
+          '4a1913c32622789bba46e5a77d7ca72fcf641342'
+          '71123c4996be736ab1e3c53ed7c6bf2885a502e9')
 
 prepare() {
   cd "$srcdir/winexe-$pkgver"

--- a/packages/winexe/gnutls.patch
+++ b/packages/winexe/gnutls.patch
@@ -21,3 +21,28 @@ diff -Nur winexe-1.00.orig/source4/lib/tls/tls.c winexe-1.00/source4/lib/tls/tls
  	tls->tls_detect = false;
  
  	tls->output_pending  = false;
+diff -Nur winexe-1.00.orig/source4/lib/tls/tls.c winexe-1.00/source4/lib/tls/tls.c
+--- winexe-1.00.orig/source4/lib/tls/tls.c	2015-07-16 18:10:12.636658106 +0200
++++ winexe-1.00/source4/lib/tls/tls.c	2015-07-16 17:51:55.528385030 +0200
+@@ -542,7 +542,9 @@
+ {
+ 	struct tls_context *tls;
+ 	int ret = 0;
++#if GNUTLS_VERSION_NUMBER < 0x030000
+ 	const int cert_type_priority[] = { GNUTLS_CRT_X509, GNUTLS_CRT_OPENPGP, 0 };
++#endif
+ 	struct socket_context *new_sock;
+ 	NTSTATUS nt_status;
+ 	
+@@ -568,7 +570,11 @@
+ 	gnutls_certificate_set_x509_trust_file(tls->xcred, ca_path, GNUTLS_X509_FMT_PEM);
+ 	TLSCHECK(gnutls_init(&tls->session, GNUTLS_CLIENT));
+ 	TLSCHECK(gnutls_set_default_priority(tls->session));
++#if GNUTLS_VERSION_NUMBER < 0x030000
+ 	gnutls_certificate_type_set_priority(tls->session, cert_type_priority);
++#else
++	gnutls_priority_set_direct(tls->session, "NORMAL:+CTYPE-OPENPGP", NULL);
++#endif
+ 	TLSCHECK(gnutls_credentials_set(tls->session, GNUTLS_CRD_CERTIFICATE, tls->xcred));
+ 
+ 	talloc_set_destructor(tls, tls_destructor);

--- a/packages/winexe/pidl.patch
+++ b/packages/winexe/pidl.patch
@@ -22,3 +22,28 @@ diff -Nur winexe-1.00.orig/pidl/lib/Parse/Pidl/IDL.pm winexe-1.00/pidl/lib/Parse
  				$parser->YYData->{LINE} = $1-1;
  				$parser->YYData->{FILE} = $2;
  				goto again;
+diff -Nur winexe-1.00.orig/pidl/lib/Parse/Pidl/ODL.pm winexe-1.00/pidl/lib/Parse/Pidl/ODL.pm
+--- winexe-1.00.orig/pidl/lib/Parse/Pidl/ODL.pm	2011-06-16 00:56:58.000000000 +0200
++++ winexe-1.00/pidl/lib/Parse/Pidl/ODL.pm	2015-07-16 17:22:09.547485504 +0200
+@@ -70,7 +70,7 @@
+ 					next;
+ 				}
+ 				my $podl = Parse::Pidl::IDL::parse_file($idl_path, $opt_incdirs);
+-				if (defined(@$podl)) {
++				if (@$podl) {
+ 					require Parse::Pidl::Typelist;
+ 					my $basename = basename($idl_path, ".idl");
+ 
+diff -Nur winexe-1.00.orig/pidl/pidl winexe-1.00/pidl/pidl
+--- winexe-1.00.orig/pidl/pidl	2011-06-16 00:56:58.000000000 +0200
++++ winexe-1.00/pidl/pidl	2015-07-16 17:22:19.477380979 +0200
+@@ -605,7 +605,7 @@
+ 		require Parse::Pidl::IDL;
+ 
+ 		$pidl = Parse::Pidl::IDL::parse_file($idl_file, \@opt_incdirs);
+-		defined @$pidl || die "Failed to parse $idl_file";
++		@$pidl || die "Failed to parse $idl_file";
+ 	}
+ 
+ 	require Parse::Pidl::Typelist;
+


### PR DESCRIPTION
Winexe did not work since gnutls versions > 3.0.0.
Also some perl problems with `defined`.

Please note that Sourceforge is currently having some issues, so you may need to download the source by hand.