### PR TITLE
brakeman: better package

### DIFF
--- a/packages/brakeman/PKGBUILD
+++ b/packages/brakeman/PKGBUILD
@@ -36,8 +36,7 @@ package() {
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
-cd /opt/$pkgname
-exec ./bin/$pkgname "\$@"
+exec /opt/$pkgname/bin/$pkgname "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"

--- a/packages/brakeman/PKGBUILD
+++ b/packages/brakeman/PKGBUILD
@@ -2,8 +2,8 @@
 # See COPYING for license details.
 
 pkgname=brakeman
-pkgver=3828.36fb9ccd5
-pkgrel=2
+pkgver=v5.3.0.r19.g985a289d8
+pkgrel=1
 pkgdesc='A static analysis security vulnerability scanner for Ruby on Rails applications.'
 groups=('blackarch' 'blackarch-code-audit' 'blackarch-exploitation'
         'blackarch-scanner' 'blackarch-webapp')
@@ -19,7 +19,7 @@ sha512sums=('SKIP')
 pkgver() {
   cd $pkgname
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 package() {


### PR DESCRIPTION
- [x] better pkgver
- [x] fix path issue

## Path issue

When I run `brakeman relative/path/source`, brakeman is looking into `brakeman_install_dir + user_provided_path` (`/opt/brakeman/relative/path/source`) instead of `shell_current_path + user_provided_path` (`~/project/example/relative/path/source`).

```
$ brakeman relative/path/source
Loading scanner...
Please supply the path to a Rails application (looking in /opt/brakeman/relative/path/source).
  Use `--force` to run a scan anyway.
```

Which is due to the `/usr/bin/brakeman` wrapper which do a cd in `/opt/brakeman` but the tool seems to run just fine with a direct `exec`.

So this will avoid to have to do `brakeman "$pwd/relative/path/source"`.