### PR TITLE
python2-tldextract: 'python2-requests-file' is required on runtime

### DIFF
--- a/packages/python2-tldextract/PKGBUILD
+++ b/packages/python2-tldextract/PKGBUILD
@@ -3,13 +3,13 @@
 
 pkgname=python2-tldextract
 pkgver=2.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Accurately separates the gTLD or ccTLD (generic or country code top-level domain) from the registered domain and subdomains of a URL.'
 arch=('any')
 url='https://github.com/john-kurkowski/tldextract'
 license=('custom:BSD')
-depends=('python2')
-makedepends=('python2-setuptools' 'python2-requests-file')
+depends=('python2' 'python2-requests-file')
+makedepends=('python2-setuptools')
 source=("https://files.pythonhosted.org/packages/35/81/ec1f53b7113d3ea340019d184fa0be2cdf8b195cd66d9b96811af65500fd/tldextract-2.2.1.tar.gz")
 sha512sums=('db4f14e514c0e68f85f28226343d7ec91ceea2843ee01c9a2950f0972f365bf343640e07cfb118aff52bab975719be71d179fc6b3bd4da7eb62a47b62747cc0b')
 


### PR DESCRIPTION
e.g. 'altdns' package (which requires 'python2-tldextract') fails to run due to missing 'python2-requests-file' package.