### PR TITLE
autorecon: Fixes current PATH

### DIFF
--- a/packages/autorecon/PKGBUILD
+++ b/packages/autorecon/PKGBUILD
@@ -47,8 +47,7 @@ package() {
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
-cd /usr/share/$pkgname
-exec python $pkgname.py "\$@"
+exec python /usr/share/$pkgname/$pkgname.py "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"


### PR DESCRIPTION
By default autorecon outputs to ./results, which we expect to be the current directory