### PR TITLE
ssh audit revamp

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,3 +1,4 @@
 libvmi
 python-libvmi
 pyvmidbg
+ssh-audit

--- a/packages/ssh-audit/PKGBUILD
+++ b/packages/ssh-audit/PKGBUILD
@@ -2,43 +2,38 @@
 # See COPYING for license details.
 
 pkgname=ssh-audit
-pkgver=165.22b671e
+pkgver=v2.2.0.r0.ge447c42
 pkgrel=1
+epoch=1
 groups=('blackarch' 'blackarch-scanner')
 pkgdesc='SSH server auditing (banner, key exchange, encryption, mac, compression, compatbility, etc).'
 arch=('any')
-url='https://github.com/arthepsy/ssh-audit'
+url='https://github.com/jtesta/ssh-audit'
 license=('MIT')
-depends=('python2')
-makedepends=('git')
-source=("git+https://github.com/arthepsy/$pkgname.git")
+depends=('python')
+makedepends=('git' 'python-setuptools')
+source=("git+https://github.com/jtesta/$pkgname.git")
 sha512sums=('SKIP')
 
 pkgver() {
   cd $pkgname
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+  cd "$pkgname/pypi"
+
+  # Lack of symbolic link workaround
+  cp ../ssh-audit.py sshaudit/sshaudit.py
+  cp ../README.md sshaudit/README.md
+
+  python setup.py build
 }
 
 package() {
-  cd $pkgname
+  cd "$pkgname/pypi"
 
-  install -dm 755 "$pkgdir/usr/bin"
-  install -dm 755 "$pkgdir/usr/share/$pkgname"
-
-  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
-  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
-
-  rm README.md LICENSE
-
-  cp -a * "$pkgdir/usr/share/$pkgname/"
-
-  cat > "$pkgdir/usr/bin/$pkgname" << EOF
-#!/bin/sh
-cd /usr/share/$pkgname
-exec python2 $pkgname.py "\$@"
-EOF
-
-  chmod +x "$pkgdir/usr/bin/$pkgname"
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
 }
 

--- a/packages/ssh-audit/PKGBUILD
+++ b/packages/ssh-audit/PKGBUILD
@@ -21,12 +21,16 @@ pkgver() {
   git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
-build() {
-  cd "$pkgname/pypi"
+prepare() {
+  cd $pkgname
 
   # Symbolic link workaround, https://github.com/jtesta/ssh-audit/issues/46
-  cp ../ssh-audit.py sshaudit/sshaudit.py
-  cp ../README.md sshaudit/README.md
+  cp ssh-audit.py pypi/sshaudit/sshaudit.py
+  cp README.md pypi/sshaudit/README.md
+}
+
+build() {
+  cd "$pkgname/pypi"
 
   python setup.py build
 }

--- a/packages/ssh-audit/PKGBUILD
+++ b/packages/ssh-audit/PKGBUILD
@@ -24,7 +24,7 @@ pkgver() {
 build() {
   cd "$pkgname/pypi"
 
-  # Lack of symbolic link workaround
+  # Symbolic link workaround, https://github.com/jtesta/ssh-audit/issues/46
   cp ../ssh-audit.py sshaudit/sshaudit.py
   cp ../README.md sshaudit/README.md
 


### PR DESCRIPTION
- Upgrade to maintained fork: from [arthepsy/ssh-audit](https://github.com/arthepsy/ssh-audit) (x-2016) to [jtesta/ssh-audit](https://github.com/jtesta/ssh-audit) (2010-2020) (fix https://github.com/BlackArch/blackarch/issues/2802)
- upgrade python 2 -> 3
- manual -> `python setup.py`
- upgrade pkgver with git tag (idk if force epoch is required @noptrix to go from `165.22b671e` to `v2.2.0.r0.ge447c42`)

Proof of test:

```
$ ba-dev -e 'ssh-audit' -p ssh-audit-1:v2.2.0.r0.ge447c42-1-any.pkg.tar.zst
...
Package ssh-audit-1:v2.2.0.r0.ge447c42-1-any.pkg.tar.zst installed correctly! Testing it now...
# ssh-audit v2.2.0, https://github.com/jtesta/ssh-audit

usage: ssh-audit [-1246pbcnjvlt] <host>

   -h,  --help             print this help
   -1,  --ssh1             force ssh version 1 only
   -2,  --ssh2             force ssh version 2 only
   -4,  --ipv4             enable IPv4 (order of precedence)
   -6,  --ipv6             enable IPv6 (order of precedence)
   -p,  --port=<port>      port to connect
   -b,  --batch            batch output
   -c,  --client-audit     starts a server on port 2222 to audit client
                               software config (use -p to change port;
                               use -t to change timeout)
   -n,  --no-colors        disable colors
   -j,  --json             JSON output
   -v,  --verbose          verbose output
   -l,  --level=<level>    minimum output level (info|warn|fail)
   -t,  --timeout=<secs>   timeout (in seconds) for connection and reading
                               (default: 5)
```