### PR TITLE
[tool request] [attention] sandsifter.

### DIFF
--- a/packages/sandsifter/PKGBUILD
+++ b/packages/sandsifter/PKGBUILD
@@ -1,0 +1,45 @@
+# This file is part of BlackArch Linux ( http://blackarch.org ).
+# See COPYING for license details.
+
+pkgname='sandsifter'
+pkgver=dff6324
+pkgrel=1
+pkgdesc='The x86 processor fuzzer.'
+groups=('blackarch' 'blackarch-fuzzer')
+arch=('x86_64')
+url='https://github.com/xoreaxeaxeax/sandsifter'
+license=('unknown')
+depends=('python2' 'capstone')
+makedepends=('git' 'make' 'sed')
+source=('git+https://github.com/xoreaxeaxeax/sandsifter.git')
+md5sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${pkgname}"
+
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+build () {
+  cd "${srcdir}/${pkgname}"
+
+  sed -i "s/\/usr\/bin\/python/\/usr\/bin\/python2/" *.py
+  sed -i "s/INJECTOR = \".\/injector\"/INJECTOR = \"\/opt\/sandsifter\/injector\"/" sifter.py
+  make
+}
+
+package() {
+  cd "${srcdir}/${pkgname}"
+
+  mkdir -p "${pkgdir}/opt/${pkgname}"
+  mkdir -p "${pkgdir}/usr/bin"
+  mkdir -p "${pkgdir}/usr/share/docs/${pkgname}"
+
+  install -Dm 644 README.md "${pkgdir}/usr/share/docs/${pkgname}/"
+
+  cp -rft "${pkgdir}/opt/${pkgname}/" \
+    disas/ gui/ injector mutator.py pyutil/ sifter.py summarize.py
+    
+  ln -sf "/opt/${pkgname}/sifter.py" "${pkgdir}/usr/bin/sifter"
+  ln -sf "/opt/${pkgname}/summarize.py" "${pkgdir}/usr/bin/summarize"
+}


### PR DESCRIPTION
https://github.com/BlackArch/blackarch/issues/1741

**I believe someone should review this Pull Request in order to confirm everything is the way it should be.**

Tested on a virtual machine running:
`Linux blackarch 4.11.4-1-ARCH #1 SMP PREEMPT Fri Jun 9 07:46:48 CEST 2017 x86_64 GNU/Linux`

**Installing log:**
```
Suppresed message about root.
==> Making package: sandsifter 1.dff6324-1 (Tue Aug 22 02:09:20 UTC 2017)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Cloning sandsifter git repo...
Cloning into bare repository '/root/testing/sifter/sandsifter'...
==> Validating source files with md5sums...
    sandsifter ... Skipped
==> Extracting sources...
  -> Creating working copy of sandsifter git repo...
Cloning into 'sandsifter'...
done.
==> Starting pkgver()...
==> Starting build()...
cc -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -c injector.c -o injector.o -Wall
injector.c:321:93: warning: excess elements in array initializer
  .start={.bytes={0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}, .len=0},
                                                                                             ^~~~
injector.c:321:93: note: (near initialization for ‘total_range.start.bytes’)
injector.c:322:91: warning: excess elements in array initializer
  .end={.bytes={0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff}, .len=0},
                                                                                           ^~~~
injector.c:322:91: note: (near initialization for ‘total_range.end.bytes’)
injector.c: In function ‘inject’:
injector.c:763:3: warning: argument 1 null where non-null expected [-Wnonnull]
   memset(p, 0, PAGE_SIZE);
   ^~~~~~~~~~~~~~~~~~~~~~~
In file included from injector.c:11:0:
/usr/include/string.h:63:14: note: in a call to function ‘memset’ declared here
 extern void *memset (void *__s, int __c, size_t __n) __THROW __nonnull ((1));
              ^~~~~~
injector.c: In function ‘main’:
injector.c:1508:5: warning: ‘pid’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  if (pid!=0) {
     ^
injector.c:1503:3: warning: ‘null_p’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   munmap(null_p, PAGE_SIZE);
   ^~~~~~~~~~~~~~~~~~~~~~~~~
cc -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong injector.o -O3 -Wall -l:libcapstone.a -o injector -pthread
==> Entering fakeroot environment...
==> Starting package()...
==> Tidying install...
  -> Removing libtool files...
  -> Purging unwanted files...
  -> Removing static library files...
  -> Stripping unneeded symbols from binaries and libraries...
  -> Compressing man and info pages...
==> Checking for packaging issue...
==> Creating package "sandsifter"...
  -> Generating .PKGINFO file...
  -> Generating .BUILDINFO file...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: sandsifter 1.dff6324-1 (Tue Aug 22 02:09:57 UTC 2017)
==> Installing package sandsifter with pacman -U...
loading packages...
resolving dependencies...
looking for conflicting packages...

Packages (1) sandsifter-1.dff6324-1

Total Installed Size:  2.49 MiB

:: Proceed with installation? [Y/n] checking keyring...
checking package integrity...
loading package files...
checking for file conflicts...
:: Processing package changes...
installing sandsifter...
:: Running post-transaction hooks...
(1/1) Arming ConditionNeedsUpdate...
```
**Output of --help:**
```
usage: sifter [-h] [--len] [--dis] [--unk] [--ill] [--tick] [--save]
              [--resume] [--sync] [--low-mem]
              ...

positional arguments:
  injector_args

optional arguments:
  -h, --help     show this help message and exit
  --len          search for length differences in all instructions
                 (instructions that executed differently than the disassembler
                 expected, or did not exist when the disassembler expected
                 them to)
  --dis          search for length differences in valid instructions
                 (instructions that executed differently than the disassembler
                 expected)
  --unk          search for unknown instructions (instructions that the
                 disassembler doesn't know about but successfully execute)
  --ill          the inverse of --unk, search for invalid disassemblies
                 (instructions that do not successfully execute but that the
                 disassembler acknowledges)
  --tick         periodically write the current instruction to disk
  --save         save search progress on exit
  --resume       resume search from last saved state
  --sync         write search results to disk as they are found
  --low-mem      do not store results in memory
```