### PR TITLE
Update url for fbht and add two dependencies

### DIFF
--- a/packages/fbht/PKGBUILD
+++ b/packages/fbht/PKGBUILD
@@ -8,11 +8,11 @@ pkgrel=2
 epoch=1
 pkgdesc='A Facebook Hacking Tool'
 arch=('any')
-url='https://github.com/chinoogawa/fbht-linux'
+url='https://github.com/chinoogawa/fbht'
 groups=('blackarch' 'blackarch-webapp')
 license=('custom')
 depends=('python2' 'python2-mechanize' 'python2-networkx' 'python2-matplotlib'
-         'python2-numpy' 'python2-simplejson')
+         'python2-numpy' 'python2-selenium' 'python2-setuptools' 'python2-simplejson')
 makedepends=('git')
 provides=('fbht')
 source=('git+https://github.com/chinoogawa/fbht.git')


### PR DESCRIPTION
Two dependencies had to be added to make fbht executable:

	python2-setuptools
	python2-selenium

Fix BlackArch/blackarch#1879

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>