### PR TITLE
blackarch-menus: add to blackarch group

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,1 +1,2 @@
 airgeddon
+blackarch-menus

--- a/packages/blackarch-menus/PKGBUILD
+++ b/packages/blackarch-menus/PKGBUILD
@@ -3,9 +3,9 @@
 
 pkgname=blackarch-menus
 pkgver=10.5244eea
-pkgrel=1
+pkgrel=2
 pkgdesc='BlackArch specific XDG-compliant menu.'
-groups=('blackarch-config')
+groups=('blackarch' 'blackarch-config')
 arch=('any')
 url='https://github.com/BlackArch/blackarch-menus'
 license=('custom:unknown')


### PR DESCRIPTION
We should add blackarch-menus to the blackarch group.
Currently if people run `pacman -S blackarch` it will not be installed
People get confused as the menu structure isn't showing up in desktop Environments that use `.desktop` files as it may be the case in #3055 