### PR TITLE
rmiscout: 1st commit

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+rmiscout

--- a/packages/rmiscout/PKGBUILD
+++ b/packages/rmiscout/PKGBUILD
@@ -1,0 +1,30 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=rmiscout
+pkgver=1.4
+pkgrel=1
+pkgdesc='Enumerate Java RMI functions and exploit RMI parameter unmarshalling vulnerabilities.'
+arch=('any')
+groups=('blackarch' 'blackarch-networking' 'blackarch-exploitation')
+url='https://github.com/BishopFox/rmiscout'
+license=('MIT')
+depends=('jre8-openjdk-headless')
+source=("https://github.com/BishopFox/rmiscout/releases/download/v1.4/$pkgname-$pkgver-SNAPSHOT-all.jar")
+sha512sums=('e9ac9d1be6321db36cad188da6fc1c998ddc6b3a2f6123f54fc80308f47a1d45d0c75a16564c6ec311052ad438ba04ef7748868d75c6a2b01219cb64f9f4d565')
+
+package() {
+  install -dm 755 "$pkgdir/usr/bin"
+
+  install -Dm 755 "$pkgname-$pkgver-SNAPSHOT-all.jar" "$pkgdir/usr/share/$pkgname/$pkgname-$pkgver.jar"
+
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+  cat > "$pkgdir/usr/bin/$pkgname" << EOF
+#!/bin/sh
+exec java -jar /usr/share/$pkgname/$pkgname-$pkgver.jar "\$@"
+EOF
+
+  chmod +x "$pkgdir/usr/bin/$pkgname"
+}
+


### PR DESCRIPTION
fix #3266

PS: keep `jre8-openjdk-headless` and not `java-environment` because it works properly only under java 1.8