### PR TITLE
peass: Changed gnu-netcat dependency to openbsd-netcat

### DIFF
--- a/packages/peass/PKGBUILD
+++ b/packages/peass/PKGBUILD
@@ -11,7 +11,7 @@ url='https://github.com/carlospolop/privilege-escalation-awesome-scripts-suite'
 license=('MIT')
 depends=('bash')
 makedepends=('git')
-optdepends=('fping' 'nmap' 'ping' 'gnu-netcat')
+optdepends=('fping' 'nmap' 'ping' 'openbsd-netcat')
 source=("$pkgname::git+https://github.com/carlospolop/privilege-escalation-awesome-scripts-suite.git")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
gnu-netcat does not provide any output when run as listener while openbsd-netcat does (i.e. Listening on port 4444...) and it makes the user aware that netcat is listening. gnu-netcat and openbsd-netcat cannot be installed together because in conflict but openbsd-netcat is better (used also on other pentesting distros).