### PR TITLE
Pass arguments to oletools /usr/bin/ wrappers

### DIFF
--- a/packages/oletools/PKGBUILD
+++ b/packages/oletools/PKGBUILD
@@ -35,7 +35,7 @@ package() {
   do
     cat > "$pkgdir/usr/bin/${f%.py}" <<EOF
 #!/bin/sh
-exec python2 /usr/lib/python2.7/site-packages/oletools/$f
+exec python2 /usr/lib/python2.7/site-packages/oletools/$f \$@
 EOF
     chmod +x "$pkgdir/usr/bin/${f%.py}"
 


### PR DESCRIPTION
Without the arguments ($@) the wrappers only show builtin help

Ex:
```
$ oleid suspicious.doc 
Usage: 
oleid.py

oleid is a script to analyze OLE files such as MS Office documents (e.g. Word,
Excel), to detect specific characteristics that could potentially indicate that
the file is suspicious or malicious, in terms of security (e.g. malware).
For example it can detect VBA macros, embedded Flash objects, fragmentation.
The results can be displayed or returned as XML for further processing.

Usage: oleid.py <file>

oleid project website: http://www.decalage.info/python/oleid

oleid is part of the python-oletools package:
http://www.decalage.info/python/oletools

usage: oleid.py [options] <file>

Options:
  -h, --help  show this help message and exit
```

```
$ cat `which oleid`
#!/bin/sh
exec python2 /usr/lib/python2.7/site-packages/oletools/oleid.py
```

Work-around: edit file to add $@ at the end:

```
$ cat `which oleid`
#!/bin/sh
exec python2 /usr/lib/python2.7/site-packages/oletools/oleid.py $@

$ oleid suspicious.doc 

Filename: suspicious.doc
+-------------------------------+-----------------------+
| Indicator                     | Value                 |
+-------------------------------+-----------------------+
| OLE format                    | True                  |
| Has SummaryInformation stream | True                  |
| Application name              | Microsoft Office Word |
| Encrypted                     | False                 |
| Word Document                 | True                  |
| VBA Macros                    | True                  |
| Excel Workbook                | False                 |
| PowerPoint Presentation       | False                 |
| Visio Drawing                 | False                 |
| ObjectPool                    | False                 |
| Flash objects                 | 0                     |
+-------------------------------+-----------------------+
