### PR TITLE
[fix] removing unnecessary file (more)...

### DIFF
--- a/packages/airgeddon/PKGBUILD
+++ b/packages/airgeddon/PKGBUILD
@@ -40,7 +40,7 @@ package() {
   install -Dm644 -t "$pkgdir/usr/share/doc/airgeddon/" README.md CHANGELOG.md
   install -Dm644 LICENSE.md "$pkgdir/usr/share/licenses/airgeddon/LICENSE.md"
 
-  rm -rf *.md .github binaries imgs Dockerfile pindb_checksum.txt
+  rm -rf *.md .github binaries imgs Dockerfile pindb_checksum.txt .editorconfig
 
   cp -a --no-preserve=ownership * "$pkgdir/usr/share/airgeddon"
 


### PR DESCRIPTION
As pointed out by OscarAkaElvis on #blackarch (freenode), .editorconfig isn't necessary.

```
- hey noptrix, I saw your commit with new airgeddon 7.21 version... only a very small change
- there is a new .editorconfig file that can be removed on your "rm" line in the same way as Dockerfile and others
- there is no changes on dependencies, everything ok :)
```