### PR TITLE
Another s1per dependency called goohak

### DIFF
--- a/packages/goohak/PKGBUILD
+++ b/packages/goohak/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname='goohak'
-pkgver=15.726458b
+pkgver=17.c44a544
 pkgrel=1
 pkgdesc='Automatically Launch Google Hacking Queries Against A Target Domain'
 groups=('blackarch' 'blackarch-recon' 'blackarch-automation'
@@ -12,18 +12,17 @@ license=('custom:unknown')
 arch=('any')
 depends=('bash')
 makedepends=('git')
-source=('git+https://github.com/1N3/MassBleed')
-install='goohak.install'
+source=('git+https://github.com/1N3/Goohak')
 sha1sums=('SKIP')
 
 pkgver() {
-  cd "$srcdir/MassBleed"
+  cd "$srcdir/Goohak"
 
   echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
 }
 
 package() {
-  cd "$srcdir/GooHak"
+  cd "$srcdir/Goohak"
 
   mkdir -p "$pkgdir/usr/bin"
   mkdir -p "$pkgdir/usr/share/goohak"

--- a/packages/goohak/PKGBUILD
+++ b/packages/goohak/PKGBUILD
@@ -1,0 +1,44 @@
+# This file is part of BlackArch Linux ( http://blackarch.org ).
+# See COPYING for license details.
+
+pkgname='goohak'
+pkgver=15.726458b
+pkgrel=1
+pkgdesc='Automatically Launch Google Hacking Queries Against A Target Domain'
+groups=('blackarch' 'blackarch-recon' 'blackarch-automation'
+         'blackarch-scanner')
+url='https://github.com/1N3/Goohak'
+license=('custom:unknown')
+arch=('any')
+depends=('bash')
+makedepends=('git')
+source=('git+https://github.com/1N3/MassBleed')
+install='goohak.install'
+sha1sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/MassBleed"
+
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+package() {
+  cd "$srcdir/GooHak"
+
+  mkdir -p "$pkgdir/usr/bin"
+  mkdir -p "$pkgdir/usr/share/goohak"
+
+  install -Dm644 -t "$pkgdir/usr/share/doc/goohak/" README.md
+
+  rm *.md
+
+  cp -a * "$pkgdir/usr/share/goohak"
+
+  cat > "$pkgdir/usr/bin/goohak" << EOF
+#!/bin/sh
+cd /usr/share/goohak
+exec bash ./goohak "\${@}"
+EOF
+
+  chmod a+x "$pkgdir/usr/bin/goohak"
+}


### PR DESCRIPTION
Found missing another dependency on sn1per:
Sn1per/sniper: line 1021: goohak: command not found
so created the package, cheers.