### PR TITLE
IVRE: update source repos, remove unused dep

### DIFF
--- a/packages/ivre/PKGBUILD
+++ b/packages/ivre/PKGBUILD
@@ -3,15 +3,15 @@
 
 pkgbase=ivre
 pkgname=('ivre' 'ivre-web' 'ivre-docs' 'python-ivre')
-pkgver=0.9.17.dev302
+pkgver=0.9.17.dev344
 pkgrel=1
 groups=('blackarch' 'blackarch-recon' 'blackarch-networking')
 pkgdesc='Network recon framework based on Nmap, Masscan, Zeek (Bro), Argus, Netflow,...'
 arch=('any')
 url='https://ivre.rocks/'
 license=('GPL3')
-makedepends=('git' 'python2-setuptools' 'python-setuptools')
-source=("git+https://github.com/cea-sec/$pkgname.git")
+makedepends=('git' 'python-setuptools')
+source=("git+https://github.com/ivre/$pkgname.git")
 sha512sums=('SKIP')
 
 pkgver() {
@@ -125,6 +125,8 @@ package_python-ivre() {
   cd $pkgbase
 
   python setup.py install --root="$pkgdir" --prefix=/usr --optimize=1
+  echo -en "-blackarch-${pkgrel}" >> "${pkgdir}/usr/lib/"python*"/site-packages/ivre/VERSION"
+  sed -ri 's#(VERSION = .*)(['\''"])$#\1-blackarch-'"${pkgrel}"'\2#' "${pkgdir}/usr/lib/"python*"/site-packages/ivre/__init__.py"
 
   rm -r "$pkgdir/usr/bin" "$pkgdir/usr/share" "$pkgdir/etc/bash_completion.d"
 


### PR DESCRIPTION
This PR:
* (updates the current dev version)
* removes the unneeded dependency to python2-setuptools (Python 2 is no longer supported by IVRE)
* updates the repository URL (the project has moved from cea-sec org to its own org; the redirection works but it's better to use the correct URL anyway)
* adds a `-blackarch-1` to the internal version number (makes debugging easier)