### PR TITLE
bundle: remove deprecated path option

### DIFF
--- a/packages/automato/automato.install
+++ b/packages/automato/automato.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/automato
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/beef/beef.install
+++ b/packages/beef/beef.install
@@ -3,7 +3,8 @@ post_upgrade() {
   cd /usr/share/beef
   rm -f Gemfile.lock
   /usr/bin/bundle config build.nokogiri --use-system-libraries
-  /usr/bin/bundle install --path vendor/bundle
+  /usr/bin/bundle config set --local path 'vendor/bundle'
+  bundle install
   /usr/bin/bundle update
   rm -f Gemfile.lock
 }

--- a/packages/binproxy/binproxy.install
+++ b/packages/binproxy/binproxy.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/binproxy
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/catphish/catphish.install
+++ b/packages/catphish/catphish.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/catphish
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/cewl/cewl.install
+++ b/packages/cewl/cewl.install
@@ -2,7 +2,8 @@ post_install() {
   set -e
   cd /usr/share/cewl
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/ciphr/ciphr.install
+++ b/packages/ciphr/ciphr.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/ciphr
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/cmsscanner/cmsscanner.install
+++ b/packages/cmsscanner/cmsscanner.install
@@ -3,12 +3,14 @@ post_install() {
 
   cd /usr/share/cmsscanner
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
   bundle update
 
   cd /usr/share/cmsscanner/example
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
   bundle update
 }
 

--- a/packages/cve-api/cve-api.install
+++ b/packages/cve-api/cve-api.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/cve-api
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/dawnscanner/dawnscanner.install
+++ b/packages/dawnscanner/dawnscanner.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/dawnscanner
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/fingerprinter/fingerprinter.install
+++ b/packages/fingerprinter/fingerprinter.install
@@ -2,7 +2,8 @@ post_install() {
   cd /usr/share/fingerprinter
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/hoper/hoper.install
+++ b/packages/hoper/hoper.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/hoper
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/joomlavs/joomlavs.install
+++ b/packages/joomlavs/joomlavs.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/joomlavs
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/kautilya/kautilya.install
+++ b/packages/kautilya/kautilya.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/kautilya
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/sitediff/sitediff.install
+++ b/packages/sitediff/sitediff.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/sitediff
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/smbexec/smbexec.install
+++ b/packages/smbexec/smbexec.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/smbexec
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/ssrf-proxy/ssrf-proxy.install
+++ b/packages/ssrf-proxy/ssrf-proxy.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/ssrf-proxy
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/tlspretense/tlspretense.install
+++ b/packages/tlspretense/tlspretense.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/tlspretense
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/twofi/twofi.install
+++ b/packages/twofi/twofi.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/twofi
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/vsaudit/vsaudit.install
+++ b/packages/vsaudit/vsaudit.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/vsaudit
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
   rm -f Gemfile.lock
 }
 

--- a/packages/whatweb/whatweb.install
+++ b/packages/whatweb/whatweb.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/whatweb
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
   chmod 644 Gemfile.lock
 }
 

--- a/packages/whitewidow/whitewidow.install
+++ b/packages/whitewidow/whitewidow.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/whitewidow
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/wordpress-exploit-framework/wordpress-exploit-framework.install
+++ b/packages/wordpress-exploit-framework/wordpress-exploit-framework.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/wordpress-exploit-framework
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
   bundle update
 }
 

--- a/packages/wpbrute-rpc/wpbrute-rpc.install
+++ b/packages/wpbrute-rpc/wpbrute-rpc.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/wpbrute-rpc
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/xspear/xspear.install
+++ b/packages/xspear/xspear.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/xspear
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {

--- a/packages/yasuo/yasuo.install
+++ b/packages/yasuo/yasuo.install
@@ -3,7 +3,8 @@ post_install() {
   cd /usr/share/yasuo
   rm -f Gemfile.lock
   bundle config build.nokogiri --use-system-libraries
-  bundle install --path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
+  bundle install
 }
 
 post_upgrade() {


### PR DESCRIPTION
no need to pkgrel++ and release, it can wait next update, it's just to remove teh deprecated flag and avoid the warning