### PR TITLE
shodan: Correct dependencies

### DIFF
--- a/packages/shodan/PKGBUILD
+++ b/packages/shodan/PKGBUILD
@@ -31,7 +31,7 @@ package_shodan() {
 
 package_python-shodan() {
   depends=('python' 'python-requests' 'python-simplejson' 'python-click'
-           'python-click-plugins' 'python-xlsxwriter')
+           'python-click-plugins' 'python-xlsxwriter' 'python-colorama')
 
   cd "$pkgbase-$pkgver"
 
@@ -42,7 +42,7 @@ package_python-shodan() {
 
 package_python2-shodan() {
   depends=('python2' 'python2-requests' 'python2-simplejson' 'python2-click'
-           'python2-click-plugins' 'python2-xlsxwriter')
+           'python2-click-plugins' 'python2-xlsxwriter' 'python2-colorama')
 
   cd "$pkgbase-$pkgver"
 


### PR DESCRIPTION
The Python Shodan packages require Colorama.