### PR TITLE
spiderpig-pdffuzzer: Update PKGBUILD

### DIFF
--- a/packages/spiderpig-pdffuzzer/PKGBUILD
+++ b/packages/spiderpig-pdffuzzer/PKGBUILD
@@ -11,7 +11,6 @@ arch=('any')
 license=('MIT')
 makedepends=('dos2unix')
 depends=('python2')
-source=("https://spiderpig-pdffuzzer.googlecode.com/files/$pkgname.tar.gz")
 source=("https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/spiderpig-pdffuzzer/spiderpig.tar.gz")
 sha512sums=('66427a54ff278bbeccee836d2acdb387fef8b8ddecf93ca7dfa742ad6293ec91b0ed0017247ad734e93bb0fb40b20d97226cb6edf75e43f2a9fcac5ccf0a0571')
 

--- a/packages/spiderpig-pdffuzzer/PKGBUILD
+++ b/packages/spiderpig-pdffuzzer/PKGBUILD
@@ -12,7 +12,8 @@ license=('MIT')
 makedepends=('dos2unix')
 depends=('python2')
 source=("https://spiderpig-pdffuzzer.googlecode.com/files/$pkgname.tar.gz")
-sha512sums=('9b21d7c9c962e15c5d8301c617f0fdbcd376ccff')
+source=("https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/spiderpig-pdffuzzer/spiderpig.tar.gz")
+sha512sums=('66427a54ff278bbeccee836d2acdb387fef8b8ddecf93ca7dfa742ad6293ec91b0ed0017247ad734e93bb0fb40b20d97226cb6edf75e43f2a9fcac5ccf0a0571')
 
 prepare() {
   cd spiderpig


### PR DESCRIPTION
The link in the source is not working when executing a ``makepkg`` command.