### PR TITLE
Added libxslt as a dependency for beef

### DIFF
--- a/packages/beef/PKGBUILD
+++ b/packages/beef/PKGBUILD
@@ -12,7 +12,7 @@ url='http://beefproject.com/'
 install='beef.install'
 license=('Apache')
 makedepends=('git')
-depends=('ruby2.3' 'ruby2.3-bundler' 'sqlite' 'python2')
+depends=('ruby2.3' 'ruby2.3-bundler' 'sqlite' 'python2' 'libxslt')
 source=('git+http://github.com/beefproject/beef.git'
         'rake_dep.patch')
 sha1sums=('SKIP'


### PR DESCRIPTION
Beef wouldn't build without `libxslt` because `nokogiri` is being built with system libraries.