### PR TITLE
New tool: python2-libvshadow-python

### DIFF
--- a/packages/python2-libvshadow-python/PKGBUILD
+++ b/packages/python2-libvshadow-python/PKGBUILD
@@ -1,0 +1,35 @@
+# This file is part of BlackArch Linux ( http://blackarch.org ).
+# See COPYING for license details.
+
+pkgname='python2-libvshadow-python'
+pkgver=122.3e58d28
+pkgrel=1
+groups=('blackarch')
+pkgdesc='Library and tools to access the Volume Shadow Snapshot (VSS) format.'
+arch=('any')
+url='https://github.com/libyal/libvshadow'
+license=('LGPL3')
+depends=('python2')
+makedepends=('git')
+source=('git+https://github.com/libyal/libvshadow.git')
+sha1sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/libvshadow"
+
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+build() {
+  cd "$srcdir/libvshadow"
+
+  ./synclibs.sh --use-head && ./autogen.sh
+
+  python2 setup.py build
+}
+
+package() {
+  cd "$srcdir/libvshadow"
+
+  python2 setup.py install --root="$pkgdir" --prefix=/usr --optimize=1
+}


### PR DESCRIPTION
[libvshadow](https://github.com/BlackArch/blackarch/blob/master/packages/libvshadow/PKGBUILD) is already available, but missing the python2 binding, this package adds it.

@libyal