### PR TITLE
secure-delete: Fix conflicts

### DIFF
--- a/packages/secure-delete/PKGBUILD
+++ b/packages/secure-delete/PKGBUILD
@@ -38,8 +38,5 @@ package() {
 
   # Fix a conflict with community/smem.
   mv "$pkgdir/usr/bin/smem" "$pkgdir/usr/bin/smem-secure-delete"
-
-  # Fix a conflict with community/srm.
-  mv "$pkgdir/usr/share/man/man1/srm.1" \
-    "$pkgdir/usr/share/man/man1/srm_secure-delete.1"
+  mv "$pkgdir/usr/share/man/man1/smem.1.gz" "$pkgdir/usr/share/man/man1/smem-secure-delete.1.gz"
 }


### PR DESCRIPTION
secure-delete is conflict with package srm, so there is no need to rename /usr/bin/srm.
better to rename man page of smem to avoid confusion.