### PR TITLE
Update PKGBUILD

### DIFF
--- a/packages/libpff/PKGBUILD
+++ b/packages/libpff/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc='A library to access the Personal Folder File (PFF) and the Offline Fold
 arch=('i686' 'x86_64' 'armv6h' 'armv7h' 'aarch64')
 url='https://github.com/libyal/libpff'
 license=('LGPL3')
-groups=('blackarch', 'blackarch-forensic')
+groups=('blackarch' 'blackarch-forensic')
 depends=('libbfio')
 makedepends=('git' 'autoconf' 'automake' 'libtool' 'gettext' 'pkg-config'
              'bison' 'flex')


### PR DESCRIPTION
Commas are not part of bash arrays.