### PR TITLE
ctf-party

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+ctf-party

--- a/lists/to-remove
+++ b/lists/to-remove
@@ -1,0 +1,1 @@
+ruby-ctf-party

--- a/packages/ctf-party/PKGBUILD
+++ b/packages/ctf-party/PKGBUILD
@@ -1,17 +1,18 @@
 # This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
 # See COPYING for license details.
 
-pkgname=ruby-ctf-party
+pkgname=ctf-party
 _gemname=ctf-party
-pkgver=v1.3.5.r0.g05af957
+pkgver=v1.4.0.r1.gd765c87
 pkgrel=1
 groups=('blackarch' 'blackarch-misc')
-pkgdesc='A library to enhance and speed up script/exploit writing for CTF players.'
+pkgdesc='A CLI tool & library to enhance and speed up script/exploit writing for CTF players.'
 arch=('any')
 url='https://noraj.github.io/ctf-party/'
 license=('MIT')
-depends=('ruby')
+depends=('ruby' 'ruby-docopt')
 makedepends=('git')
+replaces=('ruby-ctf-party')
 options=(!emptydirs)
 source=("git+https://github.com/noraj/$_gemname.git")
 sha512sums=('SKIP')


### PR DESCRIPTION
- update to [1.4.0](https://github.com/noraj/ctf-party/releases/tag/v1.4.0)
- rename to ctf-party (because a CLI tool was added and so is not a library only anymore)