### PR TITLE
compile hostapd-eaphammer lib

### DIFF
--- a/packages/eaphammer/PKGBUILD
+++ b/packages/eaphammer/PKGBUILD
@@ -21,6 +21,11 @@ pkgver() {
   echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
 }
 
+build() {
+  cd "${srcdir}/eaphammer/hostapd-eaphammer/hostapd"
+  make hostapd-eaphammer_lib
+}
+
 package() {
   cd "$srcdir/eaphammer"
 


### PR DESCRIPTION
libhostapd-eaphammer.so was missing.

software crashed with:
OSError: /usr/share/eaphammer/hostapd-eaphammer/hostapd/libhostapd-eaphammer.so: cannot open shared object file: No such file or directory
