### PR TITLE
bump faraday to 2546.508a848

### DIFF
--- a/packages/faraday/PKGBUILD
+++ b/packages/faraday/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname='faraday'
-pkgver=2447.2690215
+pkgver=2546.508a848
 pkgrel=1
 pkgdesc='A new concept (IPE) Integrated Penetration-Test Environment a multiuser Penetration test IDE. Designed for distribution, indexation and analyze of the generated data during the process of a security audit.'
 groups=('blackarch' 'blackarch-scanner' 'blackarch-exploitation'


### PR DESCRIPTION
This is important since the new version defaults to GTK, the old one that is installed by blackarch defaults to QT and the UI comes out with international chars not western so is broken.. I just tested this build on my system and defaults to GTK and there is no issues so far.. let me know if you need anything else. cheers.