### PR TITLE
New Mirror in Moldova: md.mirrors.hacktegic.com

### DIFF
--- a/mirror/mirror.lst
+++ b/mirror/mirror.lst
@@ -36,6 +36,8 @@ IT|https://blackarch.mirror.garr.it/mirrors/blackarch/$repo/os/$arch|garr
 JP|http://ftp.kddilabs.jp/Linux/packages/blackarch/$repo/os/$arch|kddilabs
 JP|https://ftp.kddilabs.jp/Linux/packages/blackarch/$repo/os/$arch|kddilabs
 JP|http://www.ftp.ne.jp/Linux/packages/blackarch/$repo/os/$arch|ne
+MD|http://md.mirrors.hacktegic.com/blackarch/$repo/os/$arch|hacktegic
+MD|https://md.mirrors.hacktegic.com/blackarch/$repo/os/$arch|hacktegic
 NL|http://mirror.neostrada.nl/blackarch/$repo/os/$arch|neostrada
 NL|http://mirror.serverion.com/blackarch/$repo/os/$arch|serverion
 NL|https://blackarch.pr0s3c.nl/blackarch/$repo/os/$arch|pr0s3c


### PR DESCRIPTION
**Mirror domain name:**
md.mirrors.hacktegic.com

**Geographical location of the mirror (country):**
Moldova

**URLs for supported access methods (http(s), rsync) (no ftp):**
http://md.mirrors.hacktegic.com/blackarch/
https://md.mirrors.hacktegic.com/blackarch/

**Your mirror's available bandwidth:**
1Gbit, server is at IX "KIVIX" - Chisinau Internet Exchange

**An administrative contact email:**
[amocrenco@protonmail.com](mailto:amocrenco@protonmail.com)

**An alternative administrative contact email:**
[artiomm@hacktegic.com](mailto:artiomm@hacktegic.com)

**Syncing from:**
rsync://mirrors.dotsrc.org/blackarch/ every 2 hours at random minute 

