### PR TITLE
[fix] dirsearch output file...

### DIFF
--- a/packages/dirsearch/PKGBUILD
+++ b/packages/dirsearch/PKGBUILD
@@ -35,8 +35,7 @@ package() {
 
   cat > "$pkgdir/usr/bin/dirsearch" << EOF
 #!/bin/sh
-cd /usr/share/dirsearch
-exec python dirsearch.py "\$@"
+exec /usr/bin/python /usr/share/dirsearch/dirsearch.py "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/dirsearch"


### PR DESCRIPTION
As said in #blackarch (freenode), if the PKGBUILD use a wrapper
that will cd to the application directory there is a high chance
it will write file to that same directory and not to the directory
that it was called from.

This fix ensures it.

Note: we might have to do it on others PKGBUILD too.

Logs for clarification on the matter:

```
root@great-cerberus ~/tmp                                                                  [18:40:59] 
> # pwd                                                                                              
/root/tmp
                                                                                                      
root@great-cerberus ~/tmp                                                                  [18:40:59] 
> # ll                                                                                               
total 0
                                                                                                      
root@great-cerberus ~/tmp                                                                  [18:41:01] 
> # pacman -S dirsearch                                                                              
warning: dirsearch-218.a5ac52b-1 is up to date -- reinstalling
resolving dependencies...
looking for conflicting packages...

Packages (1) dirsearch-218.a5ac52b-1

Total Installed Size:  1.35 MiB
Net Upgrade Size:      0.00 MiB

:: Proceed with installation? [Y/n] Y
(1/1) checking keys in keyring                                [#################################] 100%
(1/1) checking package integrity                              [#################################] 100%
(1/1) loading package files                                   [#################################] 100%
(1/1) checking for file conflicts                             [#################################] 100%
(1/1) checking available disk space                           [#################################] 100%
:: Processing package changes...
(1/1) reinstalling dirsearch                                  [#################################] 100%
:: Running post-transaction hooks...
(1/1) Arming ConditionNeedsUpdate...
                                                                                                      
root@great-cerberus ~/tmp                                                                  [18:41:33] 
> # dirsearch -u http://192.168.0.69 -e sh,php,html,txt,htm --plain-text-report=dirbrute             

 _|. _ _  _  _  _ _|_    v0.3.8
(_||| _) (/_(_|| (_| )

Extensions: sh, php, html, txt, htm | Threads: 10 | Wordlist size: 7363

Error Log: /usr/share/dirsearch/logs/errors-17-10-21_18-41-40.log

Target: http://192.168.0.69

[18:41:40] Starting: 
[18:41:41] 403 -  330B  - /.ht_wsr.txt                              
[18:41:41] 403 -  323B  - /.hta           
[18:41:41] 403 -  332B  - /.htaccess-dev
[18:41:41] 403 -  334B  - /.htaccess-marco
[18:41:41] 403 -  334B  - /.htaccess-local
[18:41:41] 403 -  333B  - /.htaccess.bak1
[18:41:41] 403 -  332B  - /.htaccess.BAK
[18:41:41] 403 -  333B  - /.htaccess.orig
[18:41:41] 403 -  333B  - /.htaccess.save

--snipped--

[18:42:21] 401 -  518B  - /phpmyadmin/scripts/setup.php                 
[18:42:21] 200 -    8KB - /phpmyadmin/                 
[18:42:23] 403 -  332B  - /server-status                                                             
[18:42:23] 403 -  333B  - /server-status/                                             
[18:42:25] 301 -  351B  - /style  ->  http://192.168.0.69/style/                            
                                                                                        
Task Completed
                                                                                                      
root@great-cerberus ~/tmp                                                                  [18:42:30] 
> # ls                                                                                               
                                                                                                      
root@great-cerberus ~/tmp                                                                  [18:45:37] 
> # ll                                                                                               
total 0
                                                                                                      
root@great-cerberus ~/tmp                                                                  [18:45:39] 
> # ll /usr/share/dirsearch                                                                          
total 40K
-rw-r--r--  1 root root 1.4K Sep  8 10:45 CHANGELOG.md
drwxr-xr-x  2 root root 4.0K Oct 21 18:41 db
-rw-r--r--  1 root root  403 Sep  8 10:45 default.conf
-rw-r--r--  1 root root 2.3K Oct 21 18:42 dirbrute
-rw-r--r--  1 root root   83 Oct  7 17:48 dirsearch.out
-rwxr-xr-x  1 root root 1.4K Sep  8 10:45 dirsearch.py
drwxr-xr-x  9 root root 4.0K Oct 21 18:41 lib
drwxr-xr-x  2 root root 4.0K Oct 21 18:41 logs
drwxr-xr-x 13 root root 4.0K Oct 21 18:41 reports
drwxr-xr-x  7 root root 4.0K Oct 21 18:41 thirdparty
                                                                                                      
root@great-cerberus ~/tmp                                                                  [18:45:55] 
> #                                                                                                  



```