### PR TITLE
fix mrsmith0x00 mess

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+ruby-ctf-party

--- a/packages/ruby-ctf-party/PKGBUILD
+++ b/packages/ruby-ctf-party/PKGBUILD
@@ -3,10 +3,9 @@
 
 pkgname=ruby-ctf-party
 _gemname=ctf-party
-pkgver=v1.0.0.r9.g9a26030
-pkgrel=4
-pkgver=1.0.0
-pkgrel=4
+pkgver=v1.1.0.r13.g3bfd828
+pkgrel=1
+groups=('blackarch' 'blackarch-misc')
 pkgdesc='A library to enhance and speed up script/exploit writting for CTF players'
 arch=('any')
 url='https://orange-cyberdefense.github.io/ctf-party/'
@@ -16,8 +15,6 @@ makedepends=('git')
 options=(!emptydirs)
 source=("git+https://github.com/Orange-Cyberdefense/$_gemname.git")
 sha512sums=('SKIP')
-source=("https://rubygems.org/gems/$_pkgname-$pkgver.gem")
-sha512sums=('b965f544ad4f903108d151298b75b7573ad705d9455cfb8a314f94118099e6f596cb2fd736c6ae07ff12c4c7bcbc556fbc78706e87e6767c2f49683ac7697192')
 
 pkgver() {
   cd $_gemname

--- a/scripts/up-libraries
+++ b/scripts/up-libraries
@@ -128,7 +128,7 @@ def main(function, needed):
         'python2-pytsk3', 'python2-pywavelets', 'python2-pyxml',
     ]
 
-    ruby_exclusions = ['ruby-unf', 'ruby-ctf-party',]
+    ruby_exclusions = ['ruby-unf']
 
 
     if needed == 'python':


### PR DESCRIPTION
- fix mrsmith0x00 mess that broke the package
- add back a group since it is a targeted tool and not the dependency of another tool that is not meant to be used directly (see it as pwntool)
- remove from exclusion