### PR TITLE
Revert "wascan: better exec file"

### DIFF
--- a/packages/wascan/PKGBUILD
+++ b/packages/wascan/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=wascan
 _pkgname=WAScan
 pkgver=26.59fe412
-pkgrel=2
+pkgrel=4
 epoch=1
 pkgdesc='Web Application Scanner.'
 groups=('blackarch' 'blackarch-webapp' 'blackarch-scanner')

--- a/packages/wascan/PKGBUILD
+++ b/packages/wascan/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=wascan
 _pkgname=WAScan
 pkgver=26.59fe412
-pkgrel=3
+pkgrel=2
 epoch=1
 pkgdesc='Web Application Scanner.'
 groups=('blackarch' 'blackarch-webapp' 'blackarch-scanner')
@@ -34,7 +34,8 @@ package() {
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
-exec python2 /usr/share/$pkgname/$pkgname.py "\$@"
+cd /usr/share/$pkgname
+exec python2 $pkgname.py "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"


### PR DESCRIPTION
- Reverts BlackArch/blackarch#2307
- When wascan try to import modules from the current dir, it fails.

```
[i] Starting full scan...
[i] Starting attacks module...
Traceback (most recent call last):
  File "/usr/share/wascan/wascan.py", line 118, in <module>
    wascan().main()
  File "/usr/share/wascan/wascan.py", line 110, in main
    FullScan(kwargs,u,kwargs['data'])
  File "/usr/share/wascan/lib/handler/fullscan.py", line 19, in FullScan
    Attacks(kwargs,url,data)
  File "/usr/share/wascan/lib/handler/attacks.py", line 19, in Attacks
    for file in dirs(path):
  File "/usr/share/wascan/lib/utils/dirs.py", line 13, in dirs
    _ = os.listdir(path)
OSError: [Errno 2] No such file or directory: '/home/edu4rdshl/plugins/attacks/'
```
