### PR TITLE
ivre: version bump, use version number from setup.py, add opt dep

### DIFF
--- a/packages/ivre/PKGBUILD
+++ b/packages/ivre/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname='ivre'
-pkgver=898.078fc2d
+pkgver=0.9.3.dev.898.078fc2d
 pkgrel=1
 groups=('blackarch' 'blackarch-recon' 'blackarch-networking')
 pkgdesc='Network recon framework.'
@@ -10,31 +10,23 @@ arch=('any')
 url='https://ivre.rocks/'
 license=('GPL3')
 depends=('python2' 'python2-crypto' 'python2-pymongo')
+optdepends=('python2-py2neo: flow analysis support')
 makedepends=('git' 'python2-setuptools')
 source=('git+https://github.com/cea-sec/ivre.git')
 sha1sums=('SKIP')
 
 pkgver() {
   cd "$srcdir/ivre"
-
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  echo $(grep 'version=' setup.py | sed 's#.*version=\(.\)\(.*\)\1,$#\2#').dev.$(git rev-list --count HEAD).$(git rev-parse --short HEAD)
 }
 
 build() {
   cd "$srcdir/ivre"
-
   python2 setup.py build
 }
 
 package() {
   cd "$srcdir/ivre"
-
   install -Dm644 -t "$pkgdir/usr/share/licenses/ivre/" doc/LICENSE*
-
   python2 setup.py install --root="$pkgdir" --optimize=1
-
-#  for i in *
-#  do
-#    mv $i "ivre-$i"
-#  done
 }


### PR DESCRIPTION
IVRE includes a [new feature for flow analysis](cea-sec/ivre#227) which comes with an optional dependency.

Also, the package version now includes IVRE's base version (0.9.3 for now). I'm not sure if it matches BlackArch versions policy, so please let me know if you prefer something else.