### PR TITLE
x8: fix and update

### DIFF
--- a/packages/x8/PKGBUILD
+++ b/packages/x8/PKGBUILD
@@ -2,14 +2,16 @@
 # See COPYING for license details.
 
 pkgname=x8
-pkgver=135.8e0e802
+pkgver=v4.0.0.r1.gb954187
 pkgrel=1
 pkgdesc='Hidden parameters discovery suite.'
 arch=('x86_64' 'aarch64')
 groups=('blackarch' 'blackarch-webapp' 'blackarch-scanner')
 url='https://github.com/Sh1Yo/x8'
 license=('custom:unknown')
-depends=()
+# openssl-1.1 as tmp fix for
+# https://github.com/Sh1Yo/x8/issues/26#issuecomment-1325795207
+depends=('openssl' 'openssl-1.1')
 makedepends=('git' 'cargo')
 source=("git+https://github.com/Sh1Yo/$pkgname.git")
 sha512sums=('SKIP')
@@ -17,7 +19,7 @@ sha512sums=('SKIP')
 pkgver() {
   cd $pkgname
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 build() {


### PR DESCRIPTION
- fix dependencies
  - add openssl that was missing
  - add openssl-1.1 as tmp fix for https://github.com/Sh1Yo/x8/issues/26#issuecomment-1325795207
- update pkgver (commit 135 -> 255)
- fix #3592