### PR TITLE
pyaxmlparser: a new tool + a tool dependency

### DIFF
--- a/packages/PKGBUILD
+++ b/packages/PKGBUILD
@@ -1,0 +1,41 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-pyaxmlparser
+_pkgname=pyaxmlparser
+pkgver=v0.3.26.r2.g447fd44
+pkgrel=1
+pkgdesc='A simple parser to parse Android XML file.'
+arch=('any')
+groups=('blackarch' 'blackarch-scanners')
+url='https://github.com/appknox/pyaxmlparser'
+license=('Apache2')
+depends=('python' 'python-lxml' 'python-click' 'python-asn1crypto' 'python-pytest' 'flake8' 'python-coverage')
+makedepends=('git' 'python-setuptools')
+source=("git+https://github.com/appknox/$_pkgname.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $_pkgname
+
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+  cd $_pkgname
+
+  python setup.py build
+}
+
+package() {
+  cd $_pkgname
+
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+
+  install -dm 755 "$pkgdir/usr/share/$_pkgname"
+
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$_pkgname/LICENSE"
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$_pkgname/" *.rst *.in
+
+}
+

--- a/packages/PKGBUILD
+++ b/packages/PKGBUILD
@@ -32,8 +32,6 @@ package() {
 
   python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
 
-  install -dm 755 "$pkgdir/usr/share/$_pkgname"
-
   install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$_pkgname/LICENSE"
   install -Dm 644 -t "$pkgdir/usr/share/doc/$_pkgname/" *.rst *.in
 


### PR DESCRIPTION
note: package "python-coverage" requires "pacman -Syy" to be installed 