### PR TITLE
tcpdstat: adding new tool 'tcpdstat':

### DIFF
--- a/packages/tcpdstat/PKGBUILD
+++ b/packages/tcpdstat/PKGBUILD
@@ -1,0 +1,35 @@
+# This file is part of BlackArch Linux ( http://blackarch.org ).
+# See COPYING for license details.
+
+pkgname='tcpdstat'
+pkgver=4.be5bd28
+pkgrel=1
+groups=('blackarch' 'blackarch-networking')
+pkgdesc='Get protocol statistics from tcpdump pcap files.'
+arch=('x86_64')
+url='https://github.com/netik/tcpdstat'
+license=('custom:any')
+depends=('libcap')
+makedepends=('git' 'make')
+source=('git+https://github.com/netik/tcpdstat.git')
+sha1sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/tcpdstat"
+
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+build() {
+  cd "${srcdir}/tcpdstat"
+
+  make
+}
+
+package() {
+  cd "${srcdir}/tcpdstat"
+  mkdir -p "${pkgdir}/usr/bin"
+
+  make install PREFIX="${pkgdir}/usr"
+}
+


### PR DESCRIPTION
- https://github.com/netik/tcpdstat
- a fork of: https://staff.washington.edu/dittrich/talks/core02/tools/tools.html