### PR TITLE
tor-browser-en: zenity dependency.

### DIFF
--- a/packages/tor-browser-en/PKGBUILD
+++ b/packages/tor-browser-en/PKGBUILD
@@ -11,9 +11,8 @@ groups=('blackarch' 'blackarch-defensive')
 license=('GPL')
 depends=('gtk2' 'mozilla-common' 'libxt' 'startup-notification' 'mime-types'
          'dbus-glib' 'alsa-lib' 'desktop-file-utils' 'hicolor-icon-theme'
-         'libvpx' 'icu' 'libevent' 'nss' 'hunspell' 'sqlite')
-optdepends=('zenity: simple dialog boxes'
-            'kdialog: KDE dialog boxes'
+         'libvpx' 'icu' 'libevent' 'nss' 'hunspell' 'sqlite' 'zenity')
+optdepends=('kdialog: KDE dialog boxes'
             'gst-plugins-good: H.264 video'
             'gst-libav: H.264 video'
             'libpulse: PulseAudio audio driver'

--- a/packages/tor-browser-en/PKGBUILD
+++ b/packages/tor-browser-en/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=tor-browser-en
 pkgver=8.5.4
-pkgrel=1
+pkgrel=2
 pkgdesc='Tor Browser Bundle: anonymous browsing using Firefox and Tor.'
 url='https://www.torproject.org/projects/torbrowser.html.en'
 arch=('x86_64')


### PR DESCRIPTION
zenity is not 'optdepends' anymore, it is mandatory.