### PR TITLE
[tool request - dep] dep for pacaur.

### DIFF
--- a/packages/cower/PKGBUILD
+++ b/packages/cower/PKGBUILD
@@ -1,0 +1,34 @@
+# This file is part of BlackArch Linux ( http://blackarch.org ).
+#
+# This PKGBUILD was extracted from AUR.
+# Creator: Dave Reisner <d@falconindy.com>
+# Changes by: psf
+
+pkgname=cower
+pkgver=17
+pkgrel=2
+pkgdesc="A simple AUR agent with a pretentious name."
+arch=('i686' 'x86_64')
+url="http://github.com/falconindy/cower"
+license=('MIT')
+groups=('blackarck' 'blackarch-misc')
+depends=('curl' 'pacman' 'yajl')
+makedepends=('perl')
+source=("https://pkgbuild.com/~dreisner/sources/$pkgname/$pkgname-$pkgver.tar.gz"{,.sig})
+validpgpkeys=('487EACC08557AD082088DABA1EB2638FF56C0C53')  # Dave Reisner
+md5sums=('263c216e6643751b6c96eebfdd70c359'
+         'SKIP')
+
+build() {
+  cd "${pkgname}-${pkgver}"
+
+  make
+  sed '/^$/q' src/cower.c >LICENSE
+}
+
+package() {
+  cd "${pkgname}-${pkgver}"
+
+  make PREFIX=/usr DESTDIR="${pkgdir}" install
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}


### PR DESCRIPTION
This PKGBUILD file was extracted from AUR.
#1286 

This is a dependency for `pacaur`.