### PR TITLE
bloodhound: multi-fix

### DIFF
--- a/packages/bloodhound/PKGBUILD
+++ b/packages/bloodhound/PKGBUILD
@@ -3,7 +3,7 @@
 
 _npmname=BloodHound
 pkgname=bloodhound
-pkgver=1235.2689a5c
+pkgver=1316.5ac7a21
 pkgrel=1
 pkgdesc='Six Degrees of Domain Admin'
 groups=('blackarch' 'blackarch-recon' 'blackarch-windows')
@@ -11,7 +11,7 @@ arch=('x86_64' 'aarch64')
 url='https://github.com/BloodHoundAD/BloodHound'
 license=('GPL3')
 depends=('nodejs' 'neo4j-community' 'alsa-lib' 'gtk3' 'libxss' 'gconf' 'nss'
-         'libxtst' 'jre8-openjdk-headless')
+         'libxtst' 'jre11-openjdk-headless')
 makedepends=('git' 'nodejs-electron-packager' 'npm' 'unzip')
 optdepends=('python: for some scripts' 'powershell: for PowerShell ingestion')
 source=('git+https://github.com/BloodHoundAD/BloodHound.git'
@@ -69,9 +69,7 @@ package() {
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
 cd /usr/share/$pkgname/$_path
-export NEO4J_HOME=/usr/share/java/neo4j
-export JAVA_HOME=/usr/lib/jvm/java-8-openjdk/jre
-exec neo4j console &
+echo "To start neo4j: systemctl start neo4j"
 exec ./BloodHound --no-sandbox "\$@"
 EOF
 


### PR DESCRIPTION
- fix upload data issue by passing from 4.0.3 to 4.1.0
- neo4j 4.x requires Java 11 rather than 8 (cf. https://neo4j.com/docs/operations-manual/current/installation/requirements/#deployment-requirements-java)
- use neo4j service

TODO :

add `/etc/systemd/system/neo4j.service.d/override.conf`

```ini
[Service]
Environment=JAVA_HOME=/usr/lib/jvm/java-11-openjdk
```