### PR TITLE
python-aiosmtplib: added package

### DIFF
--- a/packages/python-aiosmtplib/PKGBUILD
+++ b/packages/python-aiosmtplib/PKGBUILD
@@ -10,7 +10,7 @@ arch=('any')
 url='https://github.com/cole/aiosmtplib'
 license=('MIT')
 depends=('python')
-makedepends=('python-setuptools')
+makedepends=('python-build' 'python-pip')
 options=(!emptydirs)
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
 sha512sums=('SKIP')
@@ -18,14 +18,25 @@ sha512sums=('SKIP')
 build() {
   cd "$_pkgname-$pkgver"
 
-  python setup.py build
+  python -m build --wheel --outdir="$startdir/dist"
 }
 
 package() {
   cd "$_pkgname-$pkgver"
 
-  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
-  
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    "$_pkgname"
+
   # workaround https://github.com/cole/aiosmtplib/issues/195
   rm -rf "$pkgdir/usr/lib/python3.10/site-packages/tests"
 }

--- a/packages/python-aiosmtplib/PKGBUILD
+++ b/packages/python-aiosmtplib/PKGBUILD
@@ -1,0 +1,28 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-aiosmtplib
+_pkgname=aiosmtplib
+pkgver=2.0.0
+pkgrel=1
+pkgdesc='Asynchronous SMTP client for use with asyncio.'
+arch=('any')
+url='https://github.com/cole/aiosmtplib'
+license=('MIT')
+depends=('python')
+makedepends=('python-setuptools')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('SKIP')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py build
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+}

--- a/packages/python-aiosmtplib/PKGBUILD
+++ b/packages/python-aiosmtplib/PKGBUILD
@@ -26,7 +26,5 @@ package() {
 
   python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
   
-  rm -rf "$pkgdir/usr/lib/python3.10/site-packages/tests/__init__.py"
-  rm -rf "$pkgdir/usr/lib/python3.10/site-packages/tests/__pycache__/__init__.cpython-310.pyc"
-  rm -rf "$pkgdir/usr/lib/python3.10/site-packages/tests/__pycache__/__init__.cpython-310.opt-1.pyc"
+  rm -rf "$pkgdir/usr/lib/python3.10/site-packages/tests"
 }

--- a/packages/python-aiosmtplib/PKGBUILD
+++ b/packages/python-aiosmtplib/PKGBUILD
@@ -26,5 +26,6 @@ package() {
 
   python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
   
+  # workaround https://github.com/cole/aiosmtplib/issues/195
   rm -rf "$pkgdir/usr/lib/python3.10/site-packages/tests"
 }

--- a/packages/python-aiosmtplib/PKGBUILD
+++ b/packages/python-aiosmtplib/PKGBUILD
@@ -25,4 +25,8 @@ package() {
   cd "$_pkgname-$pkgver"
 
   python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+  
+  rm -rf "$pkgdir/usr/lib/python3.10/site-packages/tests/__init__.py"
+  rm -rf "$pkgdir/usr/lib/python3.10/site-packages/tests/__pycache__/__init__.cpython-310.pyc"
+  rm -rf "$pkgdir/usr/lib/python3.10/site-packages/tests/__pycache__/__init__.cpython-310.opt-1.pyc"
 }

--- a/packages/python-aiosmtplib/PKGBUILD
+++ b/packages/python-aiosmtplib/PKGBUILD
@@ -40,3 +40,4 @@ package() {
   # workaround https://github.com/cole/aiosmtplib/issues/195
   rm -rf "$pkgdir/usr/lib/python3.10/site-packages/tests"
 }
+

--- a/packages/python-aiosmtplib/PKGBUILD
+++ b/packages/python-aiosmtplib/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=python-aiosmtplib
-_pkgname=aiosmtplib
+_pkgname=${pkgname#python-}
 pkgver=2.0.0
 pkgrel=1
 pkgdesc='Asynchronous SMTP client for use with asyncio.'

--- a/packages/python-aiosmtplib/PKGBUILD
+++ b/packages/python-aiosmtplib/PKGBUILD
@@ -13,7 +13,7 @@ depends=('python')
 makedepends=('python-build' 'python-pip')
 options=(!emptydirs)
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('SKIP')
+sha512sums=('3fdea00062c95f1c457a954b005a993136c150575d505f16ad1b92ef2c2997bb4699c5e8057757d7accad047ab15d49f48fa1abb37f6f2aa4368f993455824a6')
 
 build() {
   cd "$_pkgname-$pkgver"


### PR DESCRIPTION
Used for LinkScope tool to avoid the usage of Python venv: https://github.com/BlackArch/blackarch/issues/3659