### PR TITLE
airgeddon: version bump

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+airgeddon

--- a/packages/airgeddon/PKGBUILD
+++ b/packages/airgeddon/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=airgeddon
-pkgver=v11.0.r0.g3fb4312
+pkgver=v11.01.r0.gc58bb8f
 pkgrel=1
 epoch=1
 pkgdesc='Multi-use bash script for Linux systems to audit wireless networks.'
@@ -17,7 +17,7 @@ optdepends=('hashcat' 'crunch' 'mdk4' 'reaver' 'beef' 'hostapd' 'lighttpd'
             'pixiewps' 'dhcp' 'curl' 'ethtool' 'rfkill' 'wget' 'usbutils'
             'xorg-xdpyinfo' 'ccze' 'xorg-xset' 'asleap' 'john' 'hostapd-wpe'
             'nftables' 'openssl' 'mdk3' 'hcxtools' 'hcxdumptool' 'wireshark-cli')
-makedepends=('git' 'coreutils' 'binutils')
+makedepends=('git' 'coreutils')
 source=("git+https://github.com/v1s1t0r1sh3r3/$pkgname.git")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
also remove binutils makedepends since it's base-devel