### PR TITLE
chipsec: Included fix from upstream for 5.10

### DIFF
--- a/packages/chipsec/1095-kernel-5.10.patch
+++ b/packages/chipsec/1095-kernel-5.10.patch
@@ -1,0 +1,173 @@
+diff --git a/drivers/linux/chipsec_km.c b/drivers/linux/chipsec_km.c
+index 718ef76..9d9b5b6 100644
+--- a/drivers/linux/chipsec_km.c
++++ b/drivers/linux/chipsec_km.c
+@@ -36,6 +36,7 @@ chipsec@intel.com
+     #include <linux/efi.h>
+ #endif
+ 
++
+ #define _GNU_SOURCE
+ #define CHIPSEC_VER_ 		1
+ #define CHIPSEC_VER_MINOR	2
+@@ -50,6 +51,29 @@ MODULE_LICENSE("GPL");
+ #    define IOREMAP_NO_CACHE(address, size) ioremap_nocache(address, size)
+ #endif
+ 
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
++#include <linux/static_call.h>
++#include <linux/kprobes.h>
++
++static struct kprobe kp = {
++    .symbol_name = "kallsyms_lookup_name",
++    .flags = KPROBE_FLAG_DISABLED
++};
++
++unsigned long kallsyms_lookup_name_c(const char *name)
++{
++	return 0;
++}
++int page_is_ram_c(unsigned long pagenr)
++{
++	return 0;
++}
++
++DEFINE_STATIC_CALL(chipsec_lookup_name_sc, kallsyms_lookup_name_c);
++DEFINE_STATIC_CALL(chipsec_page_is_ram_sc, page_is_ram_c);
++#endif
++
+ // function page_is_ram is not exported 
+ // for modules, but is available in kallsyms.
+ // So we need determine this address using dirty tricks
+@@ -305,8 +329,11 @@ void *my_xlate_dev_mem_ptr(unsigned long phys)
+ 	unsigned long pfn = PFN_DOWN(phys);
+ 	
+         /* If page is RAM, we can use __va. Otherwise ioremap and unmap. */
+-        if ((*guess_page_is_ram)(start >> PAGE_SHIFT)) {
+-
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
++	if (static_call(chipsec_page_is_ram_sc)(start >> PAGE_SHIFT)) {
++#else
++	if ((*guess_page_is_ram)(start >> PAGE_SHIFT)) {
++#endif
+ 		if (PageHighMem(pfn_to_page(pfn))) {
+                 /* The buffer does not have a mapping.  Map it! */
+ 		        addr = kmap(pfn_to_page(pfn));	
+@@ -339,7 +366,11 @@ void my_unxlate_dev_mem_ptr(unsigned long phys,void *addr)
+ 
+ 	/* If page is RAM, check for highmem, and eventualy do nothing. 
+ 	   Otherwise need to iounmap. */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
++	if (static_call(chipsec_page_is_ram_sc)((phys >> PAGE_SHIFT))) {
++#else
+ 	if ((*guess_page_is_ram)(phys >> PAGE_SHIFT)) {
++#endif
+ 	
+ 		if (PageHighMem(pfn_to_page(pfn))) { 
+ 		/* Need to kunmap kmaped memory*/
+@@ -740,6 +771,17 @@ void print_stat(efi_status_t stat)
+ }
+ #endif
+ 
++static void apply_ucode_patch(void *info)
++{
++	CPUID_CTX *cpuinfo = (CPUID_CTX *)info;
++	__cpuid__(cpuinfo);
++}
++
++static unsigned long hypercall_page_c(void)
++{
++	return hypercall_page();
++}
++
+ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioctl_param)
+ {
+ 	int numargs = 0;
+@@ -751,7 +793,6 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
+ 	//unsigned int counter;
+ 	char small_buffer[6]; //32 bits + char + \0
+ 	unsigned long CPUInfo[4]={1,0,0,0};
+-	void (*apply_ucode_patch_p)(void *info);
+ 
+ 	switch(ioctl_num)
+ 	{
+@@ -868,8 +909,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
+ 		printk(KERN_INFO "[chipsec] [patch_apply_ucode] clear IA32_BIOS_SIGN_ID, CPUID EAX=1, read back IA32_BIOS_SIGN_ID\n" );
+ 
+ 		wrmsr_on_cpu(thread_id, MSR_IA32_BIOS_SIGN_ID, (u32)_eax[1], (u32)_edx[1]);
+-		apply_ucode_patch_p=(void *)__cpuid__;
+-		smp_call_function_single(thread_id, apply_ucode_patch_p, (CPUID_CTX *)CPUInfo,0);
++		smp_call_function_single(thread_id, apply_ucode_patch, (void *)CPUInfo,0);
+ 		rdmsr_on_cpu(thread_id, MSR_IA32_BIOS_SIGN_ID, (u32*)&_eax[1], (u32*)&_edx[1]);
+ 
+ 		if (_edx[1] != _edx[0])
+@@ -1592,8 +1632,6 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
+ 			return -EFAULT;
+ 		}
+ 
+-		ptrbuf[11] = (unsigned long)&hypercall_page;
+-
+ 		#ifdef HYPERCALL_DEBUG
+ 		printk( KERN_DEBUG "[chipsec] > IOCTL_HYPERCALL\n");
+ 		#ifdef __x86_64__
+@@ -1610,7 +1648,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
+ 		printk( KERN_DEBUG "    Hypercall page VA   = 0x%016lX\n", ptrbuf[11]);
+ 		#endif
+ 
+-		ptrbuf[0]  = hypercall(ptrbuf[0], ptrbuf[1], ptrbuf[2], ptrbuf[3], ptrbuf[4], ptrbuf[5], ptrbuf[6], ptrbuf[7], ptrbuf[8], ptrbuf[9], ptrbuf[10], ptrbuf[11]);
++		ptrbuf[0]  = hypercall(ptrbuf[0], ptrbuf[1], ptrbuf[2], ptrbuf[3], ptrbuf[4], ptrbuf[5], ptrbuf[6], ptrbuf[7], ptrbuf[8], ptrbuf[9], ptrbuf[10], (unsigned long)&hypercall_page_c);
+ 
+ 		#ifdef HYPERCALL_DEBUG
+ 		printk( KERN_DEBUG "    Hypercall status    = 0x%016lX\n", ptrbuf[0]);
+@@ -1696,7 +1734,7 @@ static struct miscdevice chipsec_dev = {
+  * 0ld dog never die:
+  * https://gist.githubusercontent.com/GoldenOak/a8cd563d671af04a3d387d198aa3ecf8/raw/8dcc90dbbf9b9ffd65cc2c03f1cd48445b84c2b6/obtain_syscall_table_by_proc.c
+ */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,0) && LINUX_VERSION_CODE < KERNEL_VERSION(5,10,0)
+ 
+ unsigned long chipsec_lookup_name(const char *name)
+ {
+@@ -1764,8 +1802,30 @@ CLEAN_UP:
+ 	return *res;
+ }
+ 
+-#else
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+ 
++unsigned long chipsec_lookup_name(const char *name)
++{
++	int kp_ret = 0;
++	unsigned long kaddr = 0;
++
++	unsigned long (*chipsec_lookup_name_fp)(const char *name);
++
++	kp_ret = register_kprobe(&kp);
++	if(kp_ret < 0){
++		printk(KERN_ALERT"register_kprobe failed, returned %d\n", kp_ret);
++		return kp_ret;
++	}
++
++	chipsec_lookup_name_fp = (unsigned long (*) (const char *name))kp.addr;
++	unregister_kprobe(&kp);
++
++	static_call_update(chipsec_lookup_name_sc, chipsec_lookup_name_fp);
++	kaddr = static_call(chipsec_lookup_name_sc)(name);
++
++	return kaddr;
++}
++#else
+ unsigned long chipsec_lookup_name(const char *name){
+ 	return kallsyms_lookup_name(name);
+ }
+@@ -1787,6 +1847,9 @@ int find_symbols(void)
+ 		#endif
+ 	#else
+ 		guess_page_is_ram = (void *)chipsec_lookup_name("page_is_ram");
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
++		static_call_update(chipsec_page_is_ram_sc, guess_page_is_ram);
++#endif	
+ 		#ifdef __HAVE_PHYS_MEM_ACCESS_PROT
+ 		guess_phys_mem_access_prot = (void *)chipsec_lookup_name("phys_mem_access_prot");
+ 		#else

--- a/packages/chipsec/PKGBUILD
+++ b/packages/chipsec/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=chipsec
 pkgver=1070.7966175
-pkgrel=2
+pkgrel=3
 epoch=4
 pkgdesc='Platform Security Assessment Framework.'
 groups=('blackarch' 'blackarch-hardware' 'blackarch-binary' 'blackarch-forensic'
@@ -13,11 +13,13 @@ url='https://github.com/chipsec/chipsec'
 license=('GPL2')
 depends=('dkms' 'libelf' 'linux-headers' 'nasm' 'python' 'python-lxml')
 makedepends=('git' 'python-setuptools')
-source=("git+https://github.com/chipsec/$pkgname.git"
-        'Makefile.patch')
+source=(
+  "git+https://github.com/chipsec/$pkgname.git"
+  'Makefile.patch'
+  '1095-kernel-5.10.patch')
 sha512sums=('SKIP'
-            'b3bd500b37871e8c0c9132613fd9254014c5288b24d7e88acacc695dbb3ff2d384c72186536e2fe5225c31b438f5d08fad991503c9335021cf03c3ed8c29e85f')
-
+            'b3bd500b37871e8c0c9132613fd9254014c5288b24d7e88acacc695dbb3ff2d384c72186536e2fe5225c31b438f5d08fad991503c9335021cf03c3ed8c29e85f'
+            'a8f9725f5c965a28c5ad92f163be18f3f58a69a7bd5f8a4cc247196b6a511adb86397ca03aeec2910b543afd0a027d3045b635c9149da98ab1b13bdbe3e76796')
 
 pkgver() {
   cd $pkgname
@@ -26,8 +28,10 @@ pkgver() {
 }
 
 prepare() {
-  cd "$pkgname/drivers/linux"
-
+  cd "$pkgname"
+  patch -Np1 < "$srcdir/1095-kernel-5.10.patch"
+  
+  cd "drivers/linux"
   patch -Np0 < "$srcdir/Makefile.patch"
 }
 


### PR DESCRIPTION
1095-kernel-5.10.patch: File added,
[source](https://github.com/chipsec/chipsec/pull/1095/files)
and was referenced [here](https://github.com/chipsec/chipsec/issues/1086)

PKGBUILD:
* Added the 'epoch=' variable back as per Black Arch upstream.
* Added the patch file which fixes the issue along with checksum.
* Slight rework on 'package() {}' to apply new patches first, before
  Makefile.patch.

```
$ makepkg -si
==> Making package: chipsec 4:1070.7966175-3 (Thu 18 Feb 2021 02:27:12)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Cloning chipsec git repo...
Cloning into bare repository '/home/blackarch/blackarch/packages/chipsec/chipsec'...
remote: Enumerating objects: 84, done.
remote: Counting objects: 100% (84/84), done.
remote: Compressing objects: 100% (80/80), done.
remote: Total 16209 (delta 25), reused 36 (delta 4), pack-reused 16125
Receiving objects: 100% (16209/16209), 47.95 MiB | 2.82 MiB/s, done.
Resolving deltas: 100% (11788/11788), done.
  -> Found Makefile.patch
  -> Found 1095-kernel-5.10.patch
==> Validating source files with sha512sums...
    chipsec ... Skipped
    Makefile.patch ... Passed
    1095-kernel-5.10.patch ... Passed
==> Extracting sources...
  -> Creating working copy of chipsec git repo...
Cloning into 'chipsec'...
done.
==> Starting prepare()...
patching file drivers/linux/chipsec_km.c
patching file Makefile
==> Starting pkgver()...
==> Starting build()...
running build
running build_py
creating build
creating build/lib
copying chipsec_main.py -> build/lib
copying chipsec_util.py -> build/lib
creating build/lib/chipsec_tools
copying chipsec_tools/__init__.py -> build/lib/chipsec_tools
creating build/lib/chipsec
copying chipsec/chipset.py -> build/lib/chipsec
copying chipsec/module.py -> build/lib/chipsec
copying chipsec/result_deltas.py -> build/lib/chipsec
copying chipsec/module_common.py -> build/lib/chipsec
copying chipsec/defines.py -> build/lib/chipsec
copying chipsec/logger.py -> build/lib/chipsec
copying chipsec/__init__.py -> build/lib/chipsec
copying chipsec/testcase.py -> build/lib/chipsec
copying chipsec/command.py -> build/lib/chipsec
copying chipsec/file.py -> build/lib/chipsec
creating build/lib/chipsec_tools/windows
copying chipsec_tools/windows/__init__.py -> build/lib/chipsec_tools/windows
creating build/lib/chipsec/helper
copying chipsec/helper/basehelper.py -> build/lib/chipsec/helper
copying chipsec/helper/__init__.py -> build/lib/chipsec/helper
copying chipsec/helper/helpers.py -> build/lib/chipsec/helper
copying chipsec/helper/oshelper.py -> build/lib/chipsec/helper
creating build/lib/chipsec/modules
copying chipsec/modules/__init__.py -> build/lib/chipsec/modules
creating build/lib/chipsec/fuzzing
copying chipsec/fuzzing/primitives.py -> build/lib/chipsec/fuzzing
copying chipsec/fuzzing/__init__.py -> build/lib/chipsec/fuzzing
creating build/lib/chipsec/hal
copying chipsec/hal/vmm.py -> build/lib/chipsec/hal
copying chipsec/hal/uefi_common.py -> build/lib/chipsec/hal
copying chipsec/hal/acpi.py -> build/lib/chipsec/hal
copying chipsec/hal/pcidb.py -> build/lib/chipsec/hal
copying chipsec/hal/cpu.py -> build/lib/chipsec/hal
copying chipsec/hal/spd.py -> build/lib/chipsec/hal
copying chipsec/hal/spi_uefi.py -> build/lib/chipsec/hal
copying chipsec/hal/io.py -> build/lib/chipsec/hal
copying chipsec/hal/cpuid.py -> build/lib/chipsec/hal
copying chipsec/hal/interrupts.py -> build/lib/chipsec/hal
copying chipsec/hal/msgbus.py -> build/lib/chipsec/hal
copying chipsec/hal/__init__.py -> build/lib/chipsec/hal
copying chipsec/hal/iommu.py -> build/lib/chipsec/hal
copying chipsec/hal/smbus.py -> build/lib/chipsec/hal
copying chipsec/hal/mmio.py -> build/lib/chipsec/hal
copying chipsec/hal/tpm12_commands.py -> build/lib/chipsec/hal
copying chipsec/hal/tpm.py -> build/lib/chipsec/hal
copying chipsec/hal/uefi_platform.py -> build/lib/chipsec/hal
copying chipsec/hal/hal_base.py -> build/lib/chipsec/hal
copying chipsec/hal/acpi_tables.py -> build/lib/chipsec/hal
copying chipsec/hal/virtmem.py -> build/lib/chipsec/hal
copying chipsec/hal/smbios.py -> build/lib/chipsec/hal
copying chipsec/hal/pci.py -> build/lib/chipsec/hal
copying chipsec/hal/tpm_eventlog.py -> build/lib/chipsec/hal
copying chipsec/hal/uefi_fv.py -> build/lib/chipsec/hal
copying chipsec/hal/ucode.py -> build/lib/chipsec/hal
copying chipsec/hal/uefi.py -> build/lib/chipsec/hal
copying chipsec/hal/ec.py -> build/lib/chipsec/hal
copying chipsec/hal/cmos.py -> build/lib/chipsec/hal
copying chipsec/hal/physmem.py -> build/lib/chipsec/hal
copying chipsec/hal/paging.py -> build/lib/chipsec/hal
copying chipsec/hal/msr.py -> build/lib/chipsec/hal
copying chipsec/hal/spi_descriptor.py -> build/lib/chipsec/hal
copying chipsec/hal/igd.py -> build/lib/chipsec/hal
copying chipsec/hal/uefi_search.py -> build/lib/chipsec/hal
copying chipsec/hal/iobar.py -> build/lib/chipsec/hal
copying chipsec/hal/spi.py -> build/lib/chipsec/hal
copying chipsec/hal/spi_jedec_ids.py -> build/lib/chipsec/hal
creating build/lib/chipsec/cfg
copying chipsec/cfg/__init__.py -> build/lib/chipsec/cfg
creating build/lib/chipsec/utilcmd
copying chipsec/utilcmd/deltas_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/mmcfg_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/vmem_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/vmm_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/mmio_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/cmos_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/tpm_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/cpu_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/__init__.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/desc_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/reg_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/ec_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/spidesc_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/smbus_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/smbios_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/pci_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/msgbus_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/mem_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/uefi_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/acpi_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/iommu_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/mmcfg_base_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/msr_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/interrupts_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/spi_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/ucode_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/igd_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/spd_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/decode_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/io_cmd.py -> build/lib/chipsec/utilcmd
copying chipsec/utilcmd/chipset_cmd.py -> build/lib/chipsec/utilcmd
creating build/lib/chipsec/helper/rwe
copying chipsec/helper/rwe/__init__.py -> build/lib/chipsec/helper/rwe
copying chipsec/helper/rwe/rwehelper.py -> build/lib/chipsec/helper/rwe
creating build/lib/chipsec/helper/win
copying chipsec/helper/win/__init__.py -> build/lib/chipsec/helper/win
copying chipsec/helper/win/win32helper.py -> build/lib/chipsec/helper/win
creating build/lib/chipsec/helper/file
copying chipsec/helper/file/__init__.py -> build/lib/chipsec/helper/file
copying chipsec/helper/file/filehelper.py -> build/lib/chipsec/helper/file
creating build/lib/chipsec/helper/dal
copying chipsec/helper/dal/__init__.py -> build/lib/chipsec/helper/dal
copying chipsec/helper/dal/dalhelper.py -> build/lib/chipsec/helper/dal
creating build/lib/chipsec/helper/linux
copying chipsec/helper/linux/legacy_pci.py -> build/lib/chipsec/helper/linux
copying chipsec/helper/linux/cpuid.py -> build/lib/chipsec/helper/linux
copying chipsec/helper/linux/__init__.py -> build/lib/chipsec/helper/linux
copying chipsec/helper/linux/linuxhelper.py -> build/lib/chipsec/helper/linux
creating build/lib/chipsec/helper/efi
copying chipsec/helper/efi/__init__.py -> build/lib/chipsec/helper/efi
copying chipsec/helper/efi/efihelper.py -> build/lib/chipsec/helper/efi
creating build/lib/chipsec/helper/osx
copying chipsec/helper/osx/__init__.py -> build/lib/chipsec/helper/osx
copying chipsec/helper/osx/osxhelper.py -> build/lib/chipsec/helper/osx
creating build/lib/chipsec/modules/common
copying chipsec/modules/common/spd_wd.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/bios_kbrd_buffer.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/spi_desc.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/memconfig.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/__init__.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/spi_access.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/bios_ts.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/bios_smi.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/smrr.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/bios_wp.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/debugenabled.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/me_mfg_mode.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/spi_lock.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/ia32cfg.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/smm.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/remap.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/sgx_check.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/rtclock.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/memlock.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/spi_fdopss.py -> build/lib/chipsec/modules/common
copying chipsec/modules/common/smm_dma.py -> build/lib/chipsec/modules/common
creating build/lib/chipsec/modules/bdw
copying chipsec/modules/bdw/__init__.py -> build/lib/chipsec/modules/bdw
creating build/lib/chipsec/modules/tools
copying chipsec/modules/tools/__init__.py -> build/lib/chipsec/modules/tools
creating build/lib/chipsec/modules/ivb
copying chipsec/modules/ivb/__init__.py -> build/lib/chipsec/modules/ivb
creating build/lib/chipsec/modules/byt
copying chipsec/modules/byt/__init__.py -> build/lib/chipsec/modules/byt
creating build/lib/chipsec/modules/hsw
copying chipsec/modules/hsw/__init__.py -> build/lib/chipsec/modules/hsw
creating build/lib/chipsec/modules/snb
copying chipsec/modules/snb/__init__.py -> build/lib/chipsec/modules/snb
creating build/lib/chipsec/modules/common/secureboot
copying chipsec/modules/common/secureboot/__init__.py -> build/lib/chipsec/modules/common/secureboot
copying chipsec/modules/common/secureboot/variables.py -> build/lib/chipsec/modules/common/secureboot
creating build/lib/chipsec/modules/common/cpu
copying chipsec/modules/common/cpu/cpu_info.py -> build/lib/chipsec/modules/common/cpu
copying chipsec/modules/common/cpu/__init__.py -> build/lib/chipsec/modules/common/cpu
copying chipsec/modules/common/cpu/ia_untrusted.py -> build/lib/chipsec/modules/common/cpu
copying chipsec/modules/common/cpu/spectre_v2.py -> build/lib/chipsec/modules/common/cpu
creating build/lib/chipsec/modules/common/uefi
copying chipsec/modules/common/uefi/access_uefispec.py -> build/lib/chipsec/modules/common/uefi
copying chipsec/modules/common/uefi/__init__.py -> build/lib/chipsec/modules/common/uefi
copying chipsec/modules/common/uefi/s3bootscript.py -> build/lib/chipsec/modules/common/uefi
creating build/lib/chipsec/modules/tools/secureboot
copying chipsec/modules/tools/secureboot/__init__.py -> build/lib/chipsec/modules/tools/secureboot
copying chipsec/modules/tools/secureboot/te.py -> build/lib/chipsec/modules/tools/secureboot
creating build/lib/chipsec/modules/tools/cpu
copying chipsec/modules/tools/cpu/sinkhole.py -> build/lib/chipsec/modules/tools/cpu
copying chipsec/modules/tools/cpu/__init__.py -> build/lib/chipsec/modules/tools/cpu
creating build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/cpuid_fuzz.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/pcie_fuzz.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/__init__.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/pcie_overlap_fuzz.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/common.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/iofuzz.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/venom.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/hypercallfuzz.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/ept_finder.py -> build/lib/chipsec/modules/tools/vmm
copying chipsec/modules/tools/vmm/msr_fuzz.py -> build/lib/chipsec/modules/tools/vmm
creating build/lib/chipsec/modules/tools/smm
copying chipsec/modules/tools/smm/rogue_mmio_bar.py -> build/lib/chipsec/modules/tools/smm
copying chipsec/modules/tools/smm/__init__.py -> build/lib/chipsec/modules/tools/smm
copying chipsec/modules/tools/smm/smm_ptr.py -> build/lib/chipsec/modules/tools/smm
creating build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/uefi/scan_image.py -> build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/uefi/uefivar_fuzz.py -> build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/uefi/__init__.py -> build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/uefi/reputation.py -> build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/uefi/scan_blocked.py -> build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/uefi/s3script_modify.py -> build/lib/chipsec/modules/tools/uefi
creating build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/vmbusfuzz.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/vmbus.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/__init__.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/synth_dev.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/synth_kbd.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/hypercallfuzz.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/define.py -> build/lib/chipsec/modules/tools/vmm/hv
copying chipsec/modules/tools/vmm/hv/hypercall.py -> build/lib/chipsec/modules/tools/vmm/hv
creating build/lib/chipsec/modules/tools/vmm/xen
copying chipsec/modules/tools/vmm/xen/__init__.py -> build/lib/chipsec/modules/tools/vmm/xen
copying chipsec/modules/tools/vmm/xen/hypercallfuzz.py -> build/lib/chipsec/modules/tools/vmm/xen
copying chipsec/modules/tools/vmm/xen/xsa188.py -> build/lib/chipsec/modules/tools/vmm/xen
copying chipsec/modules/tools/vmm/xen/define.py -> build/lib/chipsec/modules/tools/vmm/xen
copying chipsec/modules/tools/vmm/xen/hypercall.py -> build/lib/chipsec/modules/tools/vmm/xen
creating build/lib/chipsec/modules/tools/vmm/vbox
copying chipsec/modules/tools/vmm/vbox/__init__.py -> build/lib/chipsec/modules/tools/vmm/vbox
copying chipsec/modules/tools/vmm/vbox/vbox_crash_apicbase.py -> build/lib/chipsec/modules/tools/vmm/vbox
copying chipsec/VERSION -> build/lib/chipsec
copying chipsec/WARNING.txt -> build/lib/chipsec
creating build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/ivt.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_495.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/dnv.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/ivb.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/skl.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/common.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_2xx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_4xxlp.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/kbl.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/jkt.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/iommu.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_4xx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/hsx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/qrk.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_c620.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_3xxop.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/bdw.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/byt.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/cfl.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_4xxh.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/icl.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/whl.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_c60x.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_1xx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/cml.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/apl.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/glk.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/skx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_3xxlp.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_3xx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/avn.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/cht.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/hsw.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/bdx.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/snb.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/sfdp.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/8086/pch_c61x.xml -> build/lib/chipsec/cfg/8086
copying chipsec/cfg/template.xml -> build/lib/chipsec/cfg
copying chipsec/cfg/chipsec_cfg.xsd -> build/lib/chipsec/cfg
copying chipsec/modules/tools/secureboot/te.cfg -> build/lib/chipsec/modules/tools/secureboot
copying chipsec/modules/tools/smm/smm_config.ini -> build/lib/chipsec/modules/tools/smm
copying chipsec/modules/tools/uefi/blockedlist.json -> build/lib/chipsec/modules/tools/uefi
copying chipsec/modules/tools/vmm/hv/initial_data.json -> build/lib/chipsec/modules/tools/vmm/hv
==> Entering fakeroot environment...
==> Starting package()...
running install
running install_lib
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages
copying build/lib/chipsec_main.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_tools
copying build/lib/chipsec_tools/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_tools
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_tools/windows
copying build/lib/chipsec_tools/windows/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_tools/windows
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/chipset.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper
copying build/lib/chipsec/helper/basehelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/rwe
copying build/lib/chipsec/helper/rwe/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/rwe
copying build/lib/chipsec/helper/rwe/rwehelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/rwe
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/win
copying build/lib/chipsec/helper/win/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/win
copying build/lib/chipsec/helper/win/win32helper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/win
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/file
copying build/lib/chipsec/helper/file/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/file
copying build/lib/chipsec/helper/file/filehelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/file
copying build/lib/chipsec/helper/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/dal
copying build/lib/chipsec/helper/dal/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/dal
copying build/lib/chipsec/helper/dal/dalhelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/dal
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux
copying build/lib/chipsec/helper/linux/legacy_pci.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux
copying build/lib/chipsec/helper/linux/cpuid.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux
copying build/lib/chipsec/helper/linux/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux
copying build/lib/chipsec/helper/linux/linuxhelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux
copying build/lib/chipsec/helper/helpers.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/efi
copying build/lib/chipsec/helper/efi/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/efi
copying build/lib/chipsec/helper/efi/efihelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/efi
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/osx
copying build/lib/chipsec/helper/osx/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/osx
copying build/lib/chipsec/helper/osx/osxhelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/osx
copying build/lib/chipsec/helper/oshelper.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper
copying build/lib/chipsec/module.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/result_deltas.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/module_common.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/defines.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/logger.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/VERSION -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/testcase.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/WARNING.txt -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/command.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
copying build/lib/chipsec/file.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/spd_wd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/bios_kbrd_buffer.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/spi_desc.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/memconfig.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/spi_access.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/secureboot
copying build/lib/chipsec/modules/common/secureboot/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/secureboot
copying build/lib/chipsec/modules/common/secureboot/variables.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/secureboot
copying build/lib/chipsec/modules/common/bios_ts.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/bios_smi.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/smrr.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/bios_wp.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu
copying build/lib/chipsec/modules/common/cpu/cpu_info.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu
copying build/lib/chipsec/modules/common/cpu/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu
copying build/lib/chipsec/modules/common/cpu/ia_untrusted.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu
copying build/lib/chipsec/modules/common/cpu/spectre_v2.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu
copying build/lib/chipsec/modules/common/debugenabled.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/me_mfg_mode.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/spi_lock.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/ia32cfg.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/smm.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi
copying build/lib/chipsec/modules/common/uefi/access_uefispec.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi
copying build/lib/chipsec/modules/common/uefi/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi
copying build/lib/chipsec/modules/common/uefi/s3bootscript.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi
copying build/lib/chipsec/modules/common/remap.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/sgx_check.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/rtclock.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/memlock.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/spi_fdopss.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
copying build/lib/chipsec/modules/common/smm_dma.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/bdw
copying build/lib/chipsec/modules/bdw/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/bdw
copying build/lib/chipsec/modules/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools
copying build/lib/chipsec/modules/tools/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/secureboot
copying build/lib/chipsec/modules/tools/secureboot/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/secureboot
copying build/lib/chipsec/modules/tools/secureboot/te.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/secureboot
copying build/lib/chipsec/modules/tools/secureboot/te.cfg -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/secureboot
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/cpu
copying build/lib/chipsec/modules/tools/cpu/sinkhole.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/cpu
copying build/lib/chipsec/modules/tools/cpu/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/cpu
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/cpuid_fuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/pcie_fuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/vmbusfuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/initial_data.json -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/vmbus.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/synth_dev.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/synth_kbd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/hypercallfuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/define.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/hv/hypercall.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv
copying build/lib/chipsec/modules/tools/vmm/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen
copying build/lib/chipsec/modules/tools/vmm/xen/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen
copying build/lib/chipsec/modules/tools/vmm/xen/hypercallfuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen
copying build/lib/chipsec/modules/tools/vmm/xen/xsa188.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen
copying build/lib/chipsec/modules/tools/vmm/xen/define.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen
copying build/lib/chipsec/modules/tools/vmm/xen/hypercall.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen
copying build/lib/chipsec/modules/tools/vmm/pcie_overlap_fuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/common.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/iofuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/vbox
copying build/lib/chipsec/modules/tools/vmm/vbox/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/vbox
copying build/lib/chipsec/modules/tools/vmm/vbox/vbox_crash_apicbase.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/vbox
copying build/lib/chipsec/modules/tools/vmm/venom.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/hypercallfuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/ept_finder.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
copying build/lib/chipsec/modules/tools/vmm/msr_fuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm
copying build/lib/chipsec/modules/tools/smm/rogue_mmio_bar.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm
copying build/lib/chipsec/modules/tools/smm/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm
copying build/lib/chipsec/modules/tools/smm/smm_ptr.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm
copying build/lib/chipsec/modules/tools/smm/smm_config.ini -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/scan_image.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/uefivar_fuzz.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/blockedlist.json -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/reputation.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/scan_blocked.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
copying build/lib/chipsec/modules/tools/uefi/s3script_modify.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/ivb
copying build/lib/chipsec/modules/ivb/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/ivb
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/byt
copying build/lib/chipsec/modules/byt/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/byt
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/hsw
copying build/lib/chipsec/modules/hsw/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/hsw
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/snb
copying build/lib/chipsec/modules/snb/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/snb
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/fuzzing
copying build/lib/chipsec/fuzzing/primitives.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/fuzzing
copying build/lib/chipsec/fuzzing/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/fuzzing
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/vmm.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/uefi_common.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/acpi.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/pcidb.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/cpu.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/spd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/spi_uefi.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/io.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/cpuid.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/interrupts.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/msgbus.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/iommu.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/smbus.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/mmio.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/tpm12_commands.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/tpm.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/uefi_platform.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/hal_base.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/acpi_tables.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/virtmem.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/smbios.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/pci.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/tpm_eventlog.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/uefi_fv.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/ucode.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/uefi.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/ec.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/cmos.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/physmem.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/paging.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/msr.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/spi_descriptor.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/igd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/uefi_search.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/iobar.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/spi.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
copying build/lib/chipsec/hal/spi_jedec_ids.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg
copying build/lib/chipsec/cfg/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg
copying build/lib/chipsec/cfg/chipsec_cfg.xsd -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/ivt.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_495.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/dnv.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/ivb.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/skl.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/common.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_2xx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_4xxlp.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/kbl.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/jkt.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/iommu.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_4xx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/hsx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/qrk.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_c620.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_3xxop.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/bdw.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/byt.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/cfl.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_4xxh.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/icl.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/whl.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_c60x.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_1xx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/cml.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/apl.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/glk.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/skx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_3xxlp.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_3xx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/avn.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/cht.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/hsw.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/bdx.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/snb.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/sfdp.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/8086/pch_c61x.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/8086
copying build/lib/chipsec/cfg/template.xml -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg
creating /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/deltas_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/mmcfg_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/vmem_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/vmm_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/mmio_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/cmos_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/tpm_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/cpu_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/__init__.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/desc_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/reg_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/ec_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/spidesc_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/smbus_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/smbios_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/pci_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/msgbus_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/mem_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/uefi_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/acpi_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/iommu_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/mmcfg_base_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/msr_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/interrupts_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/spi_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/ucode_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/igd_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/spd_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/decode_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/io_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec/utilcmd/chipset_cmd.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd
copying build/lib/chipsec_util.py -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_main.py to chipsec_main.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_tools/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_tools/windows/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/chipset.py to chipset.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/basehelper.py to basehelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/rwe/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/rwe/rwehelper.py to rwehelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/win/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/win/win32helper.py to win32helper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/file/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/file/filehelper.py to filehelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/dal/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/dal/dalhelper.py to dalhelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux/legacy_pci.py to legacy_pci.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux/cpuid.py to cpuid.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/linux/linuxhelper.py to linuxhelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/helpers.py to helpers.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/efi/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/efi/efihelper.py to efihelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/osx/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/osx/osxhelper.py to osxhelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/helper/oshelper.py to oshelper.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/module.py to module.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/result_deltas.py to result_deltas.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/module_common.py to module_common.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/defines.py to defines.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/logger.py to logger.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/testcase.py to testcase.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/command.py to command.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/file.py to file.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/spd_wd.py to spd_wd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/bios_kbrd_buffer.py to bios_kbrd_buffer.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/spi_desc.py to spi_desc.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/memconfig.py to memconfig.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/spi_access.py to spi_access.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/secureboot/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/secureboot/variables.py to variables.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/bios_ts.py to bios_ts.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/bios_smi.py to bios_smi.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/smrr.py to smrr.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/bios_wp.py to bios_wp.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu/cpu_info.py to cpu_info.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu/ia_untrusted.py to ia_untrusted.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/cpu/spectre_v2.py to spectre_v2.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/debugenabled.py to debugenabled.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/me_mfg_mode.py to me_mfg_mode.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/spi_lock.py to spi_lock.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/ia32cfg.py to ia32cfg.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/smm.py to smm.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi/access_uefispec.py to access_uefispec.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/uefi/s3bootscript.py to s3bootscript.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/remap.py to remap.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/sgx_check.py to sgx_check.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/rtclock.py to rtclock.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/memlock.py to memlock.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/spi_fdopss.py to spi_fdopss.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/common/smm_dma.py to smm_dma.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/bdw/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/secureboot/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/secureboot/te.py to te.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/cpu/sinkhole.py to sinkhole.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/cpu/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/cpuid_fuzz.py to cpuid_fuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/pcie_fuzz.py to pcie_fuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/vmbusfuzz.py to vmbusfuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/vmbus.py to vmbus.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/synth_dev.py to synth_dev.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/synth_kbd.py to synth_kbd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/hypercallfuzz.py to hypercallfuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/define.py to define.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hv/hypercall.py to hypercall.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen/hypercallfuzz.py to hypercallfuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen/xsa188.py to xsa188.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen/define.py to define.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/xen/hypercall.py to hypercall.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/pcie_overlap_fuzz.py to pcie_overlap_fuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/common.py to common.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/iofuzz.py to iofuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/vbox/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/vbox/vbox_crash_apicbase.py to vbox_crash_apicbase.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/venom.py to venom.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/hypercallfuzz.py to hypercallfuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/ept_finder.py to ept_finder.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/vmm/msr_fuzz.py to msr_fuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm/rogue_mmio_bar.py to rogue_mmio_bar.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/smm/smm_ptr.py to smm_ptr.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi/scan_image.py to scan_image.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi/uefivar_fuzz.py to uefivar_fuzz.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi/reputation.py to reputation.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi/scan_blocked.py to scan_blocked.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/tools/uefi/s3script_modify.py to s3script_modify.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/ivb/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/byt/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/hsw/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/modules/snb/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/fuzzing/primitives.py to primitives.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/fuzzing/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/vmm.py to vmm.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/uefi_common.py to uefi_common.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/acpi.py to acpi.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/pcidb.py to pcidb.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/cpu.py to cpu.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/spd.py to spd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/spi_uefi.py to spi_uefi.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/io.py to io.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/cpuid.py to cpuid.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/interrupts.py to interrupts.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/msgbus.py to msgbus.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/iommu.py to iommu.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/smbus.py to smbus.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/mmio.py to mmio.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/tpm12_commands.py to tpm12_commands.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/tpm.py to tpm.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/uefi_platform.py to uefi_platform.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/hal_base.py to hal_base.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/acpi_tables.py to acpi_tables.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/virtmem.py to virtmem.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/smbios.py to smbios.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/pci.py to pci.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/tpm_eventlog.py to tpm_eventlog.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/uefi_fv.py to uefi_fv.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/ucode.py to ucode.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/uefi.py to uefi.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/ec.py to ec.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/cmos.py to cmos.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/physmem.py to physmem.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/paging.py to paging.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/msr.py to msr.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/spi_descriptor.py to spi_descriptor.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/igd.py to igd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/uefi_search.py to uefi_search.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/iobar.py to iobar.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/spi.py to spi.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/hal/spi_jedec_ids.py to spi_jedec_ids.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/cfg/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/deltas_cmd.py to deltas_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/mmcfg_cmd.py to mmcfg_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/vmem_cmd.py to vmem_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/vmm_cmd.py to vmm_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/mmio_cmd.py to mmio_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/cmos_cmd.py to cmos_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/tpm_cmd.py to tpm_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/cpu_cmd.py to cpu_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/__init__.py to __init__.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/desc_cmd.py to desc_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/reg_cmd.py to reg_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/ec_cmd.py to ec_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/spidesc_cmd.py to spidesc_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/smbus_cmd.py to smbus_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/smbios_cmd.py to smbios_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/pci_cmd.py to pci_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/msgbus_cmd.py to msgbus_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/mem_cmd.py to mem_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/uefi_cmd.py to uefi_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/acpi_cmd.py to acpi_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/iommu_cmd.py to iommu_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/mmcfg_base_cmd.py to mmcfg_base_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/msr_cmd.py to msr_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/interrupts_cmd.py to interrupts_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/spi_cmd.py to spi_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/ucode_cmd.py to ucode_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/igd_cmd.py to igd_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/spd_cmd.py to spd_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/decode_cmd.py to decode_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/io_cmd.py to io_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec/utilcmd/chipset_cmd.py to chipset_cmd.cpython-39.pyc
byte-compiling /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec_util.py to chipsec_util.cpython-39.pyc
writing byte-compilation script '/tmp/tmp5595vzu5.py'
/usr/bin/python /tmp/tmp5595vzu5.py
removing /tmp/tmp5595vzu5.py
running install_data
copying chipsec-manual.pdf -> /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/
running install_egg_info
running egg_info
creating chipsec.egg-info
writing chipsec.egg-info/PKG-INFO
writing dependency_links to chipsec.egg-info/dependency_links.txt
writing entry points to chipsec.egg-info/entry_points.txt
writing top-level names to chipsec.egg-info/top_level.txt
writing manifest file 'chipsec.egg-info/SOURCES.txt'
writing manifest file 'chipsec.egg-info/SOURCES.txt'
Copying chipsec.egg-info to /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/lib/python3.9/site-packages/chipsec-1.5.9-py3.9.egg-info
running install_scripts
Installing chipsec_main script to /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/bin
Installing chipsec_util script to /home/blackarch/blackarch/packages/chipsec/pkg/chipsec/usr/bin
==> Tidying install...
  -> Removing libtool files...
  -> Purging unwanted files...
  -> Removing static library files...
  -> Stripping unneeded symbols from binaries and libraries...
  -> Compressing man and info pages...
==> Checking for packaging issues...
==> Creating package "chipsec"...
  -> Generating .PKGINFO file...
  -> Generating .BUILDINFO file...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: chipsec 4:1070.7966175-3 (Thu 18 Feb 2021 02:30:00)
==> Installing package chipsec with pacman -U...
loading packages...
resolving dependencies...
looking for conflicting packages...

Packages (1) chipsec-4:1070.7966175-3

Total Installed Size:  7.24 MiB
Net Upgrade Size:      0.00 MiB

:: Proceed with installation? [Y/n] 
(1/1) checking keys in keyring                                                                                                              [--------------------------------------------------------------------------------------] 100%
(1/1) checking package integrity                                                                                                            [--------------------------------------------------------------------------------------] 100%
(1/1) loading package files                                                                                                                 [--------------------------------------------------------------------------------------] 100%
(1/1) checking for file conflicts                                                                                                           [--------------------------------------------------------------------------------------] 100%
:: Running pre-transaction hooks...
(1/1) Remove upgraded DKMS modules
==> Unable to remove module chipsec/1070.7966175 for kernel 5.10.16-arch1-1: Not found in dkms status output.
:: Processing package changes...
(1/1) upgrading chipsec                                                                                                                     [--------------------------------------------------------------------------------------] 100%
:: Running post-transaction hooks...
(1/2) Arming ConditionNeedsUpdate...
(2/2) Install DKMS modules
==> dkms install --no-depmod -m chipsec -v 1070.7966175 -k 5.10.16-arch1-1
==> depmod 5.10.16-arch1-1
$ dkms status -m chipsec
chipsec, 1070.7966175, 5.10.16-arch1-1, x86_64: installed
```