### PR TITLE
Actions: Bump Action versions and fix ubuntu version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   build:
      runs-on: ubuntu-latest
      steps:
-       - uses: actions/checkout@v2
+       - uses: actions/checkout@v3
        - name: Build Package
          run: |
            CHANGED_FILES=($(git diff --name-only --diff-filter=d $THE_LAST_COMMIT HEAD))
@@ -20,11 +20,11 @@ jobs:
               fi
            done
   pkgcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 2.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 2.7
       - name: Install dependencies


### PR DESCRIPTION
actions/checkout@v2 needs to be updated to v3 to fix deprecation warning as can be seen [here](https://github.com/BlackArch/blackarch/actions/runs/3505267291):

```
Node.js 12 actions are deprecated. For more information
see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: actions/checkout@v2
```

The ubuntu version is fixed to avoid future issues if ubuntu 22.04 gets used as latest, where python 2.7 might not be available by default

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>