### PR TITLE
proxmark3 : initial commit

### DIFF
--- a/packages/proxmark3/PKGBUILD
+++ b/packages/proxmark3/PKGBUILD
@@ -1,0 +1,34 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=proxmark3
+pkgver=v4.13441.r968.gbac58d2a6
+pkgrel=1
+pkgdesc='A general purpose RFID tool for Proxmark3 hardware.'
+arch=('x86_64' 'aarch64')
+groups=('blackarch' 'blackarch-misc')
+url='https://github.com/rfidresearchgroup/proxmark3'
+license=('GPL2')
+depends=('readline' 'bzip2' 'arm-none-eabi-gcc' 'arm-none-eabi-newlib' 'qt5-base' 'bluez')
+makedepends=('git')
+source=("git+https://github.com/rfidresearchgroup/$pkgname.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+ cd $pkgname
+
+ make
+}
+
+package() {
+  cd $pkgname
+
+  make DESTDIR="$pkgdir" PREFIX=/usr install
+}
+


### PR DESCRIPTION
closes #3191.
i had to add `PREFIX=/usr` because without it the installation process will raise an `permission denied` error while copying binaries.