### PR TITLE
New mirror in Taiwan

### DIFF
--- a/mirror/mirror.lst
+++ b/mirror/mirror.lst
@@ -57,6 +57,8 @@ TR|http://ftp.linux.org.tr/blackarch/$repo/os/$arch|linux.org.tr
 TR|https://ftp.linux.org.tr/blackarch/$repo/os/$arch|linux.org.tr
 TW|http://blackarch.cs.nctu.edu.tw/$repo/os/$arch|pichuang
 TW|https://blackarch.cs.nctu.edu.tw/$repo/os/$arch|pichuang
+TW|http://mirror.archlinux.tw/BlackArch/$repo/os/$arch|PingWu
+TW|https://mirror.archlinux.tw/BlackArch/$repo/os/$arch|PingWu
 UK|http://mirrors.gethosted.online/blackarch/blackarch/$repo/os/$arch|gethosted
 UK|https://mirrors.gethosted.online/blackarch/blackarch/$repo/os/$arch|gethosted
 US|http://distro.ibiblio.org/blackarch/$repo/os/$arch|Ibiblio


### PR DESCRIPTION
Mirror domain name: mirror.archlinux.tw
Mirror IP: 125.228.118.224
Geographical location of the mirror (country): Taiwan
URLs for supported access methods (http(s), rsync) (no ftp):
* http://mirror.archlinux.tw/BlackArch/
* https://mirror.archlinux.tw/BlackArch/
* rsync://mirror.archlinux.tw/blackarch/

Mirror's available bandwidth: 250 Mbit/s
An administrative contact email: PingNote.Wu@gmail.com
An alternative administrative contact email: archlinux-tw-general@googlegroups.com