### PR TITLE
Add New Tool : CyberScan

### DIFF
--- a/packages/cyberScan/PKGBUILD
+++ b/packages/cyberScan/PKGBUILD
@@ -1,0 +1,42 @@
+# This file is part of BlackArch Linux ( http://blackarch.org ).
+# See COPYING for license details.
+
+pkgname='cyberscan'
+pkgver=1.1.1
+pkgrel=0
+pkgdesc='A Network Pentesting Tool'
+groups=('blackarch' 'blackarch-networking' 'blackarch-scanner')
+arch=('any')
+url='https://github.com/medbenali/CyberScan'
+license=('GPLv3')
+depends=('python2.7')
+makedepends=('git')
+source=('git+https://github.com/medbenali/CyberScan')
+sha1sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/CyberScan"
+
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+package() {
+  cd "$srcdir/CyberScan"
+
+  mkdir -p "$pkgdir/usr/bin"
+  mkdir -p "$pkgdir/usr/share/cyberscan"
+
+  install -Dm644 -t "$pkgdir/usr/share/doc/cyberscan/" README.md
+
+  rm README.md
+
+  cp -a * "$pkgdir/usr/share/cyberscan"
+
+  cat > "$pkgdir/usr/bin/cyberscan" << EOF
+#!/bin/sh
+cd /usr/share/cyberscan
+exec python2.7 cyberscan.py "\${@}"
+EOF
+
+  chmod a+x "$pkgdir/usr/bin/cyberscan"
+}


### PR DESCRIPTION
CyberScan is able to send and capture packets of several protocols, forging and decoding them to be used to most network tasks such as scanning, pinging, probing, and attacks.

https://github.com/medbenali/CyberScan

I have the honor to add it in Black Arch