### PR TITLE
neo-regeorg: move the main script file to its dir

### DIFF
--- a/packages/neo-regeorg/PKGBUILD
+++ b/packages/neo-regeorg/PKGBUILD
@@ -24,11 +24,16 @@ pkgver() {
 package() {
   cd $pkgname
 
-  install -dm 755 "$pkgdir/usr/share/$pkgname"
+  install -dm 755 "$pkgdir/usr/bin"
+  cat > "$pkgdir/usr/bin/$pkgname" << EOF
+#!/bin/sh
+exec /usr/share/$pkgname/neoreg.py "\$@"
+EOF
+  chmod 755 "$pkgdir/usr/bin/$pkgname"
 
-  install -Dm 755 neoreg.py "$pkgdir/usr/bin/$pkgname"
+  install -dm 755 "$pkgdir/usr/share/$pkgname"
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README-en.md
 
-  cp -a templates/ "$pkgdir/usr/share/$pkgname/"
+  cp -a --no-preserve=ownership * "$pkgdir/usr/share/$pkgname/"
 }
 


### PR DESCRIPTION
Move the main script file since it would locate the template file depending on where it's located.
This pull request closes #3503
