### PR TITLE
rustcat: Update binname

### DIFF
--- a/packages/rustcat/PKGBUILD
+++ b/packages/rustcat/PKGBUILD
@@ -2,8 +2,8 @@
 # See COPYING for license details.
 
 pkgname=rustcat
-_binname=rc
-pkgver=v1.2.0.r6.gc34bbd6
+_binname=rcat
+pkgver=v2.0.0.r0.g7a7e074
 pkgrel=1
 pkgdesc='A Modern Port Listener & Reverse Shell.'
 groups=('blackarch' 'blackarch-networking')
@@ -29,6 +29,6 @@ build() {
 package() {
   cd $pkgname
 
-  install -Dm 755 "target/release/$_binname" "$pkgdir/usr/bin/$pkgname"
+  install -Dm 755 "target/release/$_binname" "$pkgdir/usr/bin/$_binname"
 }
 


### PR DESCRIPTION
Changed from rc to rcat to prevent clash with /sbin/rc on openrc systems. 