### PR TITLE
svn-extractor: Migrate to py3

### DIFF
--- a/lists/python2-tools
+++ b/lists/python2-tools
@@ -453,7 +453,6 @@ stomper
 sublist3r
 subterfuge
 sulley
-svn-extractor
 swarm
 tabi
 taof

--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+svn-extractor

--- a/packages/svn-extractor/PKGBUILD
+++ b/packages/svn-extractor/PKGBUILD
@@ -2,14 +2,14 @@
 # See COPYING for license details.
 
 pkgname=svn-extractor
-pkgver=39.39941be
-pkgrel=2
-groups=('blackarch' 'blackarch-scanner')
+pkgver=42.c27831c
+pkgrel=1
+groups=('blackarch' 'blackarch-recon' 'blackarch-scanner')
 pkgdesc='A simple script to extract all web resources by means of .SVN folder exposed over network.'
 arch=('any')
 url='https://github.com/anantshri/svn-extractor'
 license=('GPL3')
-depends=('python2' 'python2-pysqlite' 'python2-requests')
+depends=('python' 'python-pysqlite3' 'python-requests')
 makedepends=('git')
 source=("git+https://github.com/anantshri/$pkgname.git")
 sha512sums=('SKIP')
@@ -18,12 +18,6 @@ pkgver() {
   cd $pkgname
 
   echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
-}
-
-prepare(){
-  cd $pkgname
-
-  sed -i 's|python$|python2|' svn_extractor.py
 }
 
 package() {


### PR DESCRIPTION
[Sent a PR to svn-extractor](https://github.com/anantshri/svn-extractor/pull/18) last night to migrate it to Python3. The package is now Python3 (:partying_face: ) and this PR updates it.