### PR TITLE
Update mirror.lst - add mirror

### DIFF
--- a/mirror/mirror.lst
+++ b/mirror/mirror.lst
@@ -28,6 +28,7 @@ GR|http://ftp.cc.uoc.gr/mirrors/linux/blackarch/$repo/os/$arch|cc.uoc.gr
 HU|https://quantum-mirror.hu/mirrors/pub/blackarch/$repo/os/$arch|quantum-mirror
 IT|http://blackarch.mirror.garr.it/mirrors/blackarch/$repo/os/$arch|garr
 JP|http://www.ftp.ne.jp/Linux/packages/blackarch/$repo/os/$arch|ne
+KR|https://mirror.krmir.org/blackarch/$repo/os/$arch|krmir_ftp
 NL|http://mirror.serverion.com/blackarch/$repo/os/$arch|serverion
 NL|https://mirror.serverion.com/blackarch/$repo/os/$arch|serverion
 NL|https://mirror.neostrada.nl/blackarch/$repo/os/$arch|neostrada


### PR DESCRIPTION
Our organization has been started to mirror BlackArch.
So I would like to request you to add our mirror.

- Additional Information -
Name : krmir FTP (Operated by krmir NPO)
Location : Ulsan, Republic of Korea(South Korea)
Bandwidth : 500Mbps(Main) + 1Gbps(Spare)
Supporting protocol : HTTPS(https://mirror.krmir.org/blackarch), FTP(ftp://mirror.krmir.org/blackarch), RSYNC(rsync://mirror.krmir.org/blackarch)
Source : rsync://blackarch.org/blackarch
Contact : krmir.ftp@gmail.com