### PR TITLE
recon-ng version bump to 4.7.1

### DIFF
--- a/packages/recon-ng/PKGBUILD
+++ b/packages/recon-ng/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname='recon-ng'
-pkgver='4.6.3'
+pkgver='4.7.1'
 pkgrel=3
 epoch=1
 groups=('blackarch' 'blackarch-recon')
@@ -13,16 +13,16 @@ license=('GPL3')
 depends=('python2' 'python2-xlsxwriter')
 makedepends=('git')
 source=("https://bitbucket.org/LaNMaSteR53/recon-ng/get/v${pkgver}.tar.bz2")
-sha1sums=('2d23e7317e94c3e1204ace11b93fc728ff0eccb6')
+sha1sums=('77dc1f17cafbd84f5a824a1a8f50c7b8916b0093')
 
 prepare() {
-  cd "$srcdir/LaNMaSteR53-recon-ng-a340236219d9"
+  cd "$srcdir/LaNMaSteR53-recon-ng-131c609abc42"
 
   sed -i '1s/env python/env python2/' "recon-ng"
 }
 
 package() {
-  cd "$srcdir/LaNMaSteR53-recon-ng-a340236219d9"
+  cd "$srcdir/LaNMaSteR53-recon-ng-131c609abc42"
 
   local _bins='recon-ng recon-cli recon-rpc'
 


### PR DESCRIPTION
recon-ng was outdated and was getting annoying msg to force a switch to ignore this.. so is easier to just bump the version :) so here it is. 