### PR TITLE
Fix Python Prettytable read permission for CME

### DIFF
--- a/packages/python2-prettytable/PKGBUILD
+++ b/packages/python2-prettytable/PKGBUILD
@@ -24,5 +24,7 @@ package() {
   cd "$_pkgname-$pkgver"
 
   python2 setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
-}
 
+  chmod 644 \
+    "$pkgdir/usr/lib/python2.7/site-packages/prettytable-0.7.2-py2.7.egg-info/"*
+}


### PR DESCRIPTION
Reference to @noraj issue. https://github.com/BlackArch/blackarch/issues/2694

```
 ▲ /tmp/pretty sudo pacman -U python2-prettytable-0.7.2-12-any.pkg.tar.xz
loading packages...
resolving dependencies...
looking for conflicting packages...

Packages (1) python2-prettytable-0.7.2-12

Total Installed Size:  0.15 MiB

:: Proceed with installation? [Y/n] y
(1/1) checking keys in keyring                                                    [###############################################] 100%
(1/1) checking package integrity                                                  [###############################################] 100%
(1/1) loading package files                                                       [###############################################] 100%
(1/1) checking for file conflicts                                                 [###############################################] 100%
(1/1) checking available disk space                                               [###############################################] 100%
:: Processing package changes...
(1/1) installing python2-prettytable                                              [###############################################] 100%
:: Running post-transaction hooks...
(1/1) Arming ConditionNeedsUpdate...

 ▲ /tmp/pretty ls -al /usr/lib/python2.7/site-packages/prettytable-0.7.2-py2.7.egg-info/                                                total 76
drwxr-xr-x   2 root root  4096 Mar 23 22:43 .
drwxr-xr-x 739 root root 53248 Mar 23 22:43 ..
-rw-r--r--   1 root root     1 Mar 23 22:43 dependency_links.txt
-rw-r--r--   1 root root   710 Mar 23 22:43 PKG-INFO
-rw-r--r--   1 root root   230 Mar 23 22:43 SOURCES.txt
-rw-r--r--   1 root root    12 Mar 23 22:43 top_level.txt
```