### PR TITLE
avaloniailspy: better pkgver

### DIFF
--- a/packages/avaloniailspy/PKGBUILD
+++ b/packages/avaloniailspy/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=avaloniailspy
-pkgver=216.113ef11
+pkgver=v7.2.rc.r0.g113ef11
 pkgrel=1
 groups=('blackarch' 'blackarch-decompiler')
 pkgdesc='.NET Decompiler (port of ILSpy)'
@@ -17,7 +17,7 @@ sha512sums=('SKIP')
 pkgver() {
   cd $pkgname
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 prepare() {


### PR DESCRIPTION
no need for epoch or pkgrel++

```
irb(main):001:0> ['216.113ef11','v7.2.rc.r0.g113ef11'].sort
=> ["216.113ef11", "v7.2.rc.r0.g113ef11"]
```