### PR TITLE
xortool: upgrade + dependency fix

### DIFF
--- a/packages/xortool/PKGBUILD
+++ b/packages/xortool/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc='A tool to analyze multi-byte xor cipher.'
 arch=('any')
 url="https://github.com/hellman/xortool/"
 license=('GPL')
-depends=('python' 'python-docopt>=0.6.1')
+depends=('python' 'python-docopt')
 makedepends=('git')
 source=('git+https://github.com/hellman/xortool.git')
 sha512sums=('SKIP')

--- a/packages/xortool/PKGBUILD
+++ b/packages/xortool/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc='A tool to analyze multi-byte xor cipher.'
 arch=('any')
 url="https://github.com/hellman/xortool/"
 license=('GPL')
-depends=('python2')
+depends=('python' 'python-docopt>=0.6.1')
 makedepends=('git')
 source=('git+https://github.com/hellman/xortool.git')
 sha512sums=('SKIP')
@@ -23,12 +23,12 @@ pkgver() {
 build() {
   cd $pkgname
 
-  python2 setup.py build
+  python setup.py build
 }
 
 package() {
   cd $pkgname
 
-  python2 setup.py install --optimize=1 --root="$pkgdir" --skip-build
+  python setup.py install --optimize=1 --root="$pkgdir" --skip-build
 }
 

--- a/packages/xortool/PKGBUILD
+++ b/packages/xortool/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=xortool
 pkgver=50.dbc105c
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-crypto')
 pkgdesc='A tool to analyze multi-byte xor cipher.'
 arch=('any')


### PR DESCRIPTION
solve this (see https://github.com/hellman/xortool/blob/master/setup.py)

```
xortool -h            
Traceback (most recent call last):
  File "/usr/bin/xortool", line 39, in <module>
    from xortool.args import parse_parameters, ArgError
  File "/usr/lib/python2.7/site-packages/xortool/args.py", line 4, in <module>
    from docopt import docopt
ImportError: No module named docopt
```

And is now compatible with python 3