### PR TITLE
bump sn1per to 4.0 releases

### DIFF
--- a/packages/sn1per/PKGBUILD
+++ b/packages/sn1per/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname='sn1per'
-pkgver=212.f450b78
+pkgver=221.b13866c
 pkgrel=1
 pkgdesc='Automated Pentest Recon Scanner.'
 groups=('blackarch' 'blackarch-recon' 'blackarch-automation' 'blackarch-scanner'


### PR DESCRIPTION
Hey guys, been busy with a new job, head of cybersecurity so took almost 1 year to get everything working etc, so now I will be commiting more pull request since I have more time to pentest/hacking. here is sn1per updated to 4.x the one I had installed by default is 3.x.
happy hacking.