### PR TITLE
Add python-distro as a dependency for mobsf

### DIFF
--- a/packages/mobsf/PKGBUILD
+++ b/packages/mobsf/PKGBUILD
@@ -10,7 +10,7 @@ pkgdesc='An intelligent, all-in-one open source mobile application (Android/iOS)
 arch=('any')
 url='https://github.com/MobSF/Mobile-Security-Framework-MobSF'
 license=('GPL3')
-depends=('python' 'python-django' 'python-pdfkit' 'androguard' 'wkhtmltopdf'
+depends=('python' 'python-distro' 'python-django' 'python-pdfkit' 'androguard' 'wkhtmltopdf'
          'python-lxml' 'python-rsa' 'python-biplist' 'python-requests'
          'jre-openjdk' 'python-yara' 'sqlite' 'fontconfig' 'libjpeg-turbo'
          'python-virtualenv' 'python-pytz' 'python-numpy' 'python-pyparsing'


### PR DESCRIPTION
Currently when installing mobsf on a clean install of blackarch, I receive a handful of times.
```
ModuleNotFoundError: No module named 'distro'
```

This should prevent that.