### PR TITLE
recon-ng version bump to 4.8.0

### DIFF
--- a/packages/recon-ng/PKGBUILD
+++ b/packages/recon-ng/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname='recon-ng'
-pkgver='4.7.4'
+pkgver='4.8.0'
 pkgrel=1
 epoch=1
 groups=('blackarch' 'blackarch-recon')
@@ -14,16 +14,16 @@ depends=('python2' 'python2-xlsxwriter' 'python2-dict2xml' 'python2-pypdf2'
          'python2-dicttoxml')
 makedepends=('git')
 source=("https://bitbucket.org/LaNMaSteR53/recon-ng/get/v${pkgver}.tar.bz2")
-sha1sums=('e402866813329a114eea8398048f3b6814e053f5')
+sha1sums=('9486a6b45e0386b2aae9678a352b73ef980cbd7e')
 
 prepare() {
-  cd "$srcdir/LaNMaSteR53-recon-ng-d23da13f2b6d"
+  cd "$srcdir/LaNMaSteR53-recon-ng-38977ac58b3b"
 
   sed -i '1s/env python/env python2/' "recon-ng"
 }
 
 package() {
-  cd "$srcdir/LaNMaSteR53-recon-ng-d23da13f2b6d"
+  cd "$srcdir/LaNMaSteR53-recon-ng-38977ac58b3b"
 
   local _bins='recon-ng recon-cli recon-rpc'
 


### PR DESCRIPTION
Hello again :) sorry to keep sending pull request for different packages, I work as a pentester and when some packages get behind I have to modify the package to install it.. in some cases like recon-ng I can't even use it unless I update, so figure to sent upstream my changes, i'm sure if there is other professional pentesters using blackarch they will be happy to see the version bump. Cheers.