### PR TITLE
x8: bump pkgver + remove patch

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -167,6 +167,7 @@ whispers
 wifijammer
 winpwn
 wolpertinger
+x8
 zdns
 zeek-aux
 zeek

--- a/packages/x8/PKGBUILD
+++ b/packages/x8/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=x8
-pkgver=v4.0.0.r1.gb954187
+pkgver=v4.1.0.r0.gf72ff05
 pkgrel=1
 epoch=1
 pkgdesc='Hidden parameters discovery suite.'
@@ -10,9 +10,7 @@ arch=('x86_64' 'aarch64')
 groups=('blackarch' 'blackarch-webapp' 'blackarch-scanner')
 url='https://github.com/Sh1Yo/x8'
 license=('custom:unknown')
-# openssl-1.1 as tmp fix for
-# https://github.com/Sh1Yo/x8/issues/26#issuecomment-1325795207
-depends=('openssl' 'openssl-1.1')
+depends=('openssl')
 makedepends=('git' 'cargo')
 source=("git+https://github.com/Sh1Yo/$pkgname.git")
 sha512sums=('SKIP')


### PR DESCRIPTION
4.1 offers openssl 3 support cf. https://github.com/Sh1Yo/x8/issues/26#issuecomment-1337484986