### PR TITLE
Deleted MimeType=application/x-executable

### DIFF
--- a/packages/networkminer/networkminer.desktop
+++ b/packages/networkminer/networkminer.desktop
@@ -6,4 +6,3 @@ Exec=/usr/bin/networkminer
 Terminal=false
 Type=Application
 Categories=X-BlackArch-Forensic; X-BlackArch-Sniffer;
-MimeType=application/x-executable


### PR DESCRIPTION
Deleted `MimeType=application/x-executable` because it forces AppImage files to open NetworkMiner when the AppImage has in Properties "Executable as a Program" disabled and when the user double click on AppImage file itself.