### PR TITLE
skipfish: add missing dependency

### DIFF
--- a/packages/skipfish/PKGBUILD
+++ b/packages/skipfish/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=skipfish
 pkgver=2.10b
-pkgrel=9
+pkgrel=10
 groups=('blackarch' 'blackarch-fuzzer' 'blackarch-scanner' 'blackarch-webapp')
 pkgdesc='A fully automated, active web application security reconnaissance tool.'
 arch=('x86_64' 'armv6h' 'armv7h' 'aarch64')

--- a/packages/skipfish/PKGBUILD
+++ b/packages/skipfish/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc='A fully automated, active web application security reconnaissance tool.
 arch=('x86_64' 'armv6h' 'armv7h' 'aarch64')
 license=('Apache')
 url='http://code.google.com/p/skipfish/'
-depends=('openssl' 'libidn')
+depends=('openssl' 'libidn' 'libidn11')
 source=('git+https://github.com/spinkham/skipfish.git'
         "skipfish.patch")
 sha512sums=('SKIP'


### PR DESCRIPTION
PR fixes lack of `libidn.so.11` library when executing skipfish:

`skipfish: error while loading shared libraries: libidn.so.11: cannot open shared object file: No such file or directory`