### PR TITLE
new tool: dradis-ce

### DIFF
--- a/packages/dradis-ce/PKGBUILD
+++ b/packages/dradis-ce/PKGBUILD
@@ -1,0 +1,48 @@
+# This file is part of BlackArch Linux ( http://blackarch.org ).
+# See COPYING for license details.
+
+pkgname='dradis-ce'
+pkgver=659.ad2371b
+pkgrel=1
+pkgdesc='An open source framework to enable effective information sharing.'
+groups=('blackarch' 'blackarch-recon' 'blackarch-misc')
+url='http://dradisframework.org/'
+license=('GPL')
+depends=('ruby2.3' 'ruby2.3-bundler' 'git')
+makedepends=('git')
+arch=('any')
+source=("git+https://github.com/dradis/dradis-ce.git"
+        "dradis.patch")
+install='dradis.install'
+sha1sums=('SKIP'
+          'b17358c1bc90eb820abe3304ae88ecb5f038bd97')
+
+pkgver() {
+  cd "$srcdir/$pkgname"
+
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+prepare() {
+  cd "$srcdir/$pkgname"
+
+  patch -p1 -i ../dradis.patch
+}
+
+package() {
+  cd "$srcdir"
+
+  mkdir -p "$pkgdir/usr/bin"
+  mkdir -p "$pkgdir/usr/share/dradis-ce"
+  rm -rf "$pkgname/.ruby-version"
+  cp -ar "$pkgname" "$pkgdir/usr/share/dradis-ce/"
+
+
+  cat > "$pkgdir/usr/bin/dradis-ce" << EOF
+#!/bin/sh
+cd /usr/share/dradis-ce/dradis-ce
+exec bundle-2.3 exec rails server
+EOF
+
+  chmod +x "$pkgdir/usr/bin/dradis-ce"
+}

--- a/packages/dradis-ce/dradis.install
+++ b/packages/dradis-ce/dradis.install
@@ -1,0 +1,24 @@
+
+post_install() {
+  set -e
+  cd /usr/share/dradis-ce/dradis-ce
+  bundle-2.3 config build.nokogiri --use-system-libraries
+  ruby-2.3 bin/setup
+  mkdir templates
+  chmod -R a+w tmp log
+  chmod a+w db templates db/development.sqlite3
+
+}
+
+post_upgrade() {
+  set -e
+  cd /usr/share/dradis-ce/dradis-ce
+  ruby-2.3 bin/update
+  chmod -R a+w tmp log
+  chmod a+w db templates db/development.sqlite3
+
+}
+
+post_remove() {
+  rm -r /usr/share/dradis-ce
+}

--- a/packages/dradis-ce/dradis.patch
+++ b/packages/dradis-ce/dradis.patch
@@ -1,0 +1,125 @@
+diff --git a/Gemfile b/Gemfile
+index 5eeab3e..036e3cd 100644
+--- a/Gemfile
++++ b/Gemfile
+@@ -196,6 +196,7 @@ end
+ # Base framework classes required by other plugins
+ gem 'dradis-plugins', '~> 3.5'
+ 
++gem 'ruby-nmap', '~> 0.7'
+ 
+ gem 'dradis-api', path: 'engines/dradis-api'
+ 
+diff --git a/Gemfile.plugins.template b/Gemfile.plugins.template
+index 8487b88..13820e9 100644
+--- a/Gemfile.plugins.template
++++ b/Gemfile.plugins.template
+@@ -5,12 +5,16 @@
+ #   $ bundle
+ 
+ # ----------------------------------------------------------------- Calculators
+-gem 'dradis-calculator_cvss',  '~> 3.0'
+-gem 'dradis-calculator_dread', '~> 3.0'
++# gem 'dradis-calculator_cvss',  '~> 3.0'
++# gem 'dradis-calculator_dread', '~> 3.0'
++#
++gem 'dradis-calculator_cvss',    path: '../dradis-calculator_cvss/'
++gem 'dradis-calculator_dread',    path: '../dradis-calculator_dread/'
+ 
+ # ---------------------------------------------------------------------- Export
+ gem 'dradis-csv',         path: '../dradis-csv/'
+-gem 'dradis-html_export', '3.3.3'
++# gem 'dradis-html_export', '3.3.3'
++gem 'dradis-html_export', path: '../dradis-html_export/'
+ # ---------------------------------------------------------------------- Import
+ # gem 'dradis-mediawiki', path: '../dradis-mediawiki/'
+ # gem 'dradis-vulndb',    path: '../dradis-vulndb/'
+@@ -20,11 +24,16 @@ gem 'dradis-acunetix',    path: '../dradis-acunetix/'
+ gem 'dradis-brakeman',    path: '../dradis-brakeman/'
+ gem 'dradis-burp',        path: '../dradis-burp/'
+ gem 'dradis-metasploit',  path: '../dradis-metasploit/'
+-gem 'dradis-nessus',      '~> 3.3'
++# gem 'dradis-nessus',      '~> 3.3'
++gem 'dradis-nessus',      path: '../dradis-nessus/'
+ gem 'dradis-nexpose',     path: '../dradis-nexpose/'
+ gem 'dradis-nikto',       path: '../dradis-nikto/'
+-gem 'dradis-nmap',        '~> 3.1'
++# gem 'dradis-nmap',        '~> 3.1'
++gem 'dradis-nmap',        path: '../dradis-nmap/'
++# dradis-nmap also requires ruby-nmap
++gem 'ruby-nmap', 	  '~> 0.7'
+ gem 'dradis-ntospider',   path: '../dradis-ntospider/'
+ gem 'dradis-openvas',     path: '../dradis-openvas/'
+ gem 'dradis-qualys',      path: '../dradis-qualys/'
+-gem 'dradis-zap',         '~> 3.0'
++# gem 'dradis-zap',         '~> 3.0'
++gem 'dradis-zap',         path: '../dradis-zap/'
+diff --git a/bin/bundle b/bin/bundle
+index 66e9889..56fbef1 100755
+--- a/bin/bundle
++++ b/bin/bundle
+@@ -1,3 +1,3 @@
+-#!/usr/bin/env ruby
++#!/usr/bin/env ruby-2.3
+ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ load Gem.bin_path('bundler', 'bundle')
+diff --git a/bin/rails b/bin/rails
+index 0739660..ffad6ab 100755
+--- a/bin/rails
++++ b/bin/rails
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env ruby
++#!/usr/bin/env ruby-2.3
+ APP_PATH = File.expand_path('../config/application', __dir__)
+ require_relative '../config/boot'
+ require 'rails/commands'
+diff --git a/bin/rake b/bin/rake
+index 1724048..5719296 100755
+--- a/bin/rake
++++ b/bin/rake
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env ruby
++#!/usr/bin/env ruby-2.3
+ require_relative '../config/boot'
+ require 'rake'
+ Rake.application.run
+diff --git a/bin/setup b/bin/setup
+index 97e6a62..bb13eef 100755
+--- a/bin/setup
++++ b/bin/setup
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env ruby
++#!/usr/bin/env ruby-2.3
+ require 'fileutils'
+ require 'pathname'
+ include FileUtils
+@@ -50,8 +50,7 @@ Dir.chdir APP_ROOT do
+   end
+ 
+   puts '== Installing dependencies =='
+-  system! 'gem install bundler --conservative'
+-  system('bundle check') || system!('bundle install')
++  system('bundle-2.3 check') || system!('bundle-2.3 install --path vendor/bundle')
+ 
+   puts "\n== Copying sample files =="
+   unless File.exist?('Gemfile.plugins')
+diff --git a/bin/update b/bin/update
+index a8e4462..d82f3de 100755
+--- a/bin/update
++++ b/bin/update
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env ruby
++#!/usr/bin/env ruby-2.3
+ require 'pathname'
+ require 'fileutils'
+ include FileUtils
+@@ -15,8 +15,7 @@ chdir APP_ROOT do
+   # Add necessary update steps to this file.
+ 
+   puts '== Installing dependencies =='
+-  system! 'gem install bundler --conservative'
+-  system('bundle check') || system!('bundle install')
++  system('bundle-2.3 check') || system!('bundle-2.3 install')
+ 
+   puts "\n== Updating database =="
+   system! 'bin/rails db:migrate'


### PR DESCRIPTION
I've finally found some time to look at the non-legacy dradis, dradis-ce.

To make it usable without running rails as root a few files and folders in `/usr/share/dradis-ce`  are made world writable, which is probably not the best way to approach this – I'm open to suggestions for better ways to handle this situation: maybe by creating a dradis-user who can write in those folders and launching dradis/rails with a service?

