### PR TITLE
New tool: python2-libbde-python

### DIFF
--- a/packages/python2-libbde-python/PKGBUILD
+++ b/packages/python2-libbde-python/PKGBUILD
@@ -1,0 +1,35 @@
+# This file is part of BlackArch Linux ( http://blackarch.org ).
+# See COPYING for license details.
+
+pkgname='python2-libbde-python'
+pkgver=237.874559f
+pkgrel=1
+groups=('blackarch')
+pkgdesc='Library and tools to access the BitLocker Drive Encryption (BDE) encrypted volumes.'
+arch=('any')
+url='https://github.com/libyal/libbde'
+license=('LGPL3')
+depends=('python2')
+makedepends=('git')
+source=('git+https://github.com/libyal/libbde.git')
+sha1sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/libbde"
+
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+build() {
+  cd "$srcdir/libbde"
+
+  ./synclibs.sh --use-head && ./autogen.sh
+
+  python2 setup.py build
+}
+
+package() {
+  cd "$srcdir/libbde"
+  
+  python2 setup.py install --root="$pkgdir" --prefix=/usr --optimize=1
+}


### PR DESCRIPTION
[libbde](https://github.com/BlackArch/blackarch/blob/master/packages/libbde/PKGBUILD) is already available, but missing the python2 binding, this package adds it.

@libyal