### PR TITLE
ikeforce: fix deps

### DIFF
--- a/packages/ikeforce/PKGBUILD
+++ b/packages/ikeforce/PKGBUILD
@@ -3,13 +3,13 @@
 
 pkgname=ikeforce
 pkgver=30.575af15
-pkgrel=1
+pkgrel=2
 pkgdesc='A command line IPSEC VPN brute forcing tool for Linux that allows group name/ID enumeration and XAUTH brute forcing capabilities.'
 groups=('blackarch' 'blackarch-cracker')
 arch=('any')
 url='https://github.com/SpiderLabs/ikeforce'
 license=('custom:unknown')
-depends=('python2' 'python2-pyopenssl' 'python2-pycryptodomex' 'python2-pyip')
+depends=('python2' 'python2-pyopenssl' 'python2-pycryptodome' 'python2-pycryptodomex' 'python2-pyip')
 makedepends=('git')
 source=("git+https://github.com/SpiderLabs/$pkgname.git")
 sha512sums=('SKIP')


### PR DESCRIPTION
Fix this issue:

```
$ ikeforce 10.0.0.1
/usr/lib/python2.7/site-packages/OpenSSL/crypto.py:14: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography import utils, x509
Traceback (most recent call last):
  File "ikeforce.py", line 13, in <module>
    import ikehandler
  File "/usr/share/ikeforce/ikehandler.py", line 10, in <module>
    import ikecrypto
  File "/usr/share/ikeforce/ikecrypto.py", line 13, in <module>
    from Crypto.Cipher import *
ImportError: No module named Crypto.Cipher
```