### PR TITLE
jwt-tool: fix wrapper

### DIFF
--- a/packages/jwt-tool/PKGBUILD
+++ b/packages/jwt-tool/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=jwt-tool
 pkgver=69.6c7d430
-pkgrel=1
+pkgrel=2
 pkgdesc='Toolkit for validating, forging and cracking JWTs (JSON Web Tokens).'
 arch=('any')
 groups=('blackarch' 'blackarch-cracker')
@@ -40,7 +40,8 @@ package() {
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
-exec python /usr/share/$pkgname/jwt_tool.py "\$@"
+cd /usr/share/$pkgname
+exec python jwt_tool.py "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"


### PR DESCRIPTION
When `-M cc` option is used, fails with `FileNotFoundError: [Errno 2] No such file or directory: 'common-headers.txt'` error while the file is in `/usr/share/jwt-tool/common-headers.txt`.