### PR TITLE
Fix libcrypto 32-BIT forgotten dependency

### DIFF
--- a/packages/checkpwd/PKGBUILD
+++ b/packages/checkpwd/PKGBUILD
@@ -3,13 +3,13 @@
 
 pkgname='checkpwd'
 pkgver='1.23'
-pkgrel=3
+pkgrel=4
 pkgdesc='Oracle Password Checker (Cracker).'
 groups=('blackarch' 'blackarch-cracker')
 url='http://www.red-database-security.com/software/checkpwd.html'
 license=('GPL')
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
-depends=('unixodbc' 'zlib' 'libstdc++5')
+depends=('lib32-openssl' 'unixodbc' 'zlib' 'libstdc++5')
 source=('http://www.red-database-security.com/software/oracle_checkpwd_linux.tar.gz'
         'checkpwd.sh' 'checkpwd_nopw.sh' 'sqlplus.sh')
 noextract=('oracle_checkpwd_linux.tar.gz')
@@ -24,7 +24,7 @@ package() {
   mkdir -p "$pkgdir/usr/share/checkpwd"
 
   tar xfz oracle_checkpwd_linux.tar.gz -C "$pkgdir/usr/share/checkpwd"
-  ln -s /usr/lib/libcrypto.so "$pkgdir/usr/share/checkpwd/libcrypto.so.0"
+  ln -s /usr/lib32/libcrypto.so "$pkgdir/usr/share/checkpwd/libcrypto.so.0"
 
   install -Dm755 checkpwd.sh "$pkgdir/usr/bin/checkpwd"
   install -Dm755 checkpwd_nopw.sh "$pkgdir/usr/bin/checkpwd_nopw"


### PR DESCRIPTION
### Issue Description
checkpwd tool is a 32-BIT ELF.
therefore, it requires the 32-BIT version of libcrypto LSB\

---

### Issue demonstration
**`$ yaourt -Qi checkpwd`**
```
Name           : checkpwd
Version        : 1.23-3
Description    : Oracle Password Checker (Cracker).
Architecture   : x86_64
URL            : http://www.red-database-security.com/software/checkpwd.html
Licenses       : GPL
Groups         : blackarch  blackarch-cracker
Provides       : None
Depends On     : unixodbc  zlib  libstdc++5
Optional Deps  : None
Required By    : None
Optional For   : None
Conflicts With : None
Replaces       : None
Installed Size : 116.03 MiB
Packager       : Levon Kayan <noptrix@nullsecurity.net>
Build Date     : Sun 22 Mar 2015 03:04:49 PM CET
Install Date   : Tue 17 Nov 2015 11:58:59 PM CET
Install Reason : Explicitly installed
Install Script : No
Validated By   : Signature
```
**`$ checkpwd`**
```
./checkpwd: error while loading shared libraries: libcrypto.so.0: wrong ELF class: ELFCLASS64
```