### PR TITLE
Fixed getsploit bug

### DIFF
--- a/packages/getsploit/PKGBUILD
+++ b/packages/getsploit/PKGBUILD
@@ -35,7 +35,7 @@ package() {
 
   cat > "$pkgdir/usr/bin/getsploit" << EOF
 #!/bin/sh
-cd /usr/share/getsploit
+cd /usr/share/getsploit/getsploit
 exec python2 getsploit.py "\${@}"
 EOF
 


### PR DESCRIPTION
getsploit wouldn't launch due to not being in the second `getsploit` folder. This adds the second folder to the `/usr/bin/getsploit` file so it can be launched.