### PR TITLE
terminus-font-ttf: TTF Terminus font support.

### DIFF
--- a/packages/terminus-font-ttf/PKGBUILD
+++ b/packages/terminus-font-ttf/PKGBUILD
@@ -1,0 +1,30 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+#
+# This PKGBUILD file was initially retrieved from AUR and all credits goes to:
+# Maintainer: Tilman Blumenbach <tilman [AT] ax86 [DOT] net>
+
+pkgname='terminus-font-ttf'
+pkgver=4.47.0
+pkgrel=1
+pkgdesc="Monospaced bitmap font designed for long work with computers (TTF version, mainly for Java applications)"
+arch=('any')
+url="https://files.ax86.net/terminus-ttf"
+license=('custom:OFL')
+depends=('fontconfig' 'xorg-mkfontdir')
+install='terminus-font-ttf.install'
+source=("https://files.ax86.net/terminus-ttf/files/${pkgver}/terminus-ttf-${pkgver}.zip")
+sha256sums=('3b98bde7e54827fb042686cdc7e902ac17289092e1dd2ccfeaea7ac3cedff606')
+
+package()
+{
+    cd "${srcdir}/terminus-ttf-${pkgver}"
+
+    for i in *.ttf; do
+        local destname="$(echo "$i" | sed -E 's|-[[:digit:].]+\.ttf$|.ttf|')"
+        install -Dm 644 "$i" "${pkgdir}/usr/share/fonts/TTF/${destname}"
+    done
+
+    install -Dm 644 COPYING "${pkgdir}/usr/share/licenses/terminus-font-ttf/COPYING"
+}
+

--- a/packages/terminus-font-ttf/PKGBUILD
+++ b/packages/terminus-font-ttf/PKGBUILD
@@ -7,9 +7,9 @@
 pkgname='terminus-font-ttf'
 pkgver=4.47.0
 pkgrel=1
-pkgdesc="Monospaced bitmap font designed for long work with computers (TTF version, mainly for Java applications)"
+pkgdesc='Monospaced bitmap font designed for long work with computers (TTF version, mainly for Java applications)'
 arch=('any')
-url="https://files.ax86.net/terminus-ttf"
+url='https://files.ax86.net/terminus-ttf'
 license=('custom:OFL')
 depends=('fontconfig' 'xorg-mkfontdir')
 install='terminus-font-ttf.install'

--- a/packages/terminus-font-ttf/terminus-font-ttf.install
+++ b/packages/terminus-font-ttf/terminus-font-ttf.install
@@ -1,0 +1,4 @@
+post_install()
+{
+    echo '>>> The font files have been installed into /usr/share/fonts/TTF/.'
+}


### PR DESCRIPTION
Some applications require TTF support to display Terminus font.
This PR has the potential to fix #2433, but needs further tests.