### PR TITLE
rabid: new package

### DIFF
--- a/packages/rabid/PKGBUILD
+++ b/packages/rabid/PKGBUILD
@@ -1,0 +1,32 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=rabid
+_gemname=rabid
+pkgver=0.0.1
+pkgrel=1
+pkgdesc='A CLI tool and library allowing to simply decode all kind of BigIP cookies.'
+arch=('any')
+url='https://orange-cyberdefense.github.io/rabid/'
+license=('MIT')
+depends=('ruby' 'ruby-paint' 'ruby-docopt')
+makedepends=('rubygems')
+source=("https://rubygems.org/downloads/$_gemname-$pkgver.gem")
+noextract=("$_gemname-$pkgver.gem")
+sha512sums=('f3aafe6620540d5a3b7ba5263761abd929067702b6354263783787c3893177f004a1a8efdc586d63f149ff6ce9a5ce600f8f2527860908c5ede54119cb8930a0')
+
+package() {
+  local _gemdir="$(ruby -r rubygems -e'puts Gem.default_dir')"
+
+  if [[ $CARCH == arm* ]] ; then
+    gem install --ignore-dependencies --no-user-install --no-rdoc --no-ri \
+      -i "$pkgdir$_gemdir" "$_gemname-$pkgver.gem"
+  else
+    gem install --ignore-dependencies --no-user-install -i "$pkgdir$_gemdir" \
+      "$_gemname-$pkgver.gem"
+  fi
+
+  rm -rf "$pkgdir/$_gemdir/cache"
+  install -D -m644 "$pkgdir/$_gemdir/gems/$_gemname-$pkgver/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+

--- a/packages/rabid/PKGBUILD
+++ b/packages/rabid/PKGBUILD
@@ -7,6 +7,7 @@ pkgver=0.0.1
 pkgrel=1
 pkgdesc='A CLI tool and library allowing to simply decode all kind of BigIP cookies.'
 arch=('any')
+groups=('blackarch-webapp' 'blackarch-misc')
 url='https://orange-cyberdefense.github.io/rabid/'
 license=('MIT')
 depends=('ruby' 'ruby-paint' 'ruby-docopt')
@@ -27,6 +28,6 @@ package() {
   fi
 
   rm -rf "$pkgdir/$_gemdir/cache"
-  install -D -m644 "$pkgdir/$_gemdir/gems/$_gemname-$pkgver/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm 644 "$pkgdir/$_gemdir/gems/$_gemname-$pkgver/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }
 

--- a/packages/ruby-docopt/PKGBUILD
+++ b/packages/ruby-docopt/PKGBUILD
@@ -27,6 +27,6 @@ package() {
   fi
 
   rm -rf "$pkgdir/$_gemdir/cache"
-  install -D -m644 "$pkgdir/$_gemdir/gems/$_gemname-$pkgver/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm 644 "$pkgdir/$_gemdir/gems/$_gemname-$pkgver/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }
 

--- a/packages/ruby-docopt/PKGBUILD
+++ b/packages/ruby-docopt/PKGBUILD
@@ -1,0 +1,32 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=ruby-docopt
+_gemname=docopt
+pkgver=0.6.1
+pkgrel=1
+pkgdesc='Command line option parser, that will make you smile'
+arch=('any')
+url='https://github.com/docopt/docopt.rb'
+license=('MIT')
+depends=('ruby')
+makedepends=('rubygems')
+source=("https://rubygems.org/downloads/$_gemname-$pkgver.gem")
+noextract=("$_gemname-$pkgver.gem")
+sha256sums=('73f837ed376d015971712c17f7aafa021998b964b77d52997dcaff79d6727467')
+
+package() {
+  local _gemdir="$(ruby -r rubygems -e'puts Gem.default_dir')"
+
+  if [[ $CARCH == arm* ]] ; then
+    gem install --ignore-dependencies --no-user-install --no-rdoc --no-ri \
+      -i "$pkgdir$_gemdir" "$_gemname-$pkgver.gem"
+  else
+    gem install --ignore-dependencies --no-user-install -i "$pkgdir$_gemdir" \
+      "$_gemname-$pkgver.gem"
+  fi
+
+  rm -rf "$pkgdir/$_gemdir/cache"
+  install -D -m644 "$pkgdir/$_gemdir/gems/$_gemname-$pkgver/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+


### PR DESCRIPTION
The dependency [ruby-paint](https://www.archlinux.org/packages/community/any/ruby-paint/) is out of date.

rabid requires 2.1+ and currently official arch package provides 2.0.1. waiting a little before merging.