### PR TITLE
recon-ng upgraded to version 4.6.3

### DIFF
--- a/packages/recon-ng/PKGBUILD
+++ b/packages/recon-ng/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname='recon-ng'
-pkgver='4.6.1'
+pkgver='4.6.3'
 pkgrel=1
 epoch=1
 groups=('blackarch' 'blackarch-recon')
@@ -13,16 +13,16 @@ license=('GPL3')
 depends=('python2')
 makedepends=('git')
 source=("https://bitbucket.org/LaNMaSteR53/recon-ng/get/v${pkgver}.tar.bz2")
-sha1sums=('95aa5ad1358a6e20f1827d00fbfa384ced114156')
+sha1sums=('2d23e7317e94c3e1204ace11b93fc728ff0eccb6')
 
 prepare() {
-  cd "$srcdir/LaNMaSteR53-recon-ng-1f23b7f782e7"
+  cd "$srcdir/LaNMaSteR53-recon-ng-a340236219d9"
 
   sed -i '1s/env python/env python2/' "recon-ng"
 }
 
 package() {
-  cd "$srcdir/LaNMaSteR53-recon-ng-1f23b7f782e7"
+  cd "$srcdir/LaNMaSteR53-recon-ng-a340236219d9"
 
   local _bins='recon-ng recon-cli recon-rpc'
 


### PR DESCRIPTION
I was trying to run today recon-ng on my own blackarch system for a pentest and notice it was outdated and was not able to run. so forked the project and did the changes for me locally, then i decided to push the change upstream so other people can also use it.