### PR TITLE
Fix change directory error

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -2,3 +2,4 @@ python-typing
 python-hstspreload
 python-graphviz
 python-azure-cli-core
+scoutsuite

--- a/packages/scoutsuite/PKGBUILD
+++ b/packages/scoutsuite/PKGBUILD
@@ -36,9 +36,8 @@ package() {
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
-cd /usr/share/$pkgname
-source venv/bin/activate
-exec python scout.py "\$@"
+source /usr/share/$pkgname/venv/bin/activate
+exec python /usr/share/$pkgname/scout.py "\$@"
 EOF
 
   chmod a+x "$pkgdir/usr/bin/$pkgname"

--- a/packages/scoutsuite/PKGBUILD
+++ b/packages/scoutsuite/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=scoutsuite
 pkgver=5015.8291714d
-pkgrel=1
+pkgrel=2
 pkgdesc='Multi-Cloud Security Auditing Tool.'
 groups=('blackarch' 'blackarch-scanner')
 arch=('any')


### PR DESCRIPTION
Scoutesuite by default writes files in your current directory. As this package cd's to the package directory, it returns a permission error as well as not writing to the expected directory. I have removed the cd and referenced the correct directory in both the source and the python execution