### PR TITLE
recon-ng: error fix and version upgrade

### DIFF
--- a/packages/recon-ng/PKGBUILD
+++ b/packages/recon-ng/PKGBUILD
@@ -11,7 +11,7 @@ arch=('any')
 url='https://bitbucket.org/LaNMaSteR53/recon-ng'
 license=('GPL3')
 depends=('python2' 'python2-xlsxwriter' 'python2-dict2xml' 'python2-pypdf2'
-         'python2-dicttoxml')
+         'python2-dicttoxml' 'python2-olefileio-pl')
 makedepends=('git')
 source=("https://bitbucket.org/LaNMaSteR53/recon-ng/get/v${pkgver}.tar.bz2")
 sha1sums=('9486a6b45e0386b2aae9678a352b73ef980cbd7e')

--- a/packages/recon-ng/PKGBUILD
+++ b/packages/recon-ng/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname='recon-ng'
-pkgver='4.8.0'
+pkgver='4.8.1'
 pkgrel=1
 epoch=1
 groups=('blackarch' 'blackarch-recon')
@@ -15,16 +15,16 @@ depends=('python2' 'python2-dicttoxml' 'python2-dnspython' 'python2-jsonrpclib'
          'python2-xlsxwriter' 'python2-olefileio-pl' 'python2-pypdf2')
 makedepends=('git')
 source=("https://bitbucket.org/LaNMaSteR53/recon-ng/get/v${pkgver}.tar.bz2")
-sha1sums=('9486a6b45e0386b2aae9678a352b73ef980cbd7e')
+sha1sums=('00c5fbd7688cf768f5cdd6f7f0fe5fa748e735b4')
 
 prepare() {
-  cd "$srcdir/LaNMaSteR53-recon-ng-38977ac58b3b"
+  cd "$srcdir/LaNMaSteR53-recon-ng-4e3cc65adfdd"
 
   sed -i '1s/env python/env python2/' "recon-ng"
 }
 
 package() {
-  cd "$srcdir/LaNMaSteR53-recon-ng-38977ac58b3b"
+  cd "$srcdir/LaNMaSteR53-recon-ng-4e3cc65adfdd"
 
   local _bins='recon-ng recon-cli recon-rpc'
 

--- a/packages/recon-ng/PKGBUILD
+++ b/packages/recon-ng/PKGBUILD
@@ -10,8 +10,9 @@ pkgdesc='A full-featured Web Reconnaissance framework written in Python.'
 arch=('any')
 url='https://bitbucket.org/LaNMaSteR53/recon-ng'
 license=('GPL3')
-depends=('python2' 'python2-xlsxwriter' 'python2-dict2xml' 'python2-pypdf2'
-         'python2-dicttoxml' 'python2-olefileio-pl')
+depends=('python2' 'python2-dicttoxml' 'python2-dnspython' 'python2-jsonrpclib'
+         'python2-lxml' 'python2-mechanize' 'python2-slowaes'
+         'python2-xlsxwriter' 'python2-olefileio-pl' 'python2-pypdf2')
 makedepends=('git')
 source=("https://bitbucket.org/LaNMaSteR53/recon-ng/get/v${pkgver}.tar.bz2")
 sha1sums=('9486a6b45e0386b2aae9678a352b73ef980cbd7e')
@@ -34,7 +35,7 @@ package() {
       README.md REQUIREMENTS VERSION
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/recon-ng/LICENSE"
 
-  rm README.md REQUIREMENTS VERSION LICENSE
+  rm LICENSE README.md
 
   cp -a * "$pkgdir/usr/share/recon-ng"
 

--- a/packages/recon-ng/PKGBUILD
+++ b/packages/recon-ng/PKGBUILD
@@ -30,11 +30,11 @@ package() {
   mkdir -p "$pkgdir/usr/bin"
   mkdir -p "$pkgdir/usr/share/recon-ng"
 
-  install -Dm644 -t "$pkgdir/usr/share/doc/recon-ng" README.md REQUIREMENTS \
-    VERSION
+  install -Dm644 -t "$pkgdir/usr/share/doc/recon-ng" \
+      README.md REQUIREMENTS VERSION
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/recon-ng/LICENSE"
 
-  rm LICENSE README.md
+  rm README.md REQUIREMENTS VERSION LICENSE
 
   cp -a * "$pkgdir/usr/share/recon-ng"
 
@@ -42,8 +42,8 @@ package() {
   do
     cat >> "$pkgdir/usr/bin/$bin" << EOF
 #!/bin/sh
-cd /usr/share/$bin
-exec python2 $bin
+cd /usr/share/recon-ng
+exec python2 $bin \$@
 EOF
     chmod +x "$pkgdir/usr/bin/$bin"
   done


### PR DESCRIPTION
## recon-ng: add missing dependency `olefile`

If not installed, recon-ng disables the `metacrawler` module:
    ```
    [!] Module 'recon/domains-contacts/metacrawler' disabled. Dependency
    required: 'olefile'.
    ```


## recon-ng: fix errors on bins

* the binaries reated were not working properly:
  - add '$@' on binary calls to be able to pass arguments
  - fix working directory to `/usr/share/recon-ng`
* cleanout PKGBUILD:
  - REQUIREMENTS VERSION were not properly deleted,
    added them to the list of rm items.


## recon-ng: fix some missing dependencies

dependencies tested and added according to
`recon-ng/REQUIREMENTS` file.


## recon-ng: upgrade to version 4.8.1