### PR TITLE
RsaCtfTool: upgrade

### DIFF
--- a/packages/rsactftool/PKGBUILD
+++ b/packages/rsactftool/PKGBUILD
@@ -9,8 +9,8 @@ groups=('blackarch' 'blackarch-crypto' 'blackarch-cracker')
 arch=('any')
 url='https://github.com/Ganapati/RsaCtfTool'
 license=('custom:unknown')
-depends=('python2' 'python2-sympy' 'python2-argparse' 'python2-gmpy'
-         'python2-libnum')
+depends=('python' 'python-sympy' 'python-gmpy'
+         'python-requests' 'python-pycrypto')
 makedepends=('git')
 source=('git+https://github.com/Ganapati/RsaCtfTool.git')
 sha512sums=('SKIP')

--- a/packages/rsactftool/PKGBUILD
+++ b/packages/rsactftool/PKGBUILD
@@ -3,14 +3,14 @@
 
 pkgname=rsactftool
 pkgver=142.a504f9f
-pkgrel=1
+pkgrel=2
 pkgdesc='RSA tool for ctf - retreive private key from weak public key and/or uncipher data.'
 groups=('blackarch' 'blackarch-crypto' 'blackarch-cracker')
 arch=('any')
 url='https://github.com/Ganapati/RsaCtfTool'
 license=('custom:unknown')
 depends=('python' 'python-sympy' 'python-gmpy2'
-         'python-requests' 'python-pycrypto')
+         'python-requests' 'python-pycryptodome')
 makedepends=('git')
 source=('git+https://github.com/Ganapati/RsaCtfTool.git')
 sha512sums=('SKIP')
@@ -35,8 +35,7 @@ package() {
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
-cd /usr/share/$pkgname
-exec python RsaCtfTool.py "\$@"
+exec python /usr/share/$pkgname/RsaCtfTool.py "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"

--- a/packages/rsactftool/PKGBUILD
+++ b/packages/rsactftool/PKGBUILD
@@ -9,7 +9,7 @@ groups=('blackarch' 'blackarch-crypto' 'blackarch-cracker')
 arch=('any')
 url='https://github.com/Ganapati/RsaCtfTool'
 license=('custom:unknown')
-depends=('python' 'python-sympy' 'python-gmpy'
+depends=('python' 'python-sympy' 'python-gmpy2'
          'python-requests' 'python-pycrypto')
 makedepends=('git')
 source=('git+https://github.com/Ganapati/RsaCtfTool.git')
@@ -36,7 +36,7 @@ package() {
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
 cd /usr/share/$pkgname
-exec python2 RsaCtfTool.py "\$@"
+exec python RsaCtfTool.py "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"


### PR DESCRIPTION
for this error

```
  File "RsaCtfTool.py", line 15, in <module>
    from Crypto.PublicKey import RSA
ImportError: No module named Crypto.PublicKey
```

`PyCrypto` is missing but not available in arch or blackarch repos. bur is available in AUR https://aur.archlinux.org/packages/python-pycrypto/

requirements.txt: https://github.com/Ganapati/RsaCtfTool/blob/master/requirements.txt

https://github.com/Ganapati/RsaCtfTool/blob/master/RsaCtfTool.py#L1 = `#!/usr/bin/env python3`