### PR TITLE
mirror: update to match default (blackarch.org).

### DIFF
--- a/packages/blackarch-mirrorlist/PKGBUILD
+++ b/packages/blackarch-mirrorlist/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname='blackarch-mirrorlist'
-pkgver=20180619
+pkgver=20180708
 pkgrel=1
 pkgdesc='BlackArch Linux mirror list file.'
 groups=('blackarch')


### PR DESCRIPTION
- mirroservice.org is down, due DNS expiring. We're falling back to `blackarch.org` for now.

ATTENTION: this PR should only be accepted after accepting https://github.com/BlackArch/blackarch-site/pull/97

Addressing: https://github.com/BlackArch/blackarch/issues/1961