### PR TITLE
mirror.lst: add SJTUG mirror

### DIFF
--- a/mirror/mirror.lst
+++ b/mirror/mirror.lst
@@ -5,6 +5,7 @@ CH|http://mirror.easyname.ch/blackarch/$repo/os/$arch|easyname
 CH|https://mirror.tillo.ch/ftp/blackarch/$repo/os/$arch|tillo
 CN|https://mirrors.ustc.edu.cn/blackarch/$repo/os/$arch|USTC
 CN|https://mirrors.tuna.tsinghua.edu.cn/blackarch/$repo/os/$arch|TUNA
+CN|https://mirror.sjtu.edu.cn/blackarch/$repo/os/$arch|SJTUG
 DE|https://ftp.halifax.rwth-aachen.de/blackarch/$repo/os/$arch|RWTH-Aachen
 DE|https://blackarch.unixpeople.org/$repo/os/$arch|unixpeople
 DE|http://mirror.undisclose.de/blackarch/$repo/os/$arch|undisclose


### PR DESCRIPTION
We have recently set up SJTUG mirror for blackarch.

Here is some basic information about our mirror.

```
Country: China
Organization or Name: Shanghai Jiao Tong University Linux User Group (SJTUG)
Contact Name: SJTUG
Contact Email: sjtug-mirror-maintainers@googlegroups.com
Mirror URLs: https://mirror.sjtu.edu.cn/blackarch/
Bandwidth: 1Gbps
Supports IPv6: Yes
```

Maybe we need also update https://blackarch.org/downloads.html#mirror-list