### PR TITLE
mingw-w64-headers: fix missing headers

### DIFF
--- a/packages/mingw-w64-headers/PKGBUILD
+++ b/packages/mingw-w64-headers/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=mingw-w64-headers
 pkgver=6.0.0
 _pkgver=${pkgver/rc/-rc}
-pkgrel=1
+pkgrel=2
 pkgdesc='MinGW-w64 headers for Windows.'
 arch=('any')
 url='http://mingw-w64.sourceforge.net/'
@@ -29,7 +29,7 @@ build() {
 }
 
 package() {
-  for t in $t
+  for t in $_targets
   do
     cd "$srcdir/headers-$t"
 


### PR DESCRIPTION
# Overview

All headers are missing from the package since version 6.0.0-1 / ed6a26660ce114c589604a588a228d5f41886732 (ping @noptrix :wave: )

Since the purpose of this package is to ship headers, this fix aims to put them back in!

# Test case

Requires `mingw-w64-gcc`.

Before:
```
$ cat > test.c << EOF
#include <stdio.h>
void main() {printf("Testing\n");}
EOF
$ i686-w64-mingw32-gcc -o test test.c
test.c:1:10: fatal error: stdio.h: No such file or directory
 #include <stdio.h>
          ^~~~~~~~~
compilation terminated.
```

After:
```
$ i686-w64-mingw32-gcc -o test test.c
$ echo $?
0
```