### PR TITLE
blackarch-keyring: Added pacman hook

### DIFF
--- a/packages/blackarch-keyring/PKGBUILD
+++ b/packages/blackarch-keyring/PKGBUILD
@@ -3,20 +3,24 @@
 
 pkgname=blackarch-keyring
 pkgver=20180925
-pkgrel=2
+pkgrel=3
 pkgdesc='BlackArch Linux PGP keyring.'
 arch=('any')
 url='https://github.com/BlackArch/blackarch-keyring'
 license=('GPL')
 install='blackarch-keyring.install'
-source=("https://www.blackarch.org//keyring/blackarch-keyring-$pkgver.tar.gz"
-        "https://www.blackarch.org//keyring/blackarch-keyring-$pkgver.tar.gz.sig")
+source=("https://www.blackarch.org//keyring/blackarch-keyring-${pkgver}.tar.gz"
+        "https://www.blackarch.org//keyring/blackarch-keyring-${pkgver}.tar.gz.sig"
+        "blackarch-key.hook")
 sha512sums=('32711787c017b609b66f74e500f7b939503f3ad25581b58f7559585f1e23b4921aa79447b29715198184f59c150ede4dbc07530e23358443ed0cea2deca6aa27'
-            'SKIP')
+            'SKIP'
+            '1a72fcdd958a4c9304caa3f3d28ad752fe00ef451f1069616ff88cf8f9c7e5cc7d0ec6bb593200a8b3047e62dbc93a24ecd58520e4b9aa80495313fac628c2cb')
 
 package() {
-  cd "$pkgname-$pkgver"
+  cd "${pkgname}-${pkgver}"
 
-  make PREFIX=/usr "DESTDIR=$pkgdir" install
+  make PREFIX=/usr "DESTDIR=${pkgdir}" install
+
+  install -Dm0755 "${srcdir}/blackarch-key.hook" "${pkgdir}/etc/pacman.d/hooks/blackarch-key.hook" 
 }
 

--- a/packages/blackarch-keyring/blackarch-key.hook
+++ b/packages/blackarch-keyring/blackarch-key.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Operation = Upgrade
+Type = Package
+Target = archlinux-keyring
+
+[Action]
+Description = Reinstate Black Arch keyring
+Depends = pacman
+Depends = blackarch-keyring
+When = PostTransaction
+Exec = /usr/bin/pacman-key --populate blackarch 

--- a/packages/chipsec/Makefile.patch
+++ b/packages/chipsec/Makefile.patch
@@ -1,0 +1,46 @@
+--- Makefile.orig	2021-02-07 22:44:02.671453441 +1000
++++ Makefile	2021-02-07 23:01:09.287870330 +1000
+@@ -1,8 +1,12 @@
+-KERNEL_SRC_DIR ?= /lib/modules/`uname -r`/build
+-#KERNEL_SRC_DIR = /usr/src/android/3.0-mid
+-
+ MACHINE ?= $(shell uname -m)
+ 
++DESTDIR	=
++MODDIR	= $(DESTDIR)/lib/modules
++KVERS	= $(shell uname -r)
++KVER	= $(KVERS)
++VMODDIR = $(MODDIR)/$(KVER)
++KSRC	= $(VMODDIR)/build
++
+ ifeq (,$(filter %i686 %i386 %i586,$(MACHINE)))
+ 	elf-size := elf64
+ 	asm-path := amd64
+@@ -17,21 +21,21 @@
+ all: chipsec
+ 
+ check_kernel_dir:
+-	@if [ ! -d $(KERNEL_SRC_DIR) ]; then \
++	@if [ ! -d $(KSRC) ]; then \
+ 		echo "Unable to find the Linux source tree."; \
+ 		exit 1; \
+ 	fi
+ 
+-chipsec: check_kernel_dir clean
++chipsec: check_kernel_dir clean 
+ 	nasm -f $(elf-size) -o $(asm-path)/cpu.o $(asm-path)/cpu.asm
+ 	touch $(asm-path)/.cpu.o.cmd
+ 	@if [ `grep -c 'efi_call' /proc/kallsyms` != "0" ]; then \
+-	    make CFLAGS_MODULE=-DHAS_EFI=1 -C $(KERNEL_SRC_DIR) M=${CURDIR} modules; \
++	    make CFLAGS_MODULE=-DHAS_EFI=1 -C $(KSRC) M=$(CURDIR) modules; \
+ 	else \
+-	    make -C $(KERNEL_SRC_DIR) M=${CURDIR} modules; \
++	    make -C $(KSRC) M=$(CURDIR) modules; \
+ 	fi
+ 
+-clean: check_kernel_dir
+-	make -C $(KERNEL_SRC_DIR) M=${CURDIR} clean
++clean: check_kernel_dir 
++	make -C $(KSRC) M=$(CURDIR) clean
+ 	rm -f ${asm-path}/cpu.o
+ 

--- a/packages/chipsec/PKGBUILD
+++ b/packages/chipsec/PKGBUILD
@@ -2,9 +2,8 @@
 # See COPYING for license details.
 
 pkgname=chipsec
-pkgver=1069.f27ad9d
-pkgrel=1
-epoch=4
+pkgver=1070.7966175
+pkgrel=2
 pkgdesc='Platform Security Assessment Framework.'
 groups=('blackarch' 'blackarch-hardware' 'blackarch-binary' 'blackarch-forensic'
         'blackarch-scanner' 'blackarch-fuzzer')
@@ -13,39 +12,48 @@ url='https://github.com/chipsec/chipsec'
 license=('GPL2')
 depends=('dkms' 'libelf' 'linux-headers' 'nasm' 'python' 'python-lxml')
 makedepends=('git' 'python-setuptools')
-source=("git+https://github.com/chipsec/$pkgname.git")
-sha512sums=('SKIP')
+source=(
+  "git+https://github.com/chipsec/${pkgname}.git"
+  "Makefile.patch")
+sha512sums=('SKIP'
+            'db20e5be31325ac64d1640cec233b9428101c95f434d745f187fc218136fb708a5bbe0c0fea84f389567d58ceb9db0313e08ffcf386a3f895fe9db48d43db629')
 
 pkgver() {
-  cd $pkgname
+  cd ${pkgname}
 
   echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
 }
 
+prepare() {
+  cd ${srcdir}/${pkgname}/drivers/linux
+  
+  patch -Np0 < ${srcdir}/Makefile.patch
+}
+
 build() {
-  cd $pkgname
+  cd ${pkgname}
 
   python setup.py build
 }
 
 package() {
-  cd $pkgname
+  cd ${pkgname}
 
-  python setup.py install --prefix=/usr --root="$pkgdir" -O1 --skip-build \
+  python setup.py install --prefix=/usr --root="${pkgdir}" -O1 --skip-build \
     --skip-driver
 
   install -Dm 644 drivers/linux/dkms.conf \
-    "$pkgdir/usr/src/$pkgname-$pkgver/dkms.conf"
+    "${pkgdir}/usr/src/${pkgname}-$pkgver/dkms.conf"
   cp -a --no-preserve=ownership drivers/linux/* \
-    "$pkgdir/usr/src/$pkgname-$pkgver/"
+    "${pkgdir}/usr/src/${pkgname}-$pkgver/"
 
-  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md \
+  install -Dm 644 -t "${pkgdir}/usr/share/doc/${pkgname}/" README.md \
     chipsec-manual.pdf
-  install -Dm 644 -t "$pkgdir/usr/share/licenses/$pkgname/" LICENSE COPYING
+  install -Dm 644 -t "${pkgdir}/usr/share/licenses/${pkgname}/" LICENSE COPYING
 
-  rm -rf "$pkgdir/usr/chipsec-manual.pdf"
+  rm -f "${pkgdir}/usr/chipsec-manual.pdf"
 
-  for i in "$pkgdir/usr/bin/"*; do
+  for i in "${pkgdir}/usr/bin/"*; do
     mv $i "$(echo $i | tr -s '_' '-')"
   done
 }


### PR DESCRIPTION
Installs blackarch-key.hook into /etc/pacman.d/hooks so that the keys in
blackarch-keyring gets reinstated whenever archlinux-keyring is updated.

CC @sepehrdaddev @noptrix