### PR TITLE
Added new tool: obfs4proxy

### DIFF
--- a/docs/official
+++ b/docs/official
@@ -77,7 +77,7 @@ nemesis blackarch-networking blackarch-fuzzer blackarch-spoof
 ngrep blackarch-networking
 nikto blackarch-scanner blackarch-webapp blackarch-fuzzer
 nmap blackarch-scanner
-obfsproxy blackarch-proxy blackarch-networking
+blackarch-proxy blackarch-networking
 openvas-cli blackarch-scanner blackarch-fuzzer blackarch-exploitation
 openvas-libraries blackarch-scanner blackarch-fuzzer blackarch-exploitation
 openvas-manager blackarch-scanner blackarch-fuzzer blackarch-exploitation

--- a/packages/obfs4proxy/PKGBUILD
+++ b/packages/obfs4proxy/PKGBUILD
@@ -1,0 +1,30 @@
+# This file is part of BlackArch Linux ( http://blackarch.org ).
+# See COPYING for license details.
+
+pkgname=obfs4proxy
+pkgver=0.0.7
+pkgrel=1
+pkgdesc='A pluggable transport proxy written in Go'
+groups=('blackarch' 'blackarch-proxy' 'blackarch-networking')
+arch=('i686' 'x86_64')
+url='https://gitweb.torproject.org/pluggable-transports/obfs4.git'
+license=('BSD')
+makedepends=('git' 'go')
+optdepends=('tor')
+source=("git+https://git.torproject.org/pluggable-transports/obfs4.git#tag=obfs4proxy-${pkgver}")
+sha1sums=('SKIP')
+
+build() {
+  cd "$srcdir/obfs4/obfs4proxy"
+  
+  GOPATH="$srcdir" GOBIN="$PWD" go get
+}
+
+package() {
+  cd "$srcdir/obfs4"
+  
+  install -Dm 755 obfs4proxy/obfs4proxy "$pkgdir/usr/bin/obfs4proxy"
+  install -Dm 644 doc/obfs4proxy.1 "$pkgdir/usr/share/man/man1/obfs4proxy.1"
+  install -Dm 644 ChangeLog "$pkgdir/usr/share/doc/obfs4proxy/ChangeLog"
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/obfs4proxy/LICENSE"
+}

--- a/packages/obfs4proxy/PKGBUILD
+++ b/packages/obfs4proxy/PKGBUILD
@@ -9,7 +9,7 @@ groups=('blackarch' 'blackarch-proxy' 'blackarch-networking')
 arch=('i686' 'x86_64')
 url='https://gitweb.torproject.org/pluggable-transports/obfs4.git'
 license=('BSD')
-makedepends=('git' 'go')
+makedepends=('git' 'go-pie')
 optdepends=('tor')
 source=("git+https://git.torproject.org/pluggable-transports/obfs4.git#tag=obfs4proxy-${pkgver}")
 sha1sums=('SKIP')
@@ -17,7 +17,8 @@ sha1sums=('SKIP')
 build() {
   cd "$srcdir/obfs4/obfs4proxy"
   
-  GOPATH="$srcdir" GOBIN="$PWD" go get
+  GOPATH="$srcdir" go get -d
+  GOPATH="$srcdir" go build -o "$pkgname"
 }
 
 package() {


### PR DESCRIPTION
Package `obfsproxy` isn't in a Arch repository any more.