### PR TITLE
Fix `elite-proxy-finder` missing dependency

### DIFF
--- a/packages/elite-proxy-finder/PKGBUILD
+++ b/packages/elite-proxy-finder/PKGBUILD
@@ -3,13 +3,13 @@
 
 pkgname='elite-proxy-finder'
 pkgver=49.589a76d
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-proxy')
 pkgdesc='Finds public elite anonymity proxies and concurrently tests them.'
 arch=('any')
 url='https://github.com/DanMcInerney/elite-proxy-finder'
 license=('custom')
-depends=('python2' 'python2-gevent' 'python2-requests')
+depends=('python2' 'python2-gevent' 'python2-requests' 'python2-beautifulsoup3')
 makedepends=('git')
 source=('git+https://github.com/DanMcInerney/elite-proxy-finder.git')
 sha1sums=('SKIP')


### PR DESCRIPTION
The `python2-beautifulsoup3` dependency was missing