### PR TITLE
nettacker: fix typo in group name

### DIFF
--- a/packages/nettacker/PKGBUILD
+++ b/packages/nettacker/PKGBUILD
@@ -6,7 +6,7 @@ pkgver=0.0.3.4.r86.g0d6a907
 pkgrel=1
 pkgdesc='Automated Penetration Testing Framework.'
 arch=('any')
-groups=('blackarch' 'blackarch-automation' 'blackarch-scanners'
+groups=('blackarch' 'blackarch-automation' 'blackarch-scanner'
         'blackarch-recon')
 url='https://github.com/OWASP/Nettacker'
 license=('Apache')


### PR DESCRIPTION
Nettacker is the only package in `blackarch-scanners` group. I think it was supposed to be in `blackarch-scanner` instead.