### PR TITLE
hqlmap: fix path

### DIFF
--- a/packages/hqlmap/PKGBUILD
+++ b/packages/hqlmap/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=hqlmap
 pkgver=38.bb6ab46
-pkgrel=3
+pkgrel=4
 pkgdesc='A tool to exploit HQL Injections.'
 arch=('any')
 groups=('blackarch' 'blackarch-exploitation')
@@ -35,7 +35,8 @@ package() {
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
-exec python2 /usr/share/$pkgname/$pkgname.py "\$@"
+cd /usr/share/$pkgname
+exec python2 $pkgname.py "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"


### PR DESCRIPTION
when using `--tables`

```
Traceback (most recent call last):                                                                                                                                                                                                          
  File "/usr/share/hqlmap/hqlmap.py", line 445, in <module>                                                                                                                                                                                 
    find_tables(opts.file_table)                                                                                                                                                                                                            
  File "/usr/share/hqlmap/hqlmap.py", line 121, in find_tables                                                                                                                                                                              
    with open(file_table) as f:                                                                                                                                                                                                             
IOError: [Errno 2] No such file or directory: 'db/tables.db'                                                                                                                                                                                
```