### PR TITLE
weevely: minor fixes to the packaging

### DIFF
--- a/packages/weevely/PKGBUILD
+++ b/packages/weevely/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=weevely
 pkgver=829.8036a61
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-webapp' 'blackarch-backdoor')
 pkgdesc='Weaponized web shell.'
 arch=('any')
@@ -32,12 +32,13 @@ package() {
 
   install -dm 755 "$pkgdir/usr/bin"
   install -dm 755 "$pkgdir/usr/share/$pkgname"
+  install -dm 755 "$pkgdir/usr/share/man/man1"
 
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname" README.md CHANGELOG.md \
     requirements.txt
-  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -m 644 weevely.1 "$pkgdir/usr/share/man/man1"
 
-  rm README.md CHANGELOG.md requirements.txt LICENSE
+  rm README.md CHANGELOG.md requirements.txt LICENSE weevely.1
 
   cp -a * "$pkgdir/usr/share/$pkgname/"
 


### PR DESCRIPTION
- `install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"` is useless, see https://wiki.archlinux.org/index.php/PKGBUILD#license
- install the man page