### PR TITLE
evil-winrm: build fixes

### DIFF
--- a/packages/evil-winrm/PKGBUILD
+++ b/packages/evil-winrm/PKGBUILD
@@ -3,14 +3,15 @@
 
 pkgname=evil-winrm
 pkgver=v3.4.r0.g381b126
-pkgrel=2
+pkgrel=3
 epoch=1
 pkgdesc='The ultimate WinRM shell for hacking/pentesting.'
 arch=('any')
 groups=('blackarch' 'blackarch-exploitation' 'blackarch-backdoor')
 url='https://github.com/Hackplayers/evil-winrm'
 license=('LGPL3')
-depends=('ruby' 'ruby-bundler' 'libxslt' 'ruby-rexml')
+# git required because it's used in gemspec and we bundle exec in the wrapper
+depends=('ruby' 'ruby-bundler' 'libxslt' 'ruby-rexml' 'git')
 makedepends=('git')
 source=("git+https://github.com/Hackplayers/$pkgname.git")
 sha512sums=('SKIP')
@@ -20,13 +21,6 @@ pkgver() {
   cd $pkgname
 
   git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
-}
-
-prepare() {
-  cd $pkgname
-
-  # tmp fix https://github.com/BlackArch/blackarch/issues/3102
-  echo "gem 'rexml'" >> Gemfile
 }
 
 package() {
@@ -42,6 +36,8 @@ package() {
   rm -r *.md resources/ .github/ LICENSE
 
   cp -a --no-preserve=ownership * "$pkgdir/usr/share/$pkgname/"
+  # git used in gemspec so we need .git/ for bundle exec
+  cp -a --no-preserve=ownership .git "$pkgdir/usr/share/$pkgname/"
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh


### PR DESCRIPTION
- remove the tmp fix in prepare() since ruby-rexml has been added in depends()
- add git as runtim dep. and copy .git folder because git is used in gemspec so we need it for bundle exec
- fix #3593 (partially)