### PR TITLE
neo-regeorg: enhance packaging

### DIFF
--- a/packages/neo-regeorg/PKGBUILD
+++ b/packages/neo-regeorg/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=neo-regeorg
-pkgver=160.93ea6a9
+pkgver=v3.8.0.r0.g93ea6a9
 pkgrel=1
 pkgdesc='Improved version of reGeorg, HTTP tunneling pivot tool'
 arch=('any')
@@ -17,7 +17,7 @@ sha512sums=('SKIP')
 pkgver() {
   cd $pkgname
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 package() {
@@ -27,7 +27,6 @@ package() {
 
   install -Dm 755 neoreg.py "$pkgdir/usr/bin/$pkgname"
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README-en.md
-  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
   cp -a templates/ "$pkgdir/usr/share/$pkgname/"
 }


### PR DESCRIPTION
- pkgver: use git tag (no need for epoc)
- GPL3 is in licenses package cf. https://wiki.archlinux.org/title/PKGBUILD#license