### PR TITLE
grype: version bump.

### DIFF
--- a/packages/grype/PKGBUILD
+++ b/packages/grype/PKGBUILD
@@ -10,7 +10,7 @@ arch=('x86_64' 'aarch64')
 url='https://github.com/anchore/grype'
 license=('APACHE')
 depends=('glibc')
-makedepends=('git' 'go-pie')
+makedepends=('git' 'go')
 source=("git+https://github.com/anchore/$pkgname.git")
 sha512sums=('SKIP')
 

--- a/packages/grype/PKGBUILD
+++ b/packages/grype/PKGBUILD
@@ -2,8 +2,9 @@
 # See COPYING for license details.
 
 pkgname=grype
-pkgver=263.90b4464
+pkgver=0.5.0
 pkgrel=1
+epoch=1
 groups=('blackarch' 'blackarch-scanner')
 pkgdesc='A vulnerability scanner for container images and filesystems.'
 arch=('x86_64' 'aarch64')
@@ -11,23 +12,17 @@ url='https://github.com/anchore/grype'
 license=('APACHE')
 depends=('glibc')
 makedepends=('git' 'go')
-source=("git+https://github.com/anchore/$pkgname.git")
-sha512sums=('SKIP')
-
-pkgver() {
-  cd $pkgname
-
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
-}
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz")
+sha512sums=('1138a63b640f8cb918c0c439b37a60e7c9c2c8c9a1d2e2b239a279850d4937bae054620e2ba817fba124b0b048f8e812f00f2783115277edc4e147361e59e3db')
 
 build() {
-  cd $pkgname
+  cd "${pkgname}-${pkgver}"
 
   GOPATH="$srcdir" go get -d -t .
 }
 
 package() {
-  cd $pkgname
+  cd "${pkgname}-${pkgver}"
 
   install -dm 755 "$pkgdir/usr/bin"
 

--- a/packages/grype/PKGBUILD
+++ b/packages/grype/PKGBUILD
@@ -26,7 +26,13 @@ package() {
 
   install -dm 755 "$pkgdir/usr/bin"
 
-  GOPATH="$srcdir" go build -v -o "$pkgname.bin" .
+  GOPATH="$srcdir" go build \
+    -trimpath \
+    -buildmode=pie \
+    -mod=readonly \
+    -modcacherw \
+    -ldflags "-linkmode external -extldflags \"${LDFLAGS}\"" \
+    -v -o "$pkgname.bin" .
 
   install -Dm 755 "$pkgname.bin" "$pkgdir/usr/bin/$pkgname"
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md \


### PR DESCRIPTION
And a bit more:

* #2926 is addressed
* versions are converted to github releases (from commit number)
  * `epoch` is introduced to allow updates
* go build flags & options