### PR TITLE
airgeddon: remove install license

### DIFF
--- a/packages/airgeddon/PKGBUILD
+++ b/packages/airgeddon/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=airgeddon
 pkgver=2063.dfee46c
-pkgrel=1
+pkgrel=2
 pkgdesc='Multi-use bash script for Linux systems to audit wireless networks.'
 groups=('blackarch' 'blackarch-wireless' 'blackarch-automation')
 arch=('any')
@@ -41,7 +41,6 @@ package() {
 
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md CHANGELOG.md \
     CONTRIBUTING.md
-  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
   rm -rf *.md .github binaries imgs Dockerfile pindb_checksum.txt .editorconfig\
     .git*


### PR DESCRIPTION
https://wiki.archlinux.org/index.php/PKGBUILD#license

> The license under which the software is distributed. The licenses package (a dependency of the base meta package) contains many commonly used licenses, which are installed under /usr/share/licenses/common/. If a package is licensed under one of these licenses, the value should be set to the directory name, e.g. license=('GPL').

TL;DR: do not copy the license when it's a common one.

Use `install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"` only for custom licenses or ones that have their own copyright line liek MIT, BSD, etc.