### PR TITLE
pwntools: adding missing dependency

### DIFF
--- a/packages/pwntools/PKGBUILD
+++ b/packages/pwntools/PKGBUILD
@@ -14,7 +14,7 @@ depends=('python2' 'python2-paramiko' 'python2-mako' 'python2-pyelftools'
          'python2-pip' 'python2-tox' 'python2-pygments' 'python2-socks'
          'python2-dateutil' 'python2-psutil' 'ropgadget' 'python2-pypandoc'
          'python2-intervaltree' 'python2-sphinx' 'python2-pysqlite'
-         'python2-packaging')
+         'python2-packaging', 'python2-sortedcontainers')
 makedepends=('python2-setuptools')
 source=("https://github.com/Gallopsled/pwntools/archive/${pkgver}.tar.gz")
 sha1sums=('bd40e95eb30d980166467d6560019a585f4cbd80')


### PR DESCRIPTION
```
$ ./sploit.py 
Traceback (most recent call last):
  File "./sploit.py", line 3, in <module>
    from pwn import *
  File "/usr/lib/python2.7/site-packages/pwn/__init__.py", line 4, in <module>
    from pwn.toplevel import *
  File "/usr/lib/python2.7/site-packages/pwn/toplevel.py", line 20, in <module>
    import pwnlib
  File "/usr/lib/python2.7/site-packages/pwnlib/__init__.py", line 43, in <module>
    importlib.import_module('.%s' % module, 'pwnlib')
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/usr/lib/python2.7/site-packages/pwnlib/dynelf.py", line 56, in <module>
    from pwnlib import elf
  File "/usr/lib/python2.7/site-packages/pwnlib/elf/__init__.py", line 9, in <module>
    from pwnlib.elf.corefile import Core
  File "/usr/lib/python2.7/site-packages/pwnlib/elf/corefile.py", line 84, in <module>
    from pwnlib.elf.elf import ELF
  File "/usr/lib/python2.7/site-packages/pwnlib/elf/elf.py", line 59, in <module>
    import intervaltree
  File "/usr/lib/python2.7/site-packages/intervaltree/__init__.py", line 22, in <module>
    from .intervaltree import IntervalTree
  File "/usr/lib/python2.7/site-packages/intervaltree/intervaltree.py", line 26, in <module>
    from sortedcontainers import SortedDict
ImportError: No module named sortedcontainers
```

After installing dep, everything works.

    $ sudo pacman -S python2-sortedcontainers
