### PR TITLE
Change the mirror domain name: nctu -> nycu

### DIFF
--- a/mirror/mirror.lst
+++ b/mirror/mirror.lst
@@ -56,8 +56,8 @@ SG|http://mirror.sg.gs/blackarch/$repo/os/$arch|SG.GS
 SG|https://mirror.sg.gs/blackarch/$repo/os/$arch|SG.GS
 TR|http://ftp.linux.org.tr/blackarch/$repo/os/$arch|linux.org.tr
 TR|https://ftp.linux.org.tr/blackarch/$repo/os/$arch|linux.org.tr
-TW|http://blackarch.cs.nctu.edu.tw/$repo/os/$arch|pichuang
-TW|https://blackarch.cs.nctu.edu.tw/$repo/os/$arch|pichuang
+TW|http://blackarch.cs.nycu.edu.tw/$repo/os/$arch|NYCU CSIT
+TW|https://blackarch.cs.nycu.edu.tw/$repo/os/$arch|NYCU CSIT
 TW|http://mirror.archlinux.tw/BlackArch/$repo/os/$arch|PingWu
 TW|https://mirror.archlinux.tw/BlackArch/$repo/os/$arch|PingWu
 UK|http://mirrors.gethosted.online/blackarch/blackarch/$repo/os/$arch|gethosted


### PR DESCRIPTION
Hi,
we would like to change our mirror domain name and contact information due to our school being merged with NYMU into NYCU (National Yang Ming Chiao Tung University).

The following is our new information, and we also have enabled https support additionally:
Owner: NYCU CSIT
http: http://blackarch.cs.nycu.edu.tw
https: https://blackarch.cs.nycu.edu.tw
rsync (blackarch): rsync://blackarch.cs.nycu.edu.tw/blackarch/
Location: Asia Taiwan
Sponsor: Computer Center, Department of Computer Science, National Yang Ming Chiao Tung University
Sponsor URL: https://it.cs.nycu.edu.tw/
Email contact: mirror[at]linux.cs.nycu.edu.tw

Best regards,
Fan Chung,
Computer Center, Department of Computer Science,
National Yang Ming Chiao Tung University, Taiwan.
1001 University Road, Hsinchu, Taiwan 300, ROC.
