### PR TITLE
responder: fix package.

### DIFF
--- a/packages/responder/PKGBUILD
+++ b/packages/responder/PKGBUILD
@@ -73,23 +73,14 @@ EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname-report"
 
-  # Responder DHCP
-  cat > "$pkgdir/usr/bin/$pkgname-dhcp" << EOF
+  # Responder DNSUpdate
+  cat > "$pkgdir/usr/bin/$pkgname-dnsupdate" << EOF
 #!/bin/sh
 cd /usr/share/$pkgname/tools
-exec python DHCP.py "\$@"
+exec python DNSUpdate.py "\$@"
 EOF
 
-  chmod +x "$pkgdir/usr/bin/$pkgname-dhcp"
-
-  # Responder DHCP_Auto
-  cat > "$pkgdir/usr/bin/$pkgname-dhcp-auto" << EOF
-#!/bin/sh
-cd /usr/share/$pkgname/tools
-exec bash DHCP_Auto.sh "\$@"
-EOF
-
-  chmod +x "$pkgdir/usr/bin/$pkgname-dhcp-auto"
+  chmod +x "$pkgdir/usr/bin/$pkgname-dnsupdate"
 
   # Responder FindSQLSrv
   cat > "$pkgdir/usr/bin/$pkgname-findsqlsrv" << EOF


### PR DESCRIPTION
Hi Team!

I removed the **responder-dhcp** and **responder-dhcp-auto** as they are now changed in the Responder repo (they are now modules)

Hope everything is clean :)

Cheers