### PR TITLE
jackdaw: update dependencies

### DIFF
--- a/packages/jackdaw/PKGBUILD
+++ b/packages/jackdaw/PKGBUILD
@@ -2,8 +2,9 @@
 # See COPYING for license details.
 
 pkgname=jackdaw
-pkgver=396.4c06e2b
+pkgver=0.3.1.r57.g4c06e2b
 pkgrel=1
+epoch=1
 pkgdesc='Collect all information in your domain, show you graphs on how domain objects interact with each-other and how to exploit these interactions'
 arch=('any')
 groups=('blackarch' 'blackarch-recon' 'blackarch-windows')
@@ -12,8 +13,10 @@ license=('custom:unknown')
 depends=('python' 'python-aiosmb' 'python-msldap' 'python-sqlalchemy'
          'python-tqdm' 'python-networkx' 'python-connexion'
          'python-flask-sqlalchemy' 'python-websockets'
-         'python-swagger-ui-bundle' 'python-werkzeug' 'python-bidict'
-         'python-colorama' 'python-winacl' 'python-pypykatz')
+         'python-swagger-ui-bundle' 'python-werkzeug' 'python-winacl'
+         'python-itsdangerous' 'python-flask' 'python-jinja' 'python-igraph'
+         'python-aiosqlite')
+# incompatible dependencies : python-itsdangerous, python-werkzeug, python-flask, python-jinja
 makedepends=('git')
 source=("git+https://github.com/skelsec/$pkgname.git")
 sha512sums=('SKIP')
@@ -22,7 +25,7 @@ install="$pkgname.install"
 pkgver() {
   cd $pkgname
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 package() {


### PR DESCRIPTION
AL version of python-itsdangerous, python-werkzeug, python-flask, python-jinja are not compatible with those asked https://github.com/skelsec/jackdaw/blob/master/setup.py

skelsec is saying me it's a nightmare to maintain and update as the dependencies are changing too fast

so I suggest porting this package to a virtualenv