### PR TITLE
sleuthkit-java: Fixed jar filepath so that autopsy's symlink would be valid

### DIFF
--- a/packages/sleuthkit-java/PKGBUILD
+++ b/packages/sleuthkit-java/PKGBUILD
@@ -36,6 +36,6 @@ package() {
   cd "$_pkgname-$pkgver"
 
   install -Dm 644 "bindings/java/dist/$_pkgname-$pkgver.jar" \
-    "$pkgdir/usr/share/java/$pkgname-$pkgver.jar"
+    "$pkgdir/usr/share/java/$_pkgname-$pkgver.jar"
 }
 


### PR DESCRIPTION
Fixes #2497 