### PR TITLE
Add missing dependency on 'sipsak' package

### DIFF
--- a/packages/sipsak/PKGBUILD
+++ b/packages/sipsak/PKGBUILD
@@ -3,13 +3,13 @@
 
 pkgname='sipsak'
 pkgver='4.1.1.1'
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-voip')
 pkgdesc='A small command line tool for developers and administrators of Session Initiation Protocol (SIP) applications.'
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
 url='http://sipsak.org'
 license=('GPL')
-depends=('gnutls' 'openssl')
+depends=('gnutls' 'openssl' 'c-ares')
 source=("https://github.com/sipwise/sipsak/archive/mr${pkgver}.tar.gz")
 sha1sums=('6cba30e626f8c913ffe629e1f2a2dfbbb1b91a19')
 


### PR DESCRIPTION
## Fix missing 'c-ares' dependency on 'sipsak' package

**Without c-ares package installed, running sipsak produced the following error:**
```
$ sipsak
sipsak: error while loading shared libraries: libcares.so.2: cannot open shared object file: No such file or directory
```