### PR TITLE
sublist3r: adding url.

### DIFF
--- a/packages/sublist3r/PKGBUILD
+++ b/packages/sublist3r/PKGBUILD
@@ -7,6 +7,7 @@ pkgrel=1
 arch=('any')
 groups=('blackarch' 'blackarch-recon' 'blackarch-scanner')
 pkgdesc='A Fast subdomains enumeration tool for penetration testers.'
+url='https://github.com/aboul3la/Sublist3r'
 license=('GPL2')
 depends=('python2' 'python2-argparse' 'python2-dnspython' 'python2-requests')
 makedepends=('git')


### PR DESCRIPTION
Without URL https://blackarch.org/tools.html is broken.