### PR TITLE
blackarch-keyring: Added pacman hook

### DIFF
--- a/packages/blackarch-keyring/PKGBUILD
+++ b/packages/blackarch-keyring/PKGBUILD
@@ -24,3 +24,4 @@ package() {
   install -Dm0755 "$srcdir/blackarch-key.hook" "$pkgdir/etc/pacman.d/hooks/blackarch-key.hook"
 }
 
+

--- a/packages/blackarch-keyring/PKGBUILD
+++ b/packages/blackarch-keyring/PKGBUILD
@@ -3,20 +3,24 @@
 
 pkgname=blackarch-keyring
 pkgver=20180925
-pkgrel=2
+pkgrel=3
 pkgdesc='BlackArch Linux PGP keyring.'
 arch=('any')
 url='https://github.com/BlackArch/blackarch-keyring'
 license=('GPL')
 install='blackarch-keyring.install'
 source=("https://www.blackarch.org//keyring/blackarch-keyring-$pkgver.tar.gz"
-        "https://www.blackarch.org//keyring/blackarch-keyring-$pkgver.tar.gz.sig")
+        "https://www.blackarch.org//keyring/blackarch-keyring-$pkgver.tar.gz.sig"
+        "blackarch-key.hook")
 sha512sums=('32711787c017b609b66f74e500f7b939503f3ad25581b58f7559585f1e23b4921aa79447b29715198184f59c150ede4dbc07530e23358443ed0cea2deca6aa27'
-            'SKIP')
+            'SKIP'
+            '1a72fcdd958a4c9304caa3f3d28ad752fe00ef451f1069616ff88cf8f9c7e5cc7d0ec6bb593200a8b3047e62dbc93a24ecd58520e4b9aa80495313fac628c2cb'
 
 package() {
   cd "$pkgname-$pkgver"
 
   make PREFIX=/usr "DESTDIR=$pkgdir" install
+
+  install -Dm0755 "$srcdir/blackarch-key.hook" "$pkgdir/etc/pacman.d/hooks/blackarch-key.hook"
 }
 

--- a/packages/blackarch-keyring/blackarch-key.hook
+++ b/packages/blackarch-keyring/blackarch-key.hook
@@ -9,3 +9,4 @@ Depends = pacman
 Depends = blackarch-keyring
 When = PostTransaction
 Exec = /usr/bin/pacman-key --populate blackarch 
+

--- a/packages/blackarch-keyring/blackarch-key.hook
+++ b/packages/blackarch-keyring/blackarch-key.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Operation = Upgrade
+Type = Package
+Target = archlinux-keyring
+
+[Action]
+Description = Reinstate Black Arch keyring
+Depends = pacman
+Depends = blackarch-keyring
+When = PostTransaction
+Exec = /usr/bin/pacman-key --populate blackarch 


### PR DESCRIPTION
blackarch-keyring: Added pacman hook

Installs blackarch-key.hook into /etc/pacman.d/hooks so that the keys in
blackarch-keyring gets reinstated whenever archlinux-keyring is updated.

This should be a different commit compared to the mistakes that were
done in the past. Changes to remove unnecessary braces were implemented,
the changes are done on a separate branch, and here's hoping all should
work.