### PR TITLE
fpdns: Fix install paths and dependencies

### DIFF
--- a/packages/fpdns/PKGBUILD
+++ b/packages/fpdns/PKGBUILD
@@ -3,12 +3,12 @@
 
 pkgname='fpdns'
 pkgver='20130404'
-pkgrel=9
+pkgrel=10
 epoch=1
 pkgdesc='Program that remotely determines DNS server versions.'
 groups=('blackarch' 'blackarch-fingerprint')
 url='https://github.com/kirei/fpdns'
-depends=('perl')
+depends=('perl' 'perl-net-dns')
 license=('BSD')
 options=('!emptydirs')
 arch=('any')
@@ -18,22 +18,13 @@ sha1sums=('3c3b33df1861a1a9901601d6c2252b2427ba8763')
 build() {
   cd "$srcdir/fpdns-$pkgver"
 
-  eval $(perl -V:archname)
-
-  /usr/bin/perl Makefile.PL \
-
-    INSTALLARCHLIB=/usr/lib/perl5/5.26/current/$archname \
-    INSTALLSITELIB=/usr/lib/perl5/5.26/site_perl/current \
-    INSTALLSITEARCH=/usr/lib/perl5/5.26/site_perl/current/$archname
-
+  /usr/bin/perl Makefile.PL INSTALLDIRS=vendor
   /usr/bin/make
 }
 
 package() {
   cd "$srcdir/fpdns-$pkgver"
 
-  install -Dm755 apps/fpdns "$pkgdir/usr/bin/fpdns"
-  install -Dm444 blib/lib/Net/DNS/Fingerprint.pm \
-    "$pkgdir/usr/lib/perl5/5.26/site_perl/Net/DNS/Fingerprint.pm"
-  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/LICENSE"
+  make DESTDIR="${pkgdir}" install
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/fpdns/LICENSE"
 }


### PR DESCRIPTION
The fpdns package had a missing dependency (perl-net-dns) and install paths for perl modules were hardcoded for version 5.26.