### PR TITLE
findsploit: fixing dep, groups and bumping pkgrel to force update.

### DIFF
--- a/packages/findsploit/PKGBUILD
+++ b/packages/findsploit/PKGBUILD
@@ -3,13 +3,13 @@
 
 pkgname='findsploit'
 pkgver=59.4314845
-pkgrel=1
+pkgrel=2
 pkgdesc='Find exploits in local and online databases instantly.'
-groups=('blackarch' 'blackarch-misc')
+groups=('blackarch' 'blackarch-automation' 'blackarch-exploitation')
 arch=('any')
 url='https://github.com/1N3/findsploit'
 license=('custom:unknown')
-depends=('bash' 'metasploit' 'firefox')
+depends=('bash' 'metasploit' 'firefox' 'searchsploit')
 makedepends=('git')
 source=('git+https://github.com/1N3/Findsploit.git')
 sha1sums=('SKIP')
@@ -23,7 +23,6 @@ pkgver() {
 prepare() {
   cd "$srcdir/Findsploit"
 
-  sed -i 's/iceweasel/firefox/' findsploit
   sed -i 's|/pentest/|/usr/share/|' copysploit
 }
 


### PR DESCRIPTION
- Upstream fixed the call to browser, so the `sed` for it isn't necessary anymore. (https://github.com/1N3/Findsploit/blob/master/findsploit#L14)

- I'm also adding `searchsploit` as dependency.

note: there were changes in the code (upstream) but the pkgver didn't change (git).