### PR TITLE
Add dfir_ntfs to release

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+dfir_ntfs

--- a/packages/dfir_ntfs/PKGBUILD
+++ b/packages/dfir_ntfs/PKGBUILD
@@ -1,0 +1,30 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=dfir_ntfs
+pkgver=1.0.3
+pkgrel=1
+pkgdesc='An NTFS parser for digital forensics & incident response'
+arch=('any')
+groups=('blackarch' 'blackarch-forensic')
+url='https://github.com/msuhanov/dfir_ntfs'
+license=('GPL')
+depends=('python')
+makedepends=('python-setuptools')
+source=("https://github.com/msuhanov/dfir_ntfs/archive/${pkgver}.zip")
+sha512sums=('fbf622995baa3e51b0b846bd31fc8acd6678451814fc43686a2da2dc62832cc2b4f7330733b6cc95481e86069260b5d6e0383a0a817d2226f136cbb27a51238a')
+
+build() {
+  cd "$pkgname-$pkgver"
+
+  python setup.py build
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" ReadMe ChangeLog License
+}
+


### PR DESCRIPTION
```
Package dfir_ntfs-1.0.3-1-any.pkg.tar.zst installed correctly! Testing it now...
Extract information from NTFS metadata files, volumes, and shadow copies

Usage:
 ntfs_parser --mft <input file ($MFT)> <output file (CSV)>
 ntfs_parser --usn <input file ($MFT)> <input file ($UsnJrnl:$J)> <output file (CSV)>
 ntfs_parser --log <input file ($MFT)> <input file ($LogFile)> <output file (TXT)>
 ntfs_parser --indx <input file (raw image)> <volume offset (in bytes)> <output file (CSV)>
 ntfs_parser --all-mft <input file (raw image)> <volume offset (in bytes)> <output file (CSV)>
 ntfs_parser --mem <input file (raw memory image)> <output file (CSV)>
```