### PR TITLE
Upgrade Bro to 2.6

### DIFF
--- a/packages/bro/PKGBUILD
+++ b/packages/bro/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=bro
-pkgver=2.5.5
+pkgver=2.6
 pkgrel=1
 groups=('blackarch' 'blackarch-networking' 'blackarch-defensive'
         'blackarch-sniffer')
@@ -13,7 +13,7 @@ license=('custom:unknown')
 depends=('libpcap' 'openssl-1.0' 'bash' 'python' 'swig' 'ruby' 'perl' 'crypto++')
 makedepends=('cmake' 'flex' 'bison' 'swig' 'zlib')
 source=("https://www.bro.org/downloads/bro-$pkgver.tar.gz")
-sha512sums=('d210101af11a66e8a30a30b713d7fc67845c4a8e2ad3a9c91c2641c45480fbbb720f2ea59e2219f842da4076470d10c5fc0c6a3aee1c27e90d4872c11772cfa9')
+sha512sums=('ba11fe30373f4d9439b8a874cacd9553a87bb98ce0c2ebe6c3d93c2c4005540be61862c4cc38029f146a0aaf7173a9288038e20239397f73b6576d3141fbfc1f')
 
 build() {
   install -dm 755 "$srcdir/bro-$pkgver/build"


### PR DESCRIPTION
Bro 2.6 [has just been released](http://mailman.icsi.berkeley.edu/pipermail/bro/2018-November/013785.html).

See the [release notes](https://www.bro.org/sphinx/install/release-notes.html#bro-2-6).