### PR TITLE
Added SkipTracer PKGBUILD & fixed the Invoke-Obfuscation  install of Empire

### DIFF
--- a/packages/empire/PKGBUILD
+++ b/packages/empire/PKGBUILD
@@ -47,6 +47,7 @@ package() {
 
   install -dm 755 "$pkgdir/usr/bin/"
   install -dm 755 "$pkgdir/usr/share/$pkgname"
+  install -dm 755 "$pkgdir/usr/local/share/powershell/Modules"
 
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md changelog
   install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
@@ -54,6 +55,7 @@ package() {
   rm changelog LICENSE README.md
 
   cp -a * "$pkgdir/usr/share/$pkgname/"
+  cp -a lib/powershell/Invoke-Obfuscation "$pkgdir/usr/local/share/powershell/Modules/"
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh

--- a/packages/skiptracer/PKGBUILD
+++ b/packages/skiptracer/PKGBUILD
@@ -9,8 +9,8 @@ arch=('any')
 groups=('blackarch' 'blackarch-recon' 'blackarch-social')
 url='https://github.com/xillwillx/skiptracer'
 license=('GPL')
-depends=('python2-python-docx' 'python2-urllib3' 'python2-beautifulsoup4' 'python2-lxml' 'python2-requests' 'python-ipdb' 'python2-click' 
-'python2-cfscrape' 'python2-numpy' 'python2-simplejson' 'python2-tqdm')
+depends=('python2-python-docx' 'python2-urllib3' 'python2-beautifulsoup4' 'python2-lxml' 'python2-requests' 'python-ipdb' 'python2-click'
+ 'python2-cfscrape' 'python2-numpy' 'python2-simplejson' 'python2-tqdm')
 makedepends=('git')
 source=("$pkgname::git+https://github.com/xillwillx/skiptracer.git")
 sha512sums=('SKIP')

--- a/packages/skiptracer/PKGBUILD
+++ b/packages/skiptracer/PKGBUILD
@@ -1,0 +1,43 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=skiptracer
+pkgver=108.edadbef
+pkgrel=1
+pkgdesc='OSINT python2 webscraping framework. Skipping the needs of API keys.'
+arch=('any')
+groups=('blackarch' 'blackarch-recon' 'blackarch-social')
+url='https://github.com/xillwillx/skiptracer'
+license=('GPL')
+depends=('python2-python-docx' 'python2-urllib3' 'python2-beautifulsoup4' 'python2-lxml' 'python2-requests' 'python-ipdb' 'python2-click' 
+'python2-cfscrape' 'python2-numpy' 'python2-simplejson' 'python2-tqdm')
+makedepends=('git')
+source=("$pkgname::git+https://github.com/xillwillx/skiptracer.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+package() {
+  cd $pkgname
+
+  install -dm 755 "$pkgdir/usr/bin"
+
+  install -Dm 755 -t "$pkgdir/usr/share/$pkgname" *.py
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname" Changelog README.md
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+  cp -a --no-preserve=ownership storage/ plugins/ "$pkgdir/usr/share/$pkgname/"
+
+  cat > "$pkgdir/usr/bin/$pkgname" << EOF
+#!/bin/sh
+cd /usr/share/$pkgname
+exec python2 $pkgname.py "\$@"
+EOF
+
+  chmod +x "$pkgdir/usr/bin/$pkgname"
+}
+


### PR DESCRIPTION
Hi there! I added the Skiptracer PKGBUILD.

This is an OSINT scraping framework created by @xillwillx using 100% web scraping to bypass API needs and other paywalls.

**Description (taken from the git repo):**

*Initial attack vectors for recon usually involve utilizing pay-for-data/API (Recon-NG), or paying to utilize transforms (Maltego) to get data mining results. Skiptracer utilizes some basic python webscraping (BeautifulSoup) of PII paywall sites to compile passive information on a target on a ramen noodle budget.*

[LINK](https://github.com/xillwillx/skiptracer)

I also fixed the Invoke-Obfuscation Module installation in the empire PKGBUILD.

That say, I think we should switch to the dev branch of Empire to have all the latests fixes.