### PR TITLE
dump1090: Fixed public_html location

### DIFF
--- a/packages/dump1090/PKGBUILD
+++ b/packages/dump1090/PKGBUILD
@@ -23,7 +23,7 @@ pkgver() {
 build() {
   cd "$srcdir/dump1090"
 
-  sed -i 's#gmap\.html#/usr/share/dump1090/public_html/gmap\.html#g' dump1090.c
+  sed -i 's#./public_html#/usr/share/dump1090/public_html#g' dump1090.h
 
   make
 }


### PR DESCRIPTION
Fixes the location of public_html directory in `dump1090` so that it can show the map correctly when run with `--net`.