### PR TITLE
Update and fix bro

### DIFF
--- a/packages/bro/PKGBUILD
+++ b/packages/bro/PKGBUILD
@@ -10,25 +10,23 @@ pkgdesc='A powerful network analysis framework that is much different from the t
 arch=('i686' 'x86_64' 'armv6h' 'armv7h' 'aarch64')
 url='https://www.bro.org/download/index.html'
 license=('custom:unknown')
-depends=('libpcap' 'openssl' 'bash' 'python' 'swig' 'ruby' 'perl' 'crypto++')
+depends=('libpcap' 'openssl-1.0' 'bash' 'python' 'swig' 'ruby' 'perl' 'crypto++')
 makedepends=('cmake' 'flex' 'bison' 'swig' 'zlib')
-source=("https://www.bro.org/downloads/beta/bro-${pkgver}-beta.tar.gz")
-sha1sums=('b1ce31948263f504ff9d97275bfab92643341034')
+source=("https://www.bro.org/downloads/bro-${pkgver}.tar.gz")
+sha1sums=('9c133dd3a075be1084f9bf53d79c42ddcf23633c')
 
 build() {
-  cd "$srcdir/bro-$pkgver-beta"
-
-  # tmp solution. needs to be fixed for 'broccoli' and 'broctl'
-  ./configure --prefix=/usr --with-openssl=/usr/lib \
-    --disable-broccoli --disable-broctl
-
+  mkdir -p "$srcdir/bro-${pkgver}/build"
+  cd "$srcdir/bro-${pkgver}/build"
+  cmake .. -DOPENSSL_CRYPTO_LIBRARY=/usr/lib/openssl-1.0/libcrypto.so \
+           -DOPENSSL_INCLUDE_DIR=/usr/include/openssl-1.0 \
+           -DOPENSSL_ROOT_DIR=/usr/lib/openssl-1.0 \
+           -DOPENSSL_SSL_LIBRARY=/usr/lib/openssl-1.0/libssl.so \
+           -DCMAKE_INSTALL_PREFIX=/usr
   make
 }
 
 package() {
-  cd "$srcdir/bro-$pkgver-beta"
-
+  cd "$srcdir/bro-${pkgver}/build"
   make DESTDIR="$pkgdir" install
-
-  mv "$pkgdir/usr/bin/bro" "$pkgdir/usr/bin/bro-sniffer"
 }


### PR DESCRIPTION
Bro 2.5.1 is now the stable release (see
https://www.bro.org/download/).

Bro requires openssl-1.0 (see
<https://bro-tracker.atlassian.net/browse/BIT-1775>) and will not work
with Archlinux openssl package (this package is currently broken).

This commit also fixes the `build()` function (using cmake).