### PR TITLE
Add redress

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,1 +1,2 @@
 github-dorks
+redress

--- a/packages/redress/PKGBUILD
+++ b/packages/redress/PKGBUILD
@@ -1,0 +1,41 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=redress
+pkgver=v0.8.0.alpha4.r0.g94fd0a9
+pkgrel=1
+pkgdesc="A tool for analyzing stripped Go binaries"
+arch=('x86_64' 'aarch64')
+groups=('blackarch' 'blackarch-binary' 'blackarch-reversing')
+url="https://github.com/goretk/redress"
+license=('AGPL')
+makedepends=('git' 'go')
+source=("git+https://github.com/goretk/$pkgname.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+  cd $pkgname
+
+  GOPATH="$srcdir" go mod download
+  GOPATH="$srcdir" go build \
+    -trimpath \
+    -buildmode=pie \
+    -mod=readonly \
+    -modcacherw \
+    -ldflags="-s -w -X main.redressVersion=$pkgver" \
+    -o $pkgname .
+}
+
+package() {
+  cd $pkgname
+
+  install -Dm 755 $pkgname "$pkgdir/usr/bin/$pkgname"
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+}
+


### PR DESCRIPTION
https://github.com/goretk/redress

>The redress software is a tool for analyzing stripped Go binaries compiled with the Go compiler. It extracts data from the binary and uses it to reconstruct symbols and performs analysis.

Redress is useful as a standalone binary, but it can also be executed from within radare2. That's when redress truly shines.

>It will extract all the functions and methods and construct symbol flags for them. It will also extract the types in the binary. It will mark the corresponding `_type` with this flag to make analysis easier. By doing this, it highlights which actual type is being allocated on the heap for easier analysis.