### PR TITLE
ghidra: Package fixes

### DIFF
--- a/packages/ghidra/PKGBUILD
+++ b/packages/ghidra/PKGBUILD
@@ -6,15 +6,12 @@ pkgver=9.0.2
 _releasedate=20190403
 pkgrel=1
 pkgdesc="A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission."
-arch=('any')
+arch=('x86_64')
 groups=('blackarch' 'blackarch-reversing' 'blackarch-disassembler'
         'blackarch-debugger')
 url='https://www.ghidra-sre.org/'
 license=('Apache')
-depends=('java-environment>=' 'bash')
-optdepends=('python: python plugins development.'
-            'pam: for GhidraServer support.'
-            'jython: Plugins development.')
+depends=('java-environment>=11' 'bash')
 source=("https://www.ghidra-sre.org/${pkgname}_${pkgver}_PUBLIC_${_releasedate}.zip")
 sha512sums=('865eb93029ca56936e444c76d442d14f71d7c3f59c2a19c67175759c918b8500e175e62ec7338e22e364b2a2ee42827f886c70a487f44b18dddeda60bf6a7ac7')
 

--- a/packages/ghidra/PKGBUILD
+++ b/packages/ghidra/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=ghidra
 pkgver=9.0.2
 _releasedate=20190403
-pkgrel=1
+pkgrel=2
 pkgdesc="A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission."
 arch=('x86_64')
 groups=('blackarch' 'blackarch-reversing' 'blackarch-disassembler'


### PR DESCRIPTION
Ghidra contains many 64-bit ELF executables, including one critical to
Ghidra's proper functioning, therefore should only be packaged as an
x86_64 package.

Fix typo for java-environment in dependencies.

Remove optional dependencies - Python is not needed as Ghidra uses
Jython; however, it is not an optional dependency either as it is
already bundled as a standalone environment within Ghidra; finally, PAM
is not supported by Ghidra Server.