### PR TITLE
Fix `gitdump` caller script

### DIFF
--- a/packages/gitdump/PKGBUILD
+++ b/packages/gitdump/PKGBUILD
@@ -34,8 +34,7 @@ package() {
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
-cd /usr/share/$pkgname
-exec python git-dump.py "\$@"
+exec python /usr/share/$pkgname/git-dump.py "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"


### PR DESCRIPTION
The caller script `cd`'d into the install dir, while `git-dump.py` has its output directory hard coded as `outputFolder = "output/"`. So the output would be written to the install dir. This was bad practice, confusing, and required root to run the tool.