### PR TITLE
Update python2-tld and python-tld to 0.9.1

### DIFF
--- a/packages/python-tld/PKGBUILD
+++ b/packages/python-tld/PKGBUILD
@@ -2,16 +2,16 @@
 # See COPYING for license details.
 
 pkgname='python-tld'
-pkgver='0.7.10'
-pkgrel=2
+pkgver='0.9.1'
+pkgrel=1
 pkgdesc='Extract the top level domain (TLD) from the URL given.'
-url='https://pypi.org/project/tld/#files'
 arch=('any')
-license=('MIT')
+url='https://pypi.org/project/tld/#files'
+license=('MPL' 'LGPL')
 depends=('python')
 makedepends=('python-setuptools')
-source=("https://files.pythonhosted.org/packages/cb/36/b12ca8e6212b6a6c5408f591713f0362ad1d94b3092f6429f974a7922057/tld-${pkgver}.tar.gz")
-sha1sums=('b723427ba376b707d952b0928e3600e53b99682a')
+source=("https://files.pythonhosted.org/packages/c2/9d/834387e54dcc8a0b2faed2ed684b4bd1051230dc730dfc74b62231d70364/tld-0.9.1.tar.gz")
+sha1sums=('e66daffdd56fa8528c865e5fa598ae7bf82acdb9')
 
 build() {
   cd "$srcdir/tld-$pkgver"
@@ -22,8 +22,5 @@ build() {
 package() {
   cd "$srcdir/tld-$pkgver"
 
-  python setup.py install --root="$pkgdir" --optimize=1
-
-  mv "$pkgdir/usr/bin/update-tld-names" \
-    "$pkgdir/usr/bin/update-tld-names3"
+  python setup.py install --prefix=/usr --root="$pkgdir" --optimize=1
 }

--- a/packages/python2-tld/PKGBUILD
+++ b/packages/python2-tld/PKGBUILD
@@ -2,16 +2,16 @@
 # See COPYING for license details.
 
 pkgname='python2-tld'
-pkgver='0.7.10'
-pkgrel=2
+pkgver='0.9.1'
+pkgrel=1
 pkgdesc='Extract the top level domain (TLD) from the URL given.'
 arch=('any')
 url='https://pypi.org/project/tld/#files'
 license=('MPL' 'LGPL')
 depends=('python2')
 makedepends=('python2-setuptools')
-source=("https://files.pythonhosted.org/packages/cb/36/b12ca8e6212b6a6c5408f591713f0362ad1d94b3092f6429f974a7922057/tld-${pkgver}.tar.gz")
-sha1sums=('b723427ba376b707d952b0928e3600e53b99682a')
+source=("https://files.pythonhosted.org/packages/c2/9d/834387e54dcc8a0b2faed2ed684b4bd1051230dc730dfc74b62231d70364/tld-0.9.1.tar.gz")
+sha1sums=('e66daffdd56fa8528c865e5fa598ae7bf82acdb9')
 
 build() {
   cd "$srcdir/tld-$pkgver"


### PR DESCRIPTION
The package python-tld used by photon was outdated and prevent it from starting correctly.