### PR TITLE
[fix] cewl cd'ing to directory...

### DIFF
--- a/packages/cewl/PKGBUILD
+++ b/packages/cewl/PKGBUILD
@@ -15,6 +15,12 @@ source=("https://github.com/digininja/CeWL/archive/${pkgver}.tar.gz")
 install='cewl.install'
 sha1sums=('c9f5325dd360384cc4712e2ffbb428e7fa1f56be')
 
+prepare() {
+  cd "$srcdir/CeWL-$pkgver"
+  
+  sed -i "s|require './cewl_lib'|require '/usr/share/cewl/cewl_lib'|g" cewl.rb
+}
+
 package() {
   cd "$srcdir/CeWL-$pkgver"
 
@@ -29,16 +35,14 @@ package() {
 
   cat > "$pkgdir/usr/bin/cewl" << EOF
 #!/bin/sh
-cd /usr/share/cewl
-exec ruby cewl.rb "\$@"
+exec ruby /usr/share/cewl/cewl.rb "\$@"
 EOF
 
   chmod a+x "$pkgdir/usr/bin/cewl"
 
   cat > "$pkgdir/usr/bin/cewl-fab" << EOF
 #!/bin/sh
-cd /usr/share/cewl
-exec ruby fab.rb "\$@"
+exec ruby /usr/share/cewl/fab.rb "\$@"
 EOF
 
   chmod a+x "$pkgdir/usr/bin/cewl-fab"


### PR DESCRIPTION
As said in #blackarch (freenode), if the PKGBUILD use a wrapper
that will cd to the application directory there is a high chance
it will write file to that same directory and not to the directory
that it was called from.

This fix ensures it.

Note: we might have to do it on others PKGBUILD too.