### PR TITLE
fix python-macholib

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+python-macholib

--- a/packages/python-macholib/PKGBUILD
+++ b/packages/python-macholib/PKGBUILD
@@ -35,6 +35,10 @@ package_python2-macholib() {
 
   python2 setup.py install --prefix=/usr --root="$pkgdir" --optimize=1 \
     --skip-build
+
+  mv "$pkgdir/usr/bin/macho_dump" "$pkgdir/usr/bin/macho_dump2"
+  mv "$pkgdir/usr/bin/macho_find" "$pkgdir/usr/bin/macho_find2"
+  mv "$pkgdir/usr/bin/macho_standalone" "$pkgdir/usr/bin/macho_standalone2"
 }
 
 package_python-macholib() {


### PR DESCRIPTION
Fixing the binaries overloap when python-macholib and python2-macholib gets installed.