### PR TITLE
Update to Bro 2.6.1

### DIFF
--- a/packages/bro/PKGBUILD
+++ b/packages/bro/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=bro
-pkgver=2.6
+pkgver=2.6.1
 pkgrel=1
 groups=('blackarch' 'blackarch-networking' 'blackarch-defensive'
         'blackarch-sniffer')
@@ -13,7 +13,7 @@ license=('custom:unknown')
 depends=('libpcap' 'openssl-1.0' 'bash' 'python' 'swig' 'ruby' 'perl' 'crypto++')
 makedepends=('cmake' 'flex' 'bison' 'swig' 'zlib')
 source=("https://www.bro.org/downloads/bro-$pkgver.tar.gz")
-sha512sums=('ba11fe30373f4d9439b8a874cacd9553a87bb98ce0c2ebe6c3d93c2c4005540be61862c4cc38029f146a0aaf7173a9288038e20239397f73b6576d3141fbfc1f')
+sha512sums=('18ce8efd12226b4aea962034b68f14202b03f64d2cd0c2feab354ae84160d36fd2ec94343c0f816e25aa7903e7670cf9f69cac48db75f645ee641d58af2b2f28')
 
 build() {
   install -dm 755 "$srcdir/bro-$pkgver/build"


### PR DESCRIPTION
From <http://mailman.icsi.berkeley.edu/pipermail/zeek/2018-December/013848.html>:

> This release updates the embedded SQLite to version 3.26.0 to address the "Magellan" remote code execution vulnerability.  The stock Bro configuration/scripts don't use SQLite by default, but custom user scripts/packages may.
>
> This release also updates Broker to v1.1.2, which includes a minor bug fix in its Python bindings and improved support for building it as a static library.