### PR TITLE
lfimap: update source.

### DIFF
--- a/packages/lfimap/PKGBUILD
+++ b/packages/lfimap/PKGBUILD
@@ -2,16 +2,16 @@
 # See COPYING for license details.
 
 pkgname=lfimap
-pkgver=7.99877ec
+pkgver=115.bceb90c
 pkgrel=1
 groups=('blackarch' 'blackarch-webapp' 'blackarch-fuzzer')
-pkgdesc='This script is used to take the highest beneficts of the local file include vulnerability in a webserver.'
+pkgdesc='Local file inclusion discovery and exploitation tool.'
 arch=('any')
-url='https://github.com/aepereyra/lfimap/'
-license=('unknown')
-depends=('python2')
+url='https://github.com/hansmach1ne/lfimap'
+license=('Apache')
+depends=('python' 'python-requests' 'python-urllib3' 'python-pybase64')
 makedepends=('git')
-source=("git+https://github.com/aepereyra/$pkgname.git")
+source=("git+https://github.com/hansmach1ne/$pkgname.git")
 sha512sums=('SKIP')
 
 pkgver() {
@@ -26,16 +26,17 @@ package() {
   install -dm 755 "$pkgdir/usr/bin"
   install -dm 755 "$pkgdir/usr/share/$pkgname"
 
-  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
-  rm README
+  rm README.md LICENSE requirements.txt
 
   cp -a * "$pkgdir/usr/share/$pkgname/"
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
 cd /usr/share/$pkgname
-exec python2 $pkgname.py "\$@"
+exec python $pkgname.py "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"


### PR DESCRIPTION
Hi there!

I changed the source for lfimap to something correct (python3 + more features added).
The new source repo is located here: https://github.com/hansmach1ne/lfimap

**It requires python-pybase64 as dep. This is why I created the PKGBUILD for the lib before ;)**

Hope it's ok!

Cheers!