### PR TITLE
dependency-check: fix groups

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+dependency-check

--- a/packages/dependency-check/PKGBUILD
+++ b/packages/dependency-check/PKGBUILD
@@ -3,9 +3,9 @@
 
 pkgname=dependency-check
 pkgver=6.5.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A tool that attempts to detect publicly disclosed vulnerabilities contained within a project's dependencies."
-groups=('blackarch' 'blackarch-defensive', 'blackarch-scanner')
+groups=('blackarch' 'blackarch-defensive' 'blackarch-scanner')
 arch=('any')
 url='https://github.com/jeremylong/DependencyCheck/releases/'
 license=('APACHE')


### PR DESCRIPTION
This was wrongly creating an `defensive,`category. Replace https://github.com/BlackArch/blackarch-site/pull/151/files. It's better to fix the source.

https://github.com/BlackArch/blackarch-site/pull/151/files