### PR TITLE
IVRE: use correct version, version bump, add optional dep

### DIFF
--- a/packages/ivre/PKGBUILD
+++ b/packages/ivre/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname='ivre'
-pkgver=1141.ffd95ca
+pkgver=0.9.4.dev9
 pkgrel=1
 groups=('blackarch' 'blackarch-recon' 'blackarch-networking')
 pkgdesc='Network recon framework.'
@@ -10,31 +10,23 @@ arch=('any')
 url='https://ivre.rocks/'
 license=('GPL3')
 depends=('python2' 'python2-crypto' 'python2-pymongo')
+optdepends=('python2-py2neo: flow analysis support')
 makedepends=('git' 'python2-setuptools')
 source=('git+https://github.com/cea-sec/ivre.git')
 sha1sums=('SKIP')
 
 pkgver() {
   cd "$srcdir/ivre"
-
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  python2 setup.py --version
 }
 
 build() {
   cd "$srcdir/ivre"
-
   python2 setup.py build
 }
 
 package() {
   cd "$srcdir/ivre"
-
   install -Dm644 -t "$pkgdir/usr/share/licenses/ivre/" doc/LICENSE*
-
   python2 setup.py install --root="$pkgdir" --optimize=1
-
-#  for i in *
-#  do
-#    mv $i "ivre-$i"
-#  done
 }


### PR DESCRIPTION
This adds an optional dependency and uses the correct version, based on IVRE's `setup.py --version` output.