### PR TITLE
Vcsmap version bump

### DIFF
--- a/packages/vcsmap/PKGBUILD
+++ b/packages/vcsmap/PKGBUILD
@@ -2,8 +2,8 @@
 # See COPYING for license details.
 
 pkgname='vcsmap'
-pkgver=24.c872631
-pkgrel=2
+pkgver=32.6fba205
+pkgrel=3
 pkgdesc='A plugin-based tool to scan public version control systems for sensitive information.'
 groups=('blackarch' 'blackarch-scanner')
 arch=('any')


### PR DESCRIPTION
Thanks for including vcsmap in BlackArch!

Today I released a new version that fixes a change in GitHub. This is an important update. Because I noticed that vcsmap is included in BlackArch I also made it easier to find the right directory (see: https://github.com/melvinsh/vcsmap/commit/6fba205d8d8fe32365775c32373d135cc6c4cf82). 

This is my first edit to a `PKGBUILD`, so I hope I got it right.