### PR TITLE
Add dependencies for wifi-pumpkin

### DIFF
--- a/packages/wifi-pumpkin/PKGBUILD
+++ b/packages/wifi-pumpkin/PKGBUILD
@@ -16,7 +16,8 @@ depends=('python2' 'python2-twisted' 'scapy' 'python2-beautifulsoup4'
          'python2-lxml' 'ipython2' 'hostapd' 'rfkill' 'php-cgi' 'dhcp'
          'python2-pyopenssl' 'python2-pygtail' 'python2-configparser'
          'python2-netifaces' 'sslstrip' 'driftnet' 'python2-hyperframe'
-         'python2-pefile' 'python2-h2' 'capstone' 'python2-capstone')
+         'python2-pefile' 'python2-h2' 'capstone' 'python2-capstone'
+	 'python2-configobj' 'python2-netfilterqueue' 'python2-pip')
 makedepends=('git')
 source=('git+https://github.com/P0cL4bs/WiFi-Pumpkin.git')
 sha1sums=('SKIP')
@@ -32,6 +33,8 @@ prepare() {
 
   find . -type f -exec \
     sed -i 's|/usr/share/WiFi-Pumpkin/|/usr/share/wifi-pumpkin/|g' {} \;
+
+  pip install -r requirements.txt
 }
 
 package() {


### PR DESCRIPTION
The Problem i see here is, that if pip is used to install dependencies, they wont be removed on uninstall.
This adresses BlackArch/blackarch#1533

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>