### PR TITLE
responder: enhanced packaging

### DIFF
--- a/packages/responder/PKGBUILD
+++ b/packages/responder/PKGBUILD
@@ -2,8 +2,8 @@
 # See COPYING for license details.
 
 pkgname=responder
-pkgver=443.fd9bcf7
-pkgrel=2
+pkgver=v3.1.2.0.r0.gfd9bcf7
+pkgrel=1
 epoch=3
 pkgdesc='A LLMNR and NBT-NS poisoner, with built-in HTTP/SMB/MSSQL/FTP/LDAP rogue authentication server supporting NTLMv1/NTLMv2/LMv2 (multirelay version).'
 groups=('blackarch' 'blackarch-scanner' 'blackarch-fuzzer' 'blackarch-spoof'
@@ -21,7 +21,7 @@ install="$pkgname.install"
 pkgver() {
   cd $pkgname
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 build() {
@@ -40,7 +40,6 @@ package() {
   install -dm 755 "$pkgdir/usr/share/$pkgname"
 
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname" README.md
-  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
   rm README.md LICENSE *.sh
 


### PR DESCRIPTION
- pkgver: use git tag
- GPL3 is in licenses package cf. https://wiki.archlinux.org/title/PKGBUILD#license