### PR TITLE
drozer: Fixed typo in PKGBUILD.

### DIFF
--- a/packages/drozer/PKGBUILD
+++ b/packages/drozer/PKGBUILD
@@ -20,7 +20,7 @@ prepare() {
 
 package() {
   install -dm 755 "$pkgdir/usr/bin"
-  install -dm 755 "$pkgdir/usr/share/$Pkgname"
+  install -dm 755 "$pkgdir/usr/share/$pkgname"
 
   cp -a usr/lib/python2.7/dist-packages/* "$pkgdir/usr/share/$pkgname/"
 


### PR DESCRIPTION
The PKGBUILD fails to install due to a upper case typo. Fixed that and tested that it builds correctly.