### PR TITLE
Update Burpsuite to 2020.9.1

### DIFF
--- a/packages/burpsuite/PKGBUILD
+++ b/packages/burpsuite/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=burpsuite
-pkgver=2020.9
+pkgver=2020.9.1
 pkgrel=1
 epoch=1
 groups=('blackarch' 'blackarch-fuzzer' 'blackarch-proxy' 'blackarch-scanner'
@@ -19,7 +19,7 @@ source=("$pkgname.jar::https://portswigger.net/burp/releases/download?product=co
         "$pkgname.desktop"
         'icon64.png'
         'git+https://github.com/PortSwigger/command-injection-attacker.git')
-sha512sums=('c3758db99ce7b30389f9622e47219c397ce749533ea696362dc48e8e2f4aa5c499519905a94097e69feae8d4e6b7bf5bff03d04a47e2bb1fc9bb255f1ed1d10f'
+sha512sums=('50b9aca8ed3e2e276fc7c444647f8ce9cb5565918547ae801659be146bbe963e9e2e7e6d27d19a4b4aa378f8e47244f43904025e562c18d0a31421a33977f61e'
             '07f646ce79e4e259c8da4a16ecd9b0149f09cd047ab42bfb758dc1cd4871710866e4dae6cda572f96fb49d0b156e64dd7b0a78904d9d367d41136214de5488a2'
             '87790fac549e165f93f4e1dcaff93484957f20e7530e8b51586a22f4db594f6bfae730e4748e809c9b127571d764b026432cdaf47c282469a4ab42b037245895'
             '928083e0189ce50304c4b32f8f6ef56be79881090bffdaddb5e990a59186ed2596c03293255693d488a47519e6da4e969e74e9bfe22a0f6ca53491a4e0749575'


### PR DESCRIPTION
as Portswigger did (Hotfix)