### PR TITLE
Fix 'set' PKGBUILD's indentation patch

### DIFF
--- a/packages/set/PKGBUILD
+++ b/packages/set/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname='set'
 pkgver='6.5.9'
-pkgrel=1
+pkgrel=2
 epoch=1
 groups=('blackarch' 'blackarch-social' 'blackarch-exploitation')
 pkgdesc='Social-engineer toolkit. Aimed at penetration testing around Social-Engineering.'
@@ -39,6 +39,8 @@ prepare() {
 
   # Fix tab-space inconsistencies.
   sed -i 's/\t/    /g' se*
+  # 'freehugs' easteregg command: Fix code block bad indentation
+  sed -i '194,197s/^/    /' setoolkit
 
   # Fix all calls to 'python-pycrypto' change to 'python2-crypto'
   grep -Rl python-pycrypto ./ | xargs sed -i 's|python-pycrypto|python2-crypto|g'


### PR DESCRIPTION
tabulations replacements in `setoolkit` file caused lines 194 to 197 to be missindented,
making set command unusable on the main menu loop.