### PR TITLE
cloudsploit: fix: Allow arguments to be parsed

### DIFF
--- a/packages/cloudsploit/PKGBUILD
+++ b/packages/cloudsploit/PKGBUILD
@@ -41,7 +41,7 @@ package() {
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
 cd /usr/share/$pkgname
-exec node index.js "$@"
+exec node index.js "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"

--- a/packages/cloudsploit/PKGBUILD
+++ b/packages/cloudsploit/PKGBUILD
@@ -41,7 +41,7 @@ package() {
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
 cd /usr/share/$pkgname
-exec node index.js
+exec node index.js "$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"


### PR DESCRIPTION
Currently, arguments are not parsed to cloudsploit when run using the script
stored in /usr/bin.

This commit fixes that by parsing each argument that was sent to the script to
cloudsploit