### PR TITLE
chipsec: Updated fixes in light of previous commit

### DIFF
--- a/packages/chipsec/Makefile.patch
+++ b/packages/chipsec/Makefile.patch
@@ -1,26 +1,47 @@
---- Makefile.orig	2021-02-07 23:06:32.422175783 +1000
-+++ Makefile	2021-02-08 07:12:27.882160164 +1000
-@@ -20,13 +20,7 @@
+--- Makefile.orig	2021-02-08 20:43:14.820814032 +1000
++++ Makefile	2021-02-08 20:42:25.283941482 +1000
+@@ -1,8 +1,12 @@
+-KERNEL_SRC_DIR ?= /lib/modules/`uname -r`/build
+-#KERNEL_SRC_DIR = /usr/src/android/3.0-mid
+-
+ MACHINE ?= $(shell uname -m)
  
++DESTDIR	=
++MODDIR	= $(DESTDIR)/lib/modules
++KVERS	= $(shell uname -r)
++KVER	= $(KVERS)
++VMODDIR = $(MODDIR)/$(KVER)
++KSRC	= $(VMODDIR)/build
++
+ ifeq (,$(filter %i686 %i386 %i586,$(MACHINE)))
+ 	elf-size := elf64
+ 	asm-path := amd64
+@@ -17,21 +21,20 @@
  all: chipsec
  
--check_kernel_dir:
--	@if [ ! -d $(KSRC) ]; then \
+ check_kernel_dir:
+-	@if [ ! -d $(KERNEL_SRC_DIR) ]; then \
 -		echo "Unable to find the Linux source tree."; \
 -		exit 1; \
--	fi
--
--chipsec: check_kernel_dir clean 
-+chipsec: clean 
++	@if [ ! -d $(KSRC) ]; then \
++	    echo "Unable to find the Linux source tree."; \
++	    exit 1; \
+ 	fi
+ 
+-chipsec: check_kernel_dir clean
++chipsec: check_kernel_dir clean 
  	nasm -f $(elf-size) -o $(asm-path)/cpu.o $(asm-path)/cpu.asm
  	touch $(asm-path)/.cpu.o.cmd
  	@if [ `grep -c 'efi_call' /proc/kallsyms` != "0" ]; then \
-@@ -35,7 +29,6 @@
- 	    make -C $(KSRC) M=$(CURDIR) modules; \
+-	    make CFLAGS_MODULE=-DHAS_EFI=1 -C $(KERNEL_SRC_DIR) M=${CURDIR} modules; \
++	    make CFLAGS_MODULE=-DHAS_EFI=1 -C $(KSRC) M=$(CURDIR) modules; \
+ 	else \
+-	    make -C $(KERNEL_SRC_DIR) M=${CURDIR} modules; \
++	    make -C $(KSRC) M=$(CURDIR) modules; \
  	fi
  
--clean: check_kernel_dir 
-+clean: 
- 	make -C $(KSRC) M=$(CURDIR) clean
+ clean: check_kernel_dir
+-	make -C $(KERNEL_SRC_DIR) M=${CURDIR} clean
++	make -C $(KSRC) M=$(CURDIR) clean
  	rm -f ${asm-path}/cpu.o
 -

--- a/packages/chipsec/PKGBUILD
+++ b/packages/chipsec/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=chipsec
 pkgver=1070.7966175
-pkgrel=2
+pkgrel=3
 pkgdesc='Platform Security Assessment Framework.'
 groups=('blackarch' 'blackarch-hardware' 'blackarch-binary' 'blackarch-forensic'
         'blackarch-scanner' 'blackarch-fuzzer')
@@ -14,9 +14,9 @@ depends=('dkms' 'libelf' 'linux-headers' 'nasm' 'python' 'python-lxml')
 makedepends=('git' 'python-setuptools')
 source=(
   "git+https://github.com/chipsec/$pkgname.git"
-  "Makefile.patch")
+  'Makefile.patch')
 sha512sums=('SKIP'
-            'db20e5be31325ac64d1640cec233b9428101c95f434d745f187fc218136fb708a5bbe0c0fea84f389567d58ceb9db0313e08ffcf386a3f895fe9db48d43db629')
+            'b3bd500b37871e8c0c9132613fd9254014c5288b24d7e88acacc695dbb3ff2d384c72186536e2fe5225c31b438f5d08fad991503c9335021cf03c3ed8c29e85f')
 
 pkgver() {
   cd $pkgname
@@ -25,9 +25,9 @@ pkgver() {
 }
 
 prepare() {
-  cd $srcdir/$pkgname/drivers/linux
+  cd "$pkgname/drivers/linux"
   
-  patch -Np0 < $srcdir/Makefile.patch
+  patch -Np0 < "$srcdir/Makefile.patch"
 }
 
 build() {
@@ -57,3 +57,4 @@ package() {
     mv $i "$(echo $i | tr -s '_' '-')"
   done
 }
+

--- a/packages/chipsec/PKGBUILD
+++ b/packages/chipsec/PKGBUILD
@@ -12,9 +12,8 @@ url='https://github.com/chipsec/chipsec'
 license=('GPL2')
 depends=('dkms' 'libelf' 'linux-headers' 'nasm' 'python' 'python-lxml')
 makedepends=('git' 'python-setuptools')
-source=(
-  "git+https://github.com/chipsec/$pkgname.git"
-  'Makefile.patch')
+source=("git+https://github.com/chipsec/$pkgname.git"
+        'Makefile.patch')
 sha512sums=('SKIP'
             'b3bd500b37871e8c0c9132613fd9254014c5288b24d7e88acacc695dbb3ff2d384c72186536e2fe5225c31b438f5d08fad991503c9335021cf03c3ed8c29e85f')
 


### PR DESCRIPTION
Makefile.patch: Fixed multiple issues with half-patched file that was in
my origin/work directory.
PKGBUILD: Bumped pkgrel, updated sha512sums, added changes as mentioned
below.

First and foremost, sorry for pushing a half-baked solution in previous
commit. I have addressed the Makefile.patch as well as updated the
PKGBUILD with new hashsums and changes as per suggestions in the
[commit](https://github.com/BlackArch/blackarch/commit/d3fe35ee50083368db528acb5f7c0850489bed5e).

Full build, install and compile output:
```
$ makepkg -sfC
==> Making package: chipsec 1070.7966175-3 (Mon 08 Feb 2021 20:50:18)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Updating chipsec git repo...
Fetching origin
  -> Found Makefile.patch
==> Validating source files with sha512sums...
    chipsec ... Skipped
    Makefile.patch ... Passed
==> Removing existing $srcdir/ directory...
==> Extracting sources...
  -> Creating working copy of chipsec git repo...
Cloning into 'chipsec'...
done.
==> Starting prepare()...
patching file Makefile
==> Starting pkgver()...
==> Removing existing $pkgdir/ directory...
==> Starting build()...
Error processing line 1 of /usr/lib/python3.9/site-packages/phply-1.2.5-py3.9-nspkg.pth:

  Traceback (most recent call last):
    File "/usr/lib/python3.9/site.py", line 169, in addpackage
      exec(line)
    File "<string>", line 1, in <module>
    File "<frozen importlib._bootstrap>", line 562, in module_from_spec
  AttributeError: 'NoneType' object has no attribute 'loader'

Remainder of file ignored
running build
running build_py
creating build
creating build/lib
copying chipsec_main.py -> build/lib
copying chipsec_util.py -> build/lib
creating build/lib/chipsec_tools
copying chipsec_tools/__init__.py -> build/lib/chipsec_tools
creating build/lib/chipsec
copying chipsec/chipset.py -> build/lib/chipsec
copying chipsec/file.py -> build/lib/chipsec
copying chipsec/result_deltas.py -> build/lib/chipsec
copying chipsec/__init__.py -> build/lib/chipsec
copying chipsec/module_common.py -> build/lib/chipsec
copying chipsec/module.py -> build/lib/chipsec
copying chipsec/testcase.py -> build/lib/chipsec
copying chipsec/command.py -> build/lib/chipsec
copying chipsec/defines.py -> build/lib/chipsec
copying chipsec/logger.py -> build/lib/chipsec
creating build/lib/chipsec_tools/windows
copying chipsec_tools/windows/__init__.py -> build/lib/chipsec_tools/windows
creating build/lib/chipsec/helper
copying chipsec/helper/__init__.py -> build/lib/chipsec/helper
copying chipsec/helper/basehelper.py -> build/lib/chipsec/helper
copying chipsec/helper/oshelper.py -> build/lib/chipsec/helper
copying chipsec/helper/helpers.py -> build/lib/chipsec/helper
creating build/lib/chipsec/modules
copying chipsec/modules/__init__.py -> build/lib/chipsec/modules
creating build/lib/chipsec/hal
copying chipsec/hal/acpi.py -> build/lib/chipsec/hal
copying chipsec/hal/uefi_search.py -> build/lib/chipsec/hal
copying chipsec/hal/pci.py -> build/lib/chipsec/hal
copying chipsec/hal/io.py -> build/lib/chipsec/hal
copying chipsec/hal/physmem.py -> build/lib/chipsec/hal
copying chipsec/hal/spi_uefi.py -> build/lib/chipsec/hal
copying chipsec/hal/ec.py -> build/lib/chipsec/hal
copying chipsec/hal/smbus.py -> build/lib/chipsec/hal
copying chipsec/hal/cmos.py -> build/lib/chipsec/hal
copying chipsec/hal/msr.py -> build/lib/chipsec/hal
copying chipsec/hal/virtmem.py -> build/lib/chipsec/hal
copying chipsec/hal/__init__.py -> build/lib/chipsec/hal
copying chipsec/hal/vmm.py -> build/lib/chipsec/hal
copying chipsec/hal/hal_base.py -> build/lib/chipsec/hal
copying chipsec/hal/igd.py -> build/lib/chipsec/hal
copying chipsec/hal/acpi_tables.py -> build/lib/chipsec/hal
copying chipsec/hal/mmio.py -> build/lib/chipsec/hal
copying chipsec/hal/tpm.py -> build/lib/chipsec/hal
copying chipsec/hal/uefi_common.py -> build/lib/chipsec/hal
copying chipsec/hal/iobar.py -> build/lib/chipsec/hal
copying chipsec/hal/spd.py -> build/lib/chipsec/hal
copying chipsec/hal/spi_jedec_ids.py -> build/lib/chipsec/hal
copying chipsec/hal/tpm_eventlog.py -> build/lib/chipsec/hal
copying chipsec/hal/cpuid.py -> build/lib/chipsec/hal
copying chipsec/hal/uefi_platform.py -> build/lib/chipsec/hal
copying chipsec/hal/uefi.py -> build/lib/chipsec/hal
copying chipsec/hal/pcidb.py -> build/lib/chipsec/hal
copying chipsec/hal/paging.py -> build/lib/chipsec/hal
copying chipsec/hal/iommu.py -> build/lib/chipsec/hal
copying chipsec/hal/uefi_fv.py -> build/lib/chipsec/hal
copying chipsec/hal/spi.py -> build/lib/chipsec/hal
copying chipsec/hal/msgbus.py -> build/lib/chipsec/hal
copying chipsec/hal/smbios.py -> build/lib/chipsec/hal
copying chipsec/hal/interrupts.py -> build/lib/chipsec/hal
copying chipsec/hal/tpm12_commands.py -> build/lib/chipsec/hal
copying chipsec/hal/spi_descriptor.py -> build/lib/chipsec/hal
copying chipsec/hal/ucode.py -> build/lib/chipsec/hal
copying chipsec/hal/cpu.py -> build/lib/chipsec/hal
creating build/lib/chipsec/fuzzing
copying chipsec/fuzzing/primitives.py -> build/lib/chipsec/fuzzing
copying chipsec/fuzzing/__init__.py -> build/lib/chipsec/fuzzing
creating build/lib/chipsec/cfg
copying chipsec/cfg/__init__.py -> build/lib/chipsec/cfg
creating build/lib/chipsec/utilcmd
copying chipsec/utilcmd/reg_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/mmcfg_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/mmio_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/ucode_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/vmem_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/mem_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/spd_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/mmcfg_base_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/vmm_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/__init__.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/decode_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/iommu_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/igd_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/tpm_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/acpi_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/cpu_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/msr_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/cmos_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/ec_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/interrupts_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/msgbus_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/uefi_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/smbus_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/smbios_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/spidesc_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/chipset_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/pci_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/spi_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/io_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/desc_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/deltas_cmd.py -> build/lib/chipsec/utilcmd
creating build/lib/chipsec/helper/dal
copying chipsec/helper/dal/__init__.py -> build/lib/chipsec/helper/dal
copying chipsec/helper/dal/dalhelper.py -> build/lib/chipsec/helper/dal
creating build/lib/chipsec/helper/win
copying chipsec/helper/win/win32helper.py -> build/lib/chipsec/helper/win
copying chipsec/helper/win/__init__.py -> build/lib/chipsec/helper/win
creating build/lib/chipsec/helper/efi
copying chipsec/helper/efi/efihelper.py -> build/lib/chipsec/helper/efi
copying chipsec/helper/efi/__init__.py -> build/lib/chipsec/helper/efi
creating build/lib/chipsec/helper/osx
copying chipsec/helper/osx/__init__.py -> build/lib/chipsec/helper/osx
copying chipsec/helper/osx/osxhelper.py -> build/lib/chipsec/helper/osx
creating build/lib/chipsec/helper/linux
copying chipsec/helper/linux/legacy_pci.py -> build/lib/chipsec/helper/linux
copying chipsec/helper/linux/__init__.py -> build/lib/chipsec/helper/linux
copying chipsec/helper/linux/linuxhelper.py -> build/lib/chipsec/helper/linux
copying chipsec/helper/linux/cpuid.py -> build/lib/chipsec/helper/linux
creating build/lib/chipsec/helper/rwe
copying chipsec/helper/rwe/__init__.py -> build/lib/chipsec/helper/rwe
copying chipsec/helper/rwe/rwehelper.py -> build/lib/chipsec/helper/rwe
creating build/lib/chipsec/helper/file
copying chipsec/helper/file/__init__.py -> build/lib/chipsec/helper/file
copying chipsec/helper/file/filehelper.py -> build/lib/chipsec/helper/file
creating build/lib/chipsec/modules/tools
copying chipsec/modules/tools/__init__.py -> build/lib/chipsec/modules/tools
creating build/lib/chipsec/modules/bdw
copying chipsec/modules/bdw/__init__.py -> build/lib/chipsec/modules/bdw
creating build/lib/chipsec/modules/hsw
copying chipsec/modules/hsw/__init__.py -> build/lib/chipsec/modules/hsw
creating build/lib/chipsec/modules/byt
copying chipsec/modules/byt/__init__.py -> build/lib/chipsec/modules/byt
creating build/lib/chipsec/modules/ivb
copying chipsec/modules/ivb/__init__.py -> build/lib/chipsec/modules/ivb
creating build/lib/chipsec/modules/snb
copying chipsec/modules/snb/__init__.py -> build/lib/chipsec/modules/snb
creating build/lib/chipsec/modules/common
copying chipsec/modules/common/debugenabled.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/bios_smi.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/bios_kbrd_buffer.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/spi_access.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/__init__.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/spi_desc.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/rtclock.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/me_mfg_mode.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/sgx_check.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/memconfig.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/smrr.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/smm_dma.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/bios_ts.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/ia32cfg.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/bios_wp.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/smm.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/spi_fdopss.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/remap.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/spd_wd.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/memlock.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/spi_lock.py -> build/lib/chipsec/modules/common
creating build/lib/chipsec/modules/tools/secureboot
copying chipsec/modules/tools/secureboot/te.py -> build/lib/chipsec/modules/tools/secureboot
copying chipsec/modules/tools/secureboot/__init__.py -> build/lib/chipsec/modules/tools/secureboot
creating build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/common.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/cpuid_fuzz.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/pcie_fuzz.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/__init__.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/hypercallfuzz.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/ept_finder.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/msr_fuzz.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/iofuzz.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/venom.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/pcie_overlap_fuzz.py -> build/lib/chipsec/modules/tools/vmm
creating build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/uefi/scan_image.py -> build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/uefi/s3script_modify.py -> build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/uefi/scan_blocked.py -> build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/uefi/uefivar_fuzz.py -> build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/uefi/__init__.py -> build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/uefi/reputation.py -> build/lib/chipsec/modules/tools/uefi
creating build/lib/chipsec/modules/tools/cpu
copying chipsec/modules/tools/cpu/sinkhole.py -> build/lib/chipsec/modules/tools/cpu
copying chipsec/modules/tools/cpu/__init__.py -> build/lib/chipsec/modules/tools/cpu
creating build/lib/chipsec/modules/tools/smm
copying chipsec/modules/tools/smm/__init__.py -> build/lib/chipsec/modules/tools/smm
copying chipsec/modules/tools/smm/rogue_mmio_bar.py -> build/lib/chipsec/modules/tools/smm
copying chipsec/modules/tools/smm/smm_ptr.py -> build/lib/chipsec/modules/tools/smm
creating build/lib/chipsec/modules/tools/vmm/vbox
copying chipsec/modules/tools/vmm/vbox/__init__.py -> build/lib/chipsec/modules/tools/vmm/vbox
copying chipsec/modules/tools/vmm/vbox/vbox_crash_apicbase.py -> build/lib/chipsec/modules/tools/vmm/vbox
creating build/lib/chipsec/modules/tools/vmm/xen
copying chipsec/modules/tools/vmm/xen/hypercall.py -> build/lib/chipsec/modules/tools/vmm/xen
copying chipsec/modules/tools/vmm/xen/define.py -> build/lib/chipsec/modules/tools/vmm/xen
copying chipsec/modules/tools/vmm/xen/__init__.py -> build/lib/chipsec/modules/tools/vmm/xen
copying chipsec/modules/tools/vmm/xen/hypercallfuzz.py -> build/lib/chipsec/modules/tools/vmm/xen
copying chipsec/modules/tools/vmm/xen/xsa188.py -> build/lib/chipsec/modules/tools/vmm/xen
creating build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/hypercall.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/define.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/synth_kbd.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/__init__.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/hypercallfuzz.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/synth_dev.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/vmbusfuzz.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/vmbus.py -> build/lib/chipsec/modules/tools/vmm/hv
creating build/lib/chipsec/modules/common/secureboot
copying chipsec/modules/common/secureboot/__init__.py -> build/lib/chipsec/modules/common/secureboot
copying chipsec/modules/common/secureboot/variables.py -> build/lib/chipsec/modules/common/secureboot
creating build/lib/chipsec/modules/common/uefi
copying chipsec/modules/common/uefi/access_uefispec.py -> build/lib/chipsec/modules/common/uefi
copying chipsec/modules/common/uefi/s3bootscript.py -> build/lib/chipsec/modules/common/uefi
copying chipsec/modules/common/uefi/__init__.py -> build/lib/chipsec/modules/common/uefi
creating build/lib/chipsec/modules/common/cpu
copying chipsec/modules/common/cpu/cpu_info.py -> build/lib/chipsec/modules/common/cpu
copying chipsec/modules/common/cpu/spectre_v2.py -> build/lib/chipsec/modules/common/cpu
copying chipsec/modules/common/cpu/__init__.py -> build/lib/chipsec/modules/common/cpu
copying chipsec/modules/common/cpu/ia_untrusted.py -> build/lib/chipsec/modules/common/cpu
copying chipsec/VERSION -> build/lib/chipsec
copying chipsec/WARNING.txt -> build/lib/chipsec
creating build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/avn.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/dnv.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/kbl.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_495.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/skx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/skl.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/icl.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/cht.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_3xxop.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/cfl.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_1xx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/glk.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/ivb.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_c620.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/qrk.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/hsx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_3xx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_4xxlp.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/common.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_4xxh.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_c61x.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/whl.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/iommu.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/snb.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/apl.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/ivt.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_2xx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/hsw.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/bdw.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_3xxlp.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_4xx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/byt.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/jkt.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/cml.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_c60x.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/sfdp.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/bdx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/template.xml -> build/lib/chipsec/cfg
copying chipsec/cfg/chipsec_cfg.xsd -> build/lib/chipsec/cfg
copying chipsec/modules/tools/secureboot/te.cfg -> build/lib/chipsec/modules/tools/secureboot
copying chipsec/modules/tools/uefi/blockedlist.json -> build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/smm/smm_config.ini -> build/lib/chipsec/modules/tools/smm
copying chipsec/modules/tools/vmm/hv/initial_data.json -> build/lib/chipsec/modules/tools/vmm/hv
==> Entering fakeroot environment...
==> Starting package()...
Error processing line 1 of /usr/lib/python3.9/site-packages/phply-1.2.5-py3.9-nspkg.pth:

  Traceback (most recent call last):
    File "/usr/lib/python3.9/site.py", line 169, in addpackage
      exec(line)
    File "<string>", line 1, in <module>
    File "<frozen importlib._bootstrap>", line 562, in module_from_spec
  AttributeError: 'NoneType' object has no attribute 'loader'

Remainder of file ignored
running install
running install_lib
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_tools
copying build/lib/chipsec_tools/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_tools
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_tools/windows
copying build/lib/chipsec_tools/windows/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_tools/windows
copying build/lib/chipsec_main.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/chipset.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/dal
copying build/lib/chipsec/helper/dal/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/dal
copying build/lib/chipsec/helper/dal/dalhelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/dal
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/win
copying build/lib/chipsec/helper/win/win32helper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/win
copying build/lib/chipsec/helper/win/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/win
copying build/lib/chipsec/helper/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/efi
copying build/lib/chipsec/helper/efi/efihelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/efi
copying build/lib/chipsec/helper/efi/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/efi
copying build/lib/chipsec/helper/basehelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/osx
copying build/lib/chipsec/helper/osx/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/osx
copying build/lib/chipsec/helper/osx/osxhelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/osx
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux
copying build/lib/chipsec/helper/linux/legacy_pci.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux
copying build/lib/chipsec/helper/linux/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux
copying build/lib/chipsec/helper/linux/linuxhelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux
copying build/lib/chipsec/helper/linux/cpuid.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux
copying build/lib/chipsec/helper/oshelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/rwe
copying build/lib/chipsec/helper/rwe/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/rwe
copying build/lib/chipsec/helper/rwe/rwehelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/rwe
copying build/lib/chipsec/helper/helpers.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/file
copying build/lib/chipsec/helper/file/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/file
copying build/lib/chipsec/helper/file/filehelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/file
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/secureboot
copying build/lib/chipsec/modules/tools/secureboot/te.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/secureboot
copying build/lib/chipsec/modules/tools/secureboot/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/secureboot
copying build/lib/chipsec/modules/tools/secureboot/te.cfg -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/secureboot
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/common.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/cpuid_fuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/vbox
copying build/lib/chipsec/modules/tools/vmm/vbox/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/vbox
copying build/lib/chipsec/modules/tools/vmm/vbox/vbox_crash_apicbase.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/vbox
copying build/lib/chipsec/modules/tools/vmm/pcie_fuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen
copying build/lib/chipsec/modules/tools/vmm/xen/hypercall.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen
copying build/lib/chipsec/modules/tools/vmm/xen/define.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen
copying build/lib/chipsec/modules/tools/vmm/xen/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen
copying build/lib/chipsec/modules/tools/vmm/xen/hypercallfuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen
copying build/lib/chipsec/modules/tools/vmm/xen/xsa188.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen
copying build/lib/chipsec/modules/tools/vmm/hypercallfuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/ept_finder.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/hypercall.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/initial_data.json -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/define.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/synth_kbd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/hypercallfuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/synth_dev.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/vmbusfuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/vmbus.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/msr_fuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/iofuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/venom.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/pcie_overlap_fuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/scan_image.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/s3script_modify.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/scan_blocked.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/uefivar_fuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/blockedlist.json -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/reputation.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/cpu
copying build/lib/chipsec/modules/tools/cpu/sinkhole.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/cpu
copying build/lib/chipsec/modules/tools/cpu/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/cpu
copying build/lib/chipsec/modules/tools/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm
copying build/lib/chipsec/modules/tools/smm/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm
copying build/lib/chipsec/modules/tools/smm/rogue_mmio_bar.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm
copying build/lib/chipsec/modules/tools/smm/smm_ptr.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm
copying build/lib/chipsec/modules/tools/smm/smm_config.ini -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/bdw
copying build/lib/chipsec/modules/bdw/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/bdw
copying build/lib/chipsec/modules/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/hsw
copying build/lib/chipsec/modules/hsw/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/hsw
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/byt
copying build/lib/chipsec/modules/byt/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/byt
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/ivb
copying build/lib/chipsec/modules/ivb/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/ivb
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/snb
copying build/lib/chipsec/modules/snb/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/snb
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/debugenabled.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/secureboot
copying build/lib/chipsec/modules/common/secureboot/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/secureboot
copying build/lib/chipsec/modules/common/secureboot/variables.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/secureboot
copying build/lib/chipsec/modules/common/bios_smi.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/bios_kbrd_buffer.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/spi_access.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi
copying build/lib/chipsec/modules/common/uefi/access_uefispec.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi
copying build/lib/chipsec/modules/common/uefi/s3bootscript.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi
copying build/lib/chipsec/modules/common/uefi/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu
copying build/lib/chipsec/modules/common/cpu/cpu_info.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu
copying build/lib/chipsec/modules/common/cpu/spectre_v2.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu
copying build/lib/chipsec/modules/common/cpu/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu
copying build/lib/chipsec/modules/common/cpu/ia_untrusted.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu
copying build/lib/chipsec/modules/common/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/spi_desc.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/rtclock.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/me_mfg_mode.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/sgx_check.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/memconfig.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/smrr.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/smm_dma.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/bios_ts.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/ia32cfg.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/bios_wp.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/smm.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/spi_fdopss.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/remap.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/spd_wd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/memlock.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/spi_lock.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/acpi.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/uefi_search.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/pci.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/io.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/physmem.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/spi_uefi.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/ec.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/smbus.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/cmos.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/msr.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/virtmem.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/vmm.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/hal_base.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/igd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/acpi_tables.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/mmio.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/tpm.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/uefi_common.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/iobar.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/spd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/spi_jedec_ids.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/tpm_eventlog.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/cpuid.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/uefi_platform.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/uefi.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/pcidb.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/paging.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/iommu.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/uefi_fv.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/spi.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/msgbus.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/smbios.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/interrupts.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/tpm12_commands.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/spi_descriptor.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/ucode.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/cpu.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/file.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/result_deltas.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/fuzzing
copying build/lib/chipsec/fuzzing/primitives.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/fuzzing
copying build/lib/chipsec/fuzzing/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/fuzzing
copying build/lib/chipsec/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/VERSION -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/module_common.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/module.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/testcase.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/WARNING.txt -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg
copying build/lib/chipsec/cfg/template.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg
copying build/lib/chipsec/cfg/chipsec_cfg.xsd -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg
copying build/lib/chipsec/cfg/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/avn.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/dnv.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/kbl.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_495.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/skx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/skl.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/icl.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/cht.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_3xxop.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/cfl.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_1xx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/glk.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/ivb.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_c620.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/qrk.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/hsx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_3xx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_4xxlp.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/common.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_4xxh.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_c61x.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/whl.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/iommu.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/snb.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/apl.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/ivt.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_2xx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/hsw.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/bdw.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_3xxlp.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_4xx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/byt.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/jkt.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/cml.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_c60x.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/sfdp.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/bdx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/command.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/defines.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/reg_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/mmcfg_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/mmio_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/ucode_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/vmem_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/mem_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/spd_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/mmcfg_base_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/vmm_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/decode_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/iommu_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/igd_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/tpm_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/acpi_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/cpu_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/msr_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/cmos_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/ec_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/interrupts_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/msgbus_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/uefi_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/smbus_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/smbios_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/spidesc_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/chipset_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/pci_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/spi_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/io_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/desc_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/deltas_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/logger.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec_util.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_tools/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_tools/windows/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_main.py to chipsec_main.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/chipset.py to chipset.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/dal/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/dal/dalhelper.py to dalhelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/win/win32helper.py to win32helper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/win/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/efi/efihelper.py to efihelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/efi/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/basehelper.py to basehelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/osx/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/osx/osxhelper.py to osxhelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux/legacy_pci.py to legacy_pci.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux/linuxhelper.py to linuxhelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux/cpuid.py to cpuid.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/oshelper.py to oshelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/rwe/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/rwe/rwehelper.py to rwehelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/helpers.py to helpers.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/file/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/file/filehelper.py to filehelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/secureboot/te.py to te.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/secureboot/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/common.py to common.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/cpuid_fuzz.py to cpuid_fuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/vbox/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/vbox/vbox_crash_apicbase.py to vbox_crash_apicbase.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/pcie_fuzz.py to pcie_fuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen/hypercall.py to hypercall.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen/define.py to define.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen/hypercallfuzz.py to hypercallfuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen/xsa188.py to xsa188.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hypercallfuzz.py to hypercallfuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/ept_finder.py to ept_finder.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/hypercall.py to hypercall.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/define.py to define.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/synth_kbd.py to synth_kbd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/hypercallfuzz.py to hypercallfuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/synth_dev.py to synth_dev.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/vmbusfuzz.py to vmbusfuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/vmbus.py to vmbus.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/msr_fuzz.py to msr_fuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/iofuzz.py to iofuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/venom.py to venom.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/pcie_overlap_fuzz.py to pcie_overlap_fuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi/scan_image.py to scan_image.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi/s3script_modify.py to s3script_modify.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi/scan_blocked.py to scan_blocked.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi/uefivar_fuzz.py to uefivar_fuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi/reputation.py to reputation.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/cpu/sinkhole.py to sinkhole.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/cpu/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm/rogue_mmio_bar.py to rogue_mmio_bar.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm/smm_ptr.py to smm_ptr.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/bdw/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/hsw/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/byt/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/ivb/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/snb/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/debugenabled.py to debugenabled.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/secureboot/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/secureboot/variables.py to variables.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/bios_smi.py to bios_smi.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/bios_kbrd_buffer.py to bios_kbrd_buffer.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/spi_access.py to spi_access.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi/access_uefispec.py to access_uefispec.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi/s3bootscript.py to s3bootscript.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu/cpu_info.py to cpu_info.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu/spectre_v2.py to spectre_v2.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu/ia_untrusted.py to ia_untrusted.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/spi_desc.py to spi_desc.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/rtclock.py to rtclock.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/me_mfg_mode.py to me_mfg_mode.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/sgx_check.py to sgx_check.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/memconfig.py to memconfig.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/smrr.py to smrr.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/smm_dma.py to smm_dma.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/bios_ts.py to bios_ts.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/ia32cfg.py to ia32cfg.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/bios_wp.py to bios_wp.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/smm.py to smm.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/spi_fdopss.py to spi_fdopss.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/remap.py to remap.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/spd_wd.py to spd_wd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/memlock.py to memlock.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/spi_lock.py to spi_lock.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/acpi.py to acpi.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/uefi_search.py to uefi_search.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/pci.py to pci.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/io.py to io.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/physmem.py to physmem.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/spi_uefi.py to spi_uefi.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/ec.py to ec.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/smbus.py to smbus.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/cmos.py to cmos.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/msr.py to msr.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/virtmem.py to virtmem.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/vmm.py to vmm.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/hal_base.py to hal_base.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/igd.py to igd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/acpi_tables.py to acpi_tables.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/mmio.py to mmio.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/tpm.py to tpm.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/uefi_common.py to uefi_common.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/iobar.py to iobar.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/spd.py to spd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/spi_jedec_ids.py to spi_jedec_ids.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/tpm_eventlog.py to tpm_eventlog.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/cpuid.py to cpuid.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/uefi_platform.py to uefi_platform.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/uefi.py to uefi.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/pcidb.py to pcidb.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/paging.py to paging.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/iommu.py to iommu.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/uefi_fv.py to uefi_fv.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/spi.py to spi.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/msgbus.py to msgbus.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/smbios.py to smbios.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/interrupts.py to interrupts.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/tpm12_commands.py to tpm12_commands.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/spi_descriptor.py to spi_descriptor.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/ucode.py to ucode.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/cpu.py to cpu.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/file.py to file.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/result_deltas.py to result_deltas.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/fuzzing/primitives.py to primitives.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/fuzzing/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/module_common.py to module_common.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/module.py to module.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/testcase.py to testcase.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/command.py to command.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/defines.py to defines.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/reg_cmd.py to reg_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/mmcfg_cmd.py to mmcfg_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/mmio_cmd.py to mmio_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/ucode_cmd.py to ucode_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/vmem_cmd.py to vmem_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/mem_cmd.py to mem_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/spd_cmd.py to spd_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/mmcfg_base_cmd.py to mmcfg_base_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/vmm_cmd.py to vmm_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/decode_cmd.py to decode_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/iommu_cmd.py to iommu_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/igd_cmd.py to igd_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/tpm_cmd.py to tpm_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/acpi_cmd.py to acpi_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/cpu_cmd.py to cpu_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/msr_cmd.py to msr_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/cmos_cmd.py to cmos_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/ec_cmd.py to ec_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/interrupts_cmd.py to interrupts_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/msgbus_cmd.py to msgbus_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/uefi_cmd.py to uefi_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/smbus_cmd.py to smbus_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/smbios_cmd.py to smbios_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/spidesc_cmd.py to spidesc_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/chipset_cmd.py to chipset_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/pci_cmd.py to pci_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/spi_cmd.py to spi_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/io_cmd.py to io_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/desc_cmd.py to desc_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/deltas_cmd.py to deltas_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/logger.py to logger.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_util.py to chipsec_util.cpython-39.pyc
writing byte-compilation script '/tmp/tmper0_8ng_.py'
/sbin/python /tmp/tmper0_8ng_.py
Error processing line 1 of /usr/lib/python3.9/site-packages/phply-1.2.5-py3.9-nspkg.pth:

  Traceback (most recent call last):
    File "/usr/lib/python3.9/site.py", line 169, in addpackage
      exec(line)
    File "<string>", line 1, in <module>
    File "<frozen importlib._bootstrap>", line 562, in module_from_spec
  AttributeError: 'NoneType' object has no attribute 'loader'

Remainder of file ignored
removing /tmp/tmper0_8ng_.py
running install_data
copying chipsec-manual.pdf -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/
running install_egg_info
running egg_info
creating chipsec.egg-info
writing chipsec.egg-info/PKG-INFO
writing dependency_links to chipsec.egg-info/dependency_links.txt
writing entry points to chipsec.egg-info/entry_points.txt
writing top-level names to chipsec.egg-info/top_level.txt
writing manifest file 'chipsec.egg-info/SOURCES.txt'
reading manifest file 'chipsec.egg-info/SOURCES.txt'
writing manifest file 'chipsec.egg-info/SOURCES.txt'
Copying chipsec.egg-info to /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec-1.5.9-py3.9.egg-info
running install_scripts
Installing chipsec_main script to /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/bin
Installing chipsec_util script to /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/bin
==> Tidying install...
  -> Removing libtool files...
  -> Purging unwanted files...
  -> Removing static library files...
  -> Stripping unneeded symbols from binaries and libraries...
  -> Compressing man and info pages...
==> Checking for packaging issues...
==> Creating package "chipsec"...
  -> Generating .PKGINFO file...
  -> Generating .BUILDINFO file...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: chipsec 1070.7966175-3 (Mon 08 Feb 2021 20:51:29)
```
```
$ makepkg -i
==> Making package: chipsec 1070.7966175-3 (Mon 08 Feb 2021 20:52:24)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Updating chipsec git repo...
Fetching origin
  -> Found Makefile.patch
==> Validating source files with sha512sums...
    chipsec ... Skipped
    Makefile.patch ... Passed
==> Extracting sources...
  -> Creating working copy of chipsec git repo...
Switched to a new branch 'makepkg'
==> Starting prepare()...
patching file Makefile
==> Starting pkgver()...
==> WARNING: A package has already been built, installing existing package...
==> Installing package chipsec with pacman -U...
loading packages...
warning: chipsec-1070.7966175-3 is up to date -- reinstalling
resolving dependencies...
looking for conflicting packages...

Packages (1) chipsec-1070.7966175-3

Total Installed Size:  7.24 MiB
Net Upgrade Size:      0.00 MiB

:: Proceed with installation? [Y/n] 
(1/1) checking keys in keyring                                                                                                              [--------------------------------------------------------------------------------------] 100%
(1/1) checking package integrity                                                                                                            [--------------------------------------------------------------------------------------] 100%
(1/1) loading package files                                                                                                                 [--------------------------------------------------------------------------------------] 100%
(1/1) checking for file conflicts                                                                                                           [--------------------------------------------------------------------------------------] 100%
:: Running pre-transaction hooks...
(1/1) Remove upgraded DKMS modules
==> Unable to remove module chipsec/1070.7966175 for kernel 5.10.13-arch1-2: Not found in dkms status output.
:: Processing package changes...
(1/1) reinstalling chipsec                                                                                                                  [--------------------------------------------------------------------------------------] 100%
:: Running post-transaction hooks...
(1/2) Arming ConditionNeedsUpdate...
(2/2) Install DKMS modules
==> dkms install --no-depmod -m chipsec -v 1070.7966175 -k 5.10.13-arch1-2
Error! Bad return status for module build on kernel: 5.10.13-arch1-2 (x86_64)
Consult /var/lib/dkms/chipsec/1070.7966175/build/make.log for more information.
==> Warning, `dkms install --no-depmod -m chipsec -v 1070.7966175 -k 5.10.13-arch1-2' returned 10
==> depmod 5.10.13-arch1-2
```
```
$ cat /var/lib/dkms/chipsec/1070.7966175/build/make.log
DKMS make.log for chipsec-1070.7966175 for kernel 5.10.13-arch1-2 (x86_64)
Mon 08 Feb 2021 20:53:03 AEST
make: Entering directory '/var/lib/dkms/chipsec/1070.7966175/build'
make -C /lib/modules/5.10.13-arch1-2/build M=/var/lib/dkms/chipsec/1070.7966175/build clean
make[1]: Entering directory '/var/lib/dkms/chipsec/1070.7966175/build'
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[1]: Leaving directory '/usr/lib/modules/5.10.13-arch1-2/build'
rm -f amd64/cpu.o
nasm -f elf64 -o amd64/cpu.o amd64/cpu.asm
touch amd64/.cpu.o.cmd
make[1]: Entering directory '/var/lib/dkms/chipsec/1070.7966175/build'
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
  CC [M]  /var/lib/dkms/chipsec/1070.7966175/build/chipsec_km.o
/var/lib/dkms/chipsec/1070.7966175/build/chipsec_km.c: In function ‘chipsec_lookup_name’:
/var/lib/dkms/chipsec/1070.7966175/build/chipsec_km.c:1723:10: error: implicit declaration of function ‘get_fs’; did you mean ‘sget_fc’? [-Werror=implicit-function-declaration]
 1723 |  oldfs = get_fs();
      |          ^~~~~~
      |          sget_fc
/var/lib/dkms/chipsec/1070.7966175/build/chipsec_km.c:1723:10: error: incompatible types when assigning to type ‘mm_segment_t’ from type ‘int’
/var/lib/dkms/chipsec/1070.7966175/build/chipsec_km.c:1724:2: error: implicit declaration of function ‘set_fs’; did you mean ‘sget_fc’? [-Werror=implicit-function-declaration]
 1724 |  set_fs (KERNEL_DS);
      |  ^~~~~~
      |  sget_fc
/var/lib/dkms/chipsec/1070.7966175/build/chipsec_km.c:1724:10: error: ‘KERNEL_DS’ undeclared (first use in this function); did you mean ‘KERNFS_NS’?
 1724 |  set_fs (KERNEL_DS);
      |          ^~~~~~~~~
      |          KERNFS_NS
/var/lib/dkms/chipsec/1070.7966175/build/chipsec_km.c:1724:10: note: each undeclared identifier is reported only once for each function it appears in
/var/lib/dkms/chipsec/1070.7966175/build/chipsec_km.c:1751:10: error: incompatible types when assigning to type ‘mm_segment_t’ from type ‘int’
 1751 |  oldfs = get_fs();
      |          ^~~~~~
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:279: /var/lib/dkms/chipsec/1070.7966175/build/chipsec_km.o] Error 1
make[1]: *** [Makefile:1805: /var/lib/dkms/chipsec/1070.7966175/build] Error 2
make[1]: Leaving directory '/usr/lib/modules/5.10.13-arch1-2/build'
make: *** [Makefile:32: chipsec] Error 2
make: Leaving directory '/var/lib/dkms/chipsec/1070.7966175/build'
```