### PR TITLE
avml: better pkgver

### DIFF
--- a/packages/avml/PKGBUILD
+++ b/packages/avml/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=avml
-pkgver=93.155f084
+pkgver=v0.6.1.r11.g155f084
 pkgrel=1
 pkgdesc='A portable volatile memory acquisition tool for Linux.'
 arch=('x86_64' 'aarch64')
@@ -17,7 +17,7 @@ sha512sums=('SKIP')
 pkgver() {
   cd $pkgname
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 build() {


### PR DESCRIPTION
no need for epoch or pkgrel++

```
irb(main):001:0> ['93.155f084','v0.6.1.r11.g155f084'].sort
=> ["93.155f084", "v0.6.1.r11.g155f084"]
```