### PR TITLE
faraday: add missing deps

### DIFF
--- a/packages/faraday/PKGBUILD
+++ b/packages/faraday/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=faraday
 pkgver=6973.e23a7d80
-pkgrel=1
+pkgrel=2
 pkgdesc='A new concept (IPE) Integrated Penetration-Test Environment a multiuser Penetration test IDE. Designed for distribution, indexation and analyze of the generated data during the process of a security audit.'
 groups=('blackarch' 'blackarch-scanner' 'blackarch-exploitation'
         'blackarch-fuzzer' 'blackarch-fingerprint' 'blackarch-automation'
@@ -25,7 +25,7 @@ depends=('couchdb' 'python2' 'gtk3' 'gobject-introspection' 'python2-argparse'
          'python2-pgcli' 'python2-alembic' 'python2-websocket-client'
          'python2-tqdm' 'python2-flask-sqlalchemy' 'python2-marshmallow'
          'python2-pillow' 'python2-service-identity' 'python2-webargs'
-         'python2-selenium')
+         'python2-selenium' 'python2-flask-restless')
 makedepends=('git')
 options=('!strip')
 license=('GPL')

--- a/packages/faraday/PKGBUILD
+++ b/packages/faraday/PKGBUILD
@@ -25,7 +25,7 @@ depends=('couchdb' 'python2' 'gtk3' 'gobject-introspection' 'python2-argparse'
          'python2-pgcli' 'python2-alembic' 'python2-websocket-client'
          'python2-tqdm' 'python2-flask-sqlalchemy' 'python2-marshmallow'
          'python2-pillow' 'python2-service-identity' 'python2-webargs'
-         'python2-selenium' 'python2-flask-restless')
+         'python2-selenium' 'python2-flask-restless' 'postgresql')
 makedepends=('git')
 options=('!strip')
 license=('GPL')


### PR DESCRIPTION
```
$ faraday
2019-06-07 15:17:23,484 - faraday.launcher - INFO [faraday.py:191 - check_dependencies_or_exit() ]  Checking dependencies...
2019-06-07 15:17:23,484 - faraday.launcher - INFO [faraday.py:194 - check_dependencies_or_exit() ]  Some dependencies are old. Update them with "pip install -r requirements_server.txt -U"
Do you want to install them? [y/N] N
2019-06-07 15:17:38,006 - faraday.launcher - ERROR [faraday.py:206 - check_dependencies_or_exit() ]  Dependencies not met. Please refer to the documentation in order to install them. [flask-restless]

$ sudo pacman -S python2-flask-restless --asdeps

$ faraday
2019-06-07 15:21:11,972 - faraday.launcher - INFO [faraday.py:191 - check_dependencies_or_exit() ]  Checking dependencies...
2019-06-07 15:21:11,972 - faraday.launcher - INFO [faraday.py:194 - check_dependencies_or_exit() ]  Some dependencies are old. Update them with "pip install -r requirements_server.txt -U"
Do you want to install them? [y/N] N
2019-06-07 15:21:13,824 - faraday.launcher - ERROR [faraday.py:206 - check_dependencies_or_exit() ]  Dependencies not met. Please refer to the documentation in order to install them. [flask-restless]
```

Why once `python2-flask-restless` it is still not detected? `/usr/share/faraday/requirements.txt` asks for `Flask-Restless>=0.17.0` so sounds good to me.

https://github.com/BlackArch/blackarch/blob/master/packages/python2-flask-restless/PKGBUILD

Why is there `--prefix=/usr` in it compared to the template https://github.com/BlackArch/blackarch-pkgbuilds/blob/master/PKGBUILD-python ?