### PR TITLE
responder: fix deps

### DIFF
--- a/packages/responder/PKGBUILD
+++ b/packages/responder/PKGBUILD
@@ -3,14 +3,14 @@
 
 pkgname=responder
 pkgver=437.b147229
-pkgrel=1
+pkgrel=2
 epoch=3
 pkgdesc='A LLMNR and NBT-NS poisoner, with built-in HTTP/SMB/MSSQL/FTP/LDAP rogue authentication server supporting NTLMv1/NTLMv2/LMv2 (multirelay version).'
 groups=('blackarch' 'blackarch-scanner' 'blackarch-fuzzer' 'blackarch-spoof'
         'blackarch-networking')
 arch=('any')
 depends=('impacket' 'mingw-w64-gcc' 'python' 'python-cryptography'
-         'python-pycryptodome')
+         'python-pycryptodome' 'python-netifaces')
 makedepends=('git')
 url='https://github.com/lgandx/Responder'
 license=('GPL3')


### PR DESCRIPTION
Fix this:

```
$ sudo responder --help                                                                                                                                                                                                                     
You need to install python-netifaces or run Responder with python3...                                                                                                                                                                       
Try "apt-get install python-netifaces" or "pip install netifaces"
```

Workaround: `sudo pacman -S python-netifaces --asdeps`