### PR TITLE
Update sylkie PKGBUILD

### DIFF
--- a/packages/sylkie/PKGBUILD
+++ b/packages/sylkie/PKGBUILD
@@ -2,13 +2,13 @@
 # See COPYING for license details.
 
 pkgname='sylkie'
-pkgver=48.68b4379
+pkgver=0.0.3.r0.g68b4379
 pkgrel=1
 pkgdesc='IPv6 address spoofing with the Neighbor Discovery Protocol.'
 groups=('blackarch' 'blackarch-spoof' 'blackarch-networking')
 arch=('i686' 'x86_64' 'armv6h' 'armv7h' 'aarch64')
 url='https://github.com/dlrobertson/sylkie'
-license=('BSD')
+license=('MIT')
 depends=('linux-headers' 'json-c' 'libseccomp')
 makedepends=('git' 'cmake')
 source=('git+https://github.com/dlrobertson/sylkie.git')
@@ -17,7 +17,7 @@ sha1sums=('SKIP')
 pkgver() {
   cd "$srcdir/sylkie"
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  echo $(git describe --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g')
 }
 
 build() {


### PR DESCRIPTION
 - Update the pkgver function to follow the Arch Linux VCS package guidelines
   https://wiki.archlinux.org/index.php/VCS_package_guidelines
 - Update the license to reflect the projects license