### PR TITLE
Add package python-pyqtgraph

### DIFF
--- a/packages/python-pyqtgraph/PKGBUILD
+++ b/packages/python-pyqtgraph/PKGBUILD
@@ -1,0 +1,25 @@
+# This file is part of BlackArch Linux ( http://blackarch.org ).
+# See COPYING for license details.
+
+pkgname=python-pyqtgraph
+_pkgname=pyqtgraph
+pkgver=0.10.0
+pkgrel=1
+pkgdesc="Scientific Graphics and GUI Library for Python"
+arch=('any')
+license=('MIT')
+url="http://www.pyqtgraph.org/"
+depends=('python' 'python-pyqt4' 'python-numpy')
+optdepends=('python-opengl')
+
+source=("http://www.pyqtgraph.org/downloads/${pkgver}/pyqtgraph-${pkgver}.tar.gz")
+md5sums=('3f191f724a3f9d829094af6237f1db5a')
+sha256sums=('c74597dd87c31987099bd0949a5207e5d58297bd8a663279562ca1cb334074fc')
+
+# source=("https://github.com/pyqtgraph/pyqtgraph/archive/pyqtgraph-${pkgver}.tar.gz")
+# md5sums=('d97a5681687b9cbbf2ad9674192eb5a6')
+
+package() {
+  cd "$srcdir/$_pkgname-$pkgver"
+  python setup.py -q install --prefix=/usr --root="$pkgdir" --optimize 1
+}


### PR DESCRIPTION
This pull request adds the package called `python-pyqtgraph`.

One of the optional dependencies for `binwalk` is `python-pyqtgraph`, which adds support for visualising entropy over a file. This package was not available in the core, extra, community, or blackarch repositories. 