### PR TITLE
social-analyzer: add package

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+social-analyzer

--- a/packages/social-analyzer/PKGBUILD
+++ b/packages/social-analyzer/PKGBUILD
@@ -1,0 +1,29 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=social-analyzer
+pkgver=0.21
+pkgrel=1
+pkgdesc="Analyzing & finding a person's profile across social media websites"
+arch=('any')
+groups=('blackarch' 'blackarch-recon' 'blackarch-social')
+url='https://github.com/qeeqbox/social-analyzer'
+license=('AGPL3')
+depends=('python' 'python-beautifulsoup4' 'python-tld' 'python-termcolor'
+         'python-langdetect' 'python-requests' 'python-lxml')
+makedepends=('python-setuptools')
+source=("https://files.pythonhosted.org/packages/source/s/$pkgname/$pkgname-$pkgver.tar.gz")
+sha512sums=('d986e15b77143f9c2139d81343b1b0e01d55ef295f9410a66efcd2000e6863a3405b702570dfc4be9ee311584cd7680178565d798da2aa190dca8537919186c1')
+
+build() {
+  cd "$pkgname-$pkgver"
+
+  python setup.py build
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+}
+

--- a/packages/social-analyzer/PKGBUILD
+++ b/packages/social-analyzer/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=social-analyzer
-pkgver=0.21
+pkgver=0.27
 pkgrel=1
 pkgdesc="Analyzing & finding a person's profile across social media websites"
 arch=('any')
@@ -13,7 +13,7 @@ depends=('python' 'python-beautifulsoup4' 'python-tld' 'python-termcolor'
          'python-langdetect' 'python-requests' 'python-lxml')
 makedepends=('python-setuptools')
 source=("https://files.pythonhosted.org/packages/source/s/$pkgname/$pkgname-$pkgver.tar.gz")
-sha512sums=('d986e15b77143f9c2139d81343b1b0e01d55ef295f9410a66efcd2000e6863a3405b702570dfc4be9ee311584cd7680178565d798da2aa190dca8537919186c1')
+sha512sums=('0e6827b4eeca3198783f936adafca6aa138f047bead745c21d42b3b99dbddcba4a621f25202df82e9b7081daaaf7618f4431ce886d7f4cb0e2687240f8209b44')
 
 build() {
   cd "$pkgname-$pkgver"


### PR DESCRIPTION
close  #3080

Seems it doesn't have a proper setup.py

```
$ ba-dev -e 'social-analyzer --cli --username "johndoe" --metadata --extract --trim' -p social-analyzer-0.21-1-any.pkg.tar.zst                                                                                            ...                                                                                                                                                                                                       
Package social-analyzer-0.21-1-any.pkg.tar.zst installed correctly! Testing it now...                                                                                                                                                        
sh: line 1: social-analyzer: command not found

$ ba-dev -e 'bash' -p social-analyzer-0.21-1-any.pkg.tar.zst
...
Package social-analyzer-0.21-1-any.pkg.tar.zst installed correctly! Testing it now...                                                                                                                                                        
[root@blackarch /]# social_analyzer                                                                                                                                                                                                          
Traceback (most recent call last):
  File "/usr/bin/social_analyzer", line 33, in <module>
    sys.exit(load_entry_point('social-analyzer==0.21', 'console_scripts', 'social_analyzer')())
  File "/usr/bin/social_analyzer", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'social_analyzer'
[root@blackarch /]# ls /usr/lib/python3.9/site-packages/social-analyzer/
__main__.py  __pycache__
```

They also doesn't have a proper binary:

https://github.com/qeeqbox/social-analyzer/blob/952c0f7992d05db458d4c251649bc90da89f6446/setup.py#L9-L24

using only `entry_points` but no bin script consuming the API eg. `scripts=['bin/social-analyzer']`. `app.py` [is the CLI script](https://github.com/qeeqbox/social-analyzer#install-and-run-as-python-cli-windows-linux-macos-raspberry-pi) but `scripts=["app.py"]` doesn't work. It doesn't have a proper python module structure either so so git clone + python setup.py build no working either.

It's still possible to do a [jointscript](https://github.com/BlackArch/blackarch-pkgbuilds/blob/master/PKGBUILD-generic-jointscript)  with or `python3 app.py` in the wrapper but it would be better if upstream would have a proper packaging.