### PR TITLE
Update whispers to 2.1.0

### DIFF
--- a/packages/whispers/PKGBUILD
+++ b/packages/whispers/PKGBUILD
@@ -2,17 +2,17 @@
 # See COPYING for license details.
 
 pkgname=whispers
-pkgver=1.5.3.r13.g5832bf7
+pkgver=2.1.0.r01
 pkgrel=2
-pkgdesc='Identify hardcoded secrets and dangerous behaviours.'
+pkgdesc='Identify hardcoded secrets in static structured text.'
 arch=('any')
 groups=('blackarch' 'blackarch-code-audit')
-url='https://github.com/Skyscanner/whispers/'
-license=('Apache')
+url='https://github.com/adeptex/whispers/'
+license=('GPL-3.0')
 depends=('python' 'python-astroid' 'python-beautifulsoup4' 'python-jproperties'
-         'python-levenshtein' 'python-luhn' 'python-lxml' 'python-yaml')
+         'python-jellyfish' 'python-luhn' 'python-lxml' 'python-yaml')
 makedepends=('git' 'python-setuptools' 'python-pip')
-source=("git+https://github.com/Skyscanner/$pkgname.git")
+source=("git+https://github.com/adeptex/$pkgname.git")
 sha512sums=('SKIP')
 
 pkgver() {

--- a/packages/whispers/PKGBUILD
+++ b/packages/whispers/PKGBUILD
@@ -2,13 +2,13 @@
 # See COPYING for license details.
 
 pkgname=whispers
-pkgver=2.1.0.r01
+pkgver=2.1.0.r0.g8cdc6b1
 pkgrel=2
 pkgdesc='Identify hardcoded secrets in static structured text.'
 arch=('any')
 groups=('blackarch' 'blackarch-code-audit')
 url='https://github.com/adeptex/whispers/'
-license=('GPL-3.0')
+license=('GPL3')
 depends=('python' 'python-astroid' 'python-beautifulsoup4' 'python-jproperties'
          'python-jellyfish' 'python-luhn' 'python-lxml' 'python-yaml')
 makedepends=('git' 'python-setuptools' 'python-pip')


### PR DESCRIPTION
Hey there, I am the creator of whispers. I saw that awesomely it was included into BlackArch, and I thought I would contribute by updating it to the latest version. [Ownership changed](https://github.com/adeptex/whispers/blob/2.0.6/RELEASE_NOTES.md#dizzy-licensing-changes-dizzy) from Skyscanner to my personal account. In addition, Skyscanner's [version 1](https://github.com/Skyscanner/whispers/) is no longer maintained.

Let me know if you need any additional details. Thanks!