### PR TITLE
Update sylkie PKGBUILD

### DIFF
--- a/packages/sylkie/PKGBUILD
+++ b/packages/sylkie/PKGBUILD
@@ -9,8 +9,8 @@ groups=('blackarch' 'blackarch-spoof' 'blackarch-networking')
 arch=('i686' 'x86_64' 'armv6h' 'armv7h' 'aarch64')
 url='https://github.com/dlrobertson/sylkie'
 license=('BSD')
-depends=('linux-headers' 'json-c')
-makedepends=('git' 'cmake' 'libseccomp')
+depends=('linux-headers' 'json-c' 'libseccomp')
+makedepends=('git' 'cmake')
 source=('git+https://github.com/dlrobertson/sylkie.git')
 sha1sums=('SKIP')
 
@@ -27,7 +27,7 @@ build() {
 
   cd build
 
-  cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+  cmake -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_SETUID=ON ..
 
   make
 }


### PR DESCRIPTION
 - Add the [ENABLE_SETUID](https://github.com/dlrobertson/sylkie/wiki#build-options) build option
 - Move libseccomp from makedepends to depends. We don't statically link
   against it.