### PR TITLE
evil-winrm: fix OpenSSL 3 error

### DIFF
--- a/packages/evil-winrm/evil-winrm.install
+++ b/packages/evil-winrm/evil-winrm.install
@@ -5,6 +5,8 @@ post_install() {
   bundle config build.nokogiri --use-system-libraries
   bundle config set --local path 'vendor/bundle'
   bundle install
+  sed -zi "s/\[provider_sect\]\ndefault = default_sect/\[provider_sect\]\ndefault = default_sect\nlegacy = legacy_sect/" /etc/ssl/openssl.cnf
+  sed -zi "s/\[default_sect\]\n# activate = 1/\[default_sect\]\nactivate = 1\n\[legacy_sect\]\nactivate = 1/" /etc/ssl/openssl.cnf
 }
 
 post_upgrade() {


### PR DESCRIPTION
Fixing the issue linked in https://github.com/BlackArch/blackarch/issues/3593 by enabling legacy protocols that Evil-WinRM uses for attacking the target machine. The issue is solved by enabling the legacy protocols after the pkg installation that have been kept disabled by default by OpenSSL maintainers with the latest OpenSSL version.