### PR TITLE
added non-deprecated repository and download

### DIFF
--- a/packages/dripcap/PKGBUILD
+++ b/packages/dripcap/PKGBUILD
@@ -2,15 +2,16 @@
 # See COPYING for license details.
 
 pkgname=dripcap
-pkgver=0.6.15
+pkgver=0.3.10
 pkgrel=1
+epoch=1
 pkgdesc='Caffeinated Packet Analyzer.'
 groups=('blackarch' 'blackarch-networking' 'blackarch-sniffer')
 arch=('x86_64')
-url='https://github.com/dripcap/dripcap'
+url='https://github.com/orinocoz/dripcap'
 license=('MIT')
 options=(!strip)
-source=("https://github.com/dripcap/$pkgname/releases/download/v$pkgver/$pkgname-linux-amd64.deb")
+source=("https://github.com/orinocoz/$pkgname/archive/download/v$pkgver.tar.gz")
 sha512sums=('8b5765a13f3ef60aaf6e2f65fd74e0c7119e005162f98f370a7a8e0b21e01a8596910c16e93bb7145d29dd63557db1f9b836fc021008d1bafcd345a7876a8626')
 
 package() {


### PR DESCRIPTION
a) Fixed dead repository link
b) Added most recent dripcap version tag 
c) Added proper .tar.gz download link from the archived versions