### PR TITLE
pwncat 0.1.1 (update 0.1.0 -> 0.1.1)

### DIFF
--- a/packages/pwncat/PKGBUILD
+++ b/packages/pwncat/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=pwncat
-pkgver=0.1.0
+pkgver=0.1.1
 pkgrel=1
 groups=('blackarch' 'blackarch-backdoor' 'blackarch-scanner' 'blackarch-proxy'
         'blackarch-networking')
@@ -12,7 +12,7 @@ license=('MIT')
 arch=('any')
 depends=('python')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/cytopia/$pkgname/archive/v$pkgver.tar.gz")
-sha512sums=('cd4d142779cb8581cc7ee327c9eefa1454dc46096bbf27e425e5f54cf4d69b72537c75639eb4ac1e18a48128df48b18aaa49e4e520b9755186c9d57f33cfab1a')
+sha512sums=('3a21510288048753734c5f33c589b0d2438ad24bf586d1b25fe618fcb09530c45ad8f7247e9729bebeb00cfc679253c31b3ae3d2831018d3cc3774eece6dad2f')
 
 package() {
   cd "$pkgname-$pkgver"


### PR DESCRIPTION
# pwncat 0.1.1

Updating pwncat from version 0.1.0 to version 0.1.1

Created as follows:
```bash
#!/usr/bin/env bash

set -e
set -u
set -o pipefail


VERSION="0.1.1"


SHA512="$( curl -sS --fail -L \
	"https://github.com/cytopia/pwncat/archive/v${VERSION}.tar.gz" --output - \
	| sha512sum \
	| awk '{print $1}' \
)"


cat <<- EOF
# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
# See COPYING for license details.

pkgname=pwncat
pkgver=${VERSION}
pkgrel=1
groups=('blackarch' 'blackarch-backdoor' 'blackarch-scanner' 'blackarch-proxy'
        'blackarch-networking')
pkgdesc='Bind and reverse shell handler with FW/IDS/IPS evasion, self-inject and port-scanning.'
url='http://pwncat.org/'
license=('MIT')
arch=('any')
depends=('python')
source=("\$pkgname-\$pkgver.tar.gz::https://github.com/cytopia/\$pkgname/archive/v\$pkgver.tar.gz")
sha512sums=('${SHA512}')

package() {
  cd "\$pkgname-\$pkgver"

  install -Dm 755 bin/\$pkgname "\$pkgdir/usr/bin/\$pkgname"
  install -Dm 644 man/\$pkgname.1 -t "\$pkgdir/usr/share/man/man1"
  install -Dm 644 LICENSE.txt "\$pkgdir/usr/share/licenses/\$pkgname/LICENSE"
  install -Dm 644 README.md CHANGELOG.md -t "\$pkgdir/usr/share/doc/\$pkgname/"

  cp --no-preserve=ownership -a pse "\$pkgdir/usr/share/doc/\$pkgname/"
}

EOF
```