### PR TITLE
[tool] adding slurp #1825

### DIFF
--- a/packages/slurp/PKGBUILD
+++ b/packages/slurp/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname='slurp'
 pkgver=31.66fd8ce
 pkgrel=1
-groups=('blackarch' 'blackarch-scanner' 'blackarch-defensive')
+groups=('blackarch' 'blackarch-scanner')
 pkgdesc='S3 bucket enumerator'
 arch=('x86_64')
 url='https://github.com/bbb31/slurp'
@@ -54,7 +54,6 @@ cd /usr/share/$_name
 EOF
 
   chmod 755 "$pkdir/usr/bin/$_name"
-
 }
 
 

--- a/packages/slurp/PKGBUILD
+++ b/packages/slurp/PKGBUILD
@@ -1,0 +1,60 @@
+# This file is part of BlackArch Linux ( http://blackarch.org ).
+# See COPYING for license details.
+
+pkgname='slurp'
+pkgver=31.66fd8ce
+pkgrel=1
+groups=('blackarch' 'blackarch-scanner' 'blackarch-defensive')
+pkgdesc='S3 bucket enumerator'
+arch=('x86_64')
+url='https://github.com/bbb31/slurp'
+license=('AGPLv3')
+depends=('go')
+makedepends=('go' 'git')
+source=('git+https://github.com/bbb31/slurp.git')
+sha1sums=('SKIP')
+_url='github.com/bbb31/slurp'
+
+pkgver() {
+  cd "$srcdir/slurp"
+
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+build() {
+  cd "$srcdir"
+
+  mkdir -p src/${_url} && rm -rf src/${_url} && mv slurp src/${_url} && \
+    cd src/${_url}
+
+  GOPATH="$srcdir" go get -d -t ${_url}
+}
+
+package() {
+  cd "$srcdir"
+  _name="slurp"
+
+  GOPATH="$srcdir" go build -v ${_url}
+
+  mkdir -p "$pkgdir/usr/bin"
+  mkdir -p "$pkgdir/usr/share/$_name"
+
+  install -Dm755 "$srcdir/$_name" "$pkgdir/usr/share/$_name/$_name"
+  install -Dm644 src/${_url}/README.md \
+    "$pkgdir/usr/share/doc/$_name/README.md"
+  install -Dm644 src/${_url}/permutations.json \
+    "$pkgdir/usr/share/$_name/permutations.json"
+  install -Dm644 src/${_url}/LICENSE \
+    "$pkgdir/usr/share/licenses/$_name/LICENSE"
+
+  cat > "$pkdir/usr/bin/$_name" << EOF
+#!/bin/sh
+cd /usr/share/$_name
+./$_name \${@}
+EOF
+
+  chmod 755 "$pkdir/usr/bin/$_name"
+
+}
+
+


### PR DESCRIPTION
Adding `slurp` as requested on #1825.

Although I don't like cd'ing to the binary folder (usually `/usr/share/application`) and then call the binary, in this case I think it was necessary because it couldn't find the `permutation.json`. I didn't know what else I could do to avoid cd'ing, so I'm open to suggestion.