### PR TITLE
Bloodhound: fix unsupported Java runtime

### DIFF
--- a/packages/bloodhound/bloodhound.install
+++ b/packages/bloodhound/bloodhound.install
@@ -4,6 +4,7 @@ post_install() {
 	echo ">>  Don't forget to change the default password for neo4j."
 	echo ">>"
 	echo
+	archlinux-java set java-11-openjdk
 }
 
 post_upgrade() {


### PR DESCRIPTION
Fixing the error:
```
<SNIP>
Exception in thread "main" java.lang.LinkageError: Cannot to link java.nio.DirectByteBuffer
<SNIP>
```
obtained when `sudo neo4j console` is run. neo4j is the Graph Database used by Bloodhound. This error is caused by the usage of a Java runtime version different from Java OpenJDK 11. The error will fail neo4j server to start.

It can be solved easily by adding at the end of `post_installation()` function of `bloodhound.install` file the command `archlinux-java set java-11-openjdk`.

Note: during the bloodhound package building by `makepkg`, if you get some errors like:
```
opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
library: 'digital envelope routines',
reason: 'unsupported',
code: 'ERR_OSSL_EVP_UNSUPPORTED'
```
just run `export NODE_OPTIONS=--openssl-legacy-provider` and re-run `makepkg`.