### PR TITLE
angrop: fix building

### DIFF
--- a/packages/angrop/PKGBUILD
+++ b/packages/angrop/PKGBUILD
@@ -3,15 +3,14 @@
 
 pkgname=angrop
 pkgver=210.d685b68
-pkgrel=1
+pkgrel=2
 pkgdesc='A rop gadget finder and chain builder.'
 groups=('blackarch' 'blackarch-exploitation')
 arch=('any')
 url='https://github.com/salls/angrop'
 license=('BSD')
-depends=('python' 'python-progressbar' 'python-pyvex' 'python-claripy'
-         'python-simuvex' 'angr')
-makedepends=('git' 'python-setuptools')
+depends=('python' 'angr' 'python-tqdm')
+makedepends=('git' 'python-build' 'python-pip')
 source=("git+https://github.com/salls/$pkgname.git")
 sha512sums=('SKIP')
 
@@ -24,13 +23,23 @@ pkgver() {
 build() {
   cd $pkgname
 
-  python setup.py build
+  python -m build --wheel --outdir="$startdir/dist"
 }
 
 package() {
   cd $pkgname
 
-  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+  pip install --verbose \
+              --disable-pip-version-check \
+              --no-warn-script-location \
+              --ignore-installed \
+              --no-compile \
+              --no-deps \
+              --root="$pkgdir" \
+              --prefix=/usr \
+              --no-index \
+              --find-links="file://$startdir/dist" \
+              "$pkgname"
 
   install -Dm 644 -t "$pkgdir/usr/share/$pkgname/tests" tests/*
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md


### PR DESCRIPTION
upstream changed from setuptools to PEP517 https://github.com/angr/angrop/commit/928ed1ec52d7aa53022d6c07591a60594298789a

I have added it to https://github.com/BlackArch/blackarch-pkgbuilds/commit/4ae2d3f269ad76eda2d78f3ea172e9bba6fd1835

Thank @ph20 for the work with python-build