### PR TITLE
crosstool-ng: update URL

### DIFF
--- a/packages/crosstool-ng/PKGBUILD
+++ b/packages/crosstool-ng/PKGBUILD
@@ -11,19 +11,20 @@ url='https://crosstool-ng.github.io/'
 license=('GPL')
 depends=('make' 'gperf' 'wget' 'help2man')
 makedepends=('unzip')
-source=("https://crosstool-ng.github.io/download/$pkgname/$pkgname-$pkgver.tar.xz")
-sha512sums=('379e668365628f0ab359ae119213bed44960870093f64f0fbb12e92bbe2a3b82bfed77f5ab33f2e2f17c1977e7a63f2151c46ad8d0e6208220fb7fa8726fae33')
+source=("https://github.com/crosstool-ng/crosstool-ng/archive/$pkgname-$pkgver.tar.gz")
+sha512sums=('a0f355b37e221687f5aa2a0ded701bd503debfb29d2200ee8737c141c430078678be04690e491b3927792ac43d2499e5899bd993f1e514ebac737fd1d126871f')
 
 build() {
-  cd "$pkgname-$pkgver"
+  cd "$pkgname-$pkgname-$pkgver"
 
+  ./bootstrap
   ./configure --prefix=/usr
 
   make -j1
 }
 
 package() {
-  cd "$pkgname-$pkgver"
+  cd "$pkgname-$pkgname-$pkgver"
 
   make DESTDIR="$pkgdir" install
 }

--- a/packages/crosstool-ng/PKGBUILD
+++ b/packages/crosstool-ng/PKGBUILD
@@ -3,15 +3,15 @@
 
 pkgname=crosstool-ng
 pkgver=1.24.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Versatile (cross-)toolchain generator.'
 groups=('blackarch' 'blackarch-misc')
 arch=('x86_64' 'aarch64')
-url='http://crosstool-ng.org/'
+url='https://crosstool-ng.github.io/'
 license=('GPL')
 depends=('make' 'gperf' 'wget' 'help2man')
 makedepends=('unzip')
-source=("http://crosstool-ng.org/download/$pkgname/$pkgname-$pkgver.tar.bz2")
+source=("https://crosstool-ng.github.io/download/$pkgname/$pkgname-$pkgver.tar.xz")
 sha512sums=('379e668365628f0ab359ae119213bed44960870093f64f0fbb12e92bbe2a3b82bfed77f5ab33f2e2f17c1977e7a63f2151c46ad8d0e6208220fb7fa8726fae33')
 
 build() {


### PR DESCRIPTION
The original URL is dead and has moved to https://crosstool-ng.github.io/

a github is available to create a git package https://github.com/crosstool-ng/crosstool-ng