### PR TITLE
python-name-that-hash: added package

### DIFF
--- a/packages/python-name-that-hash/PKGBUILD
+++ b/packages/python-name-that-hash/PKGBUILD
@@ -38,6 +38,5 @@ package() {
     --no-index \
     --find-links="file://$startdir/dist" \
     "$_pkgname"
-
 }
 

--- a/packages/python-name-that-hash/PKGBUILD
+++ b/packages/python-name-that-hash/PKGBUILD
@@ -14,7 +14,7 @@ url="https://github.com/HashPals/Name-That-Hash"
 license=("GPL3")
 depends=("python" "python-click" "python-rich")
 makedepends=("python-installer" "python-poetry-core" "python-wheel")
-source=("https://files.pythonhosted.org/packages/19/7a/731c96302f39610f1ce6742a4e5b997d621b06f5608dc939f5cd48a639a0/name_that_hash-1.11.0-py3-none-any.whl")
+https://files.pythonhosted.org/packages/py2.py3/${_pkgname::1}/$_pkgname/${_pkgname//-/_}-$pkgver-py2.py3-none-any.whl
 sha256sums=("59682a35714235d958e723d658c0874abb81edf77ceb9d81d7e6416bc2af3b84")
 
 

--- a/packages/python-name-that-hash/PKGBUILD
+++ b/packages/python-name-that-hash/PKGBUILD
@@ -1,33 +1,42 @@
 # This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
 # See COPYING for license details.
 
-# This PKGBUILD was originally extracted from AUR.
-# AUR Maintainer: amadejpapez <amadej.papez@gmail.com>
+# This file is based on the AUR package by amadejpapez <amadej.papez@gmail.com>
 
 pkgname=python-name-that-hash
-_pkgname=Name-That-Hash
+_pkgname=name_that_hash
 pkgver=1.11.0
 pkgrel=6
 pkgdesc="The Modern Hash Identification System."
 arch=("any")
 url="https://github.com/HashPals/Name-That-Hash"
 license=("GPL3")
-depends=("python" "python-click" "python-rich")
-makedepends=("python-installer" "python-poetry-core" "python-wheel")
-https://files.pythonhosted.org/packages/py2.py3/${_pkgname::1}/$_pkgname/${_pkgname//-/_}-$pkgver-py2.py3-none-any.whl
-sha256sums=("59682a35714235d958e723d658c0874abb81edf77ceb9d81d7e6416bc2af3b84")
+depends=('python' 'python-click' 'python-rich')
+makedepends=('python-build' 'python-installer' 'python-pip' 'python-poetry-core' 'python-wheel')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('SKIP')
 
+build() {
+  cd "$_pkgname-$pkgver"
 
-# NOTE: for now install directly via wheel as I was getting the
-# 		ModuleNotFoundError: No module named 'name_that_hash'
-#       error after installation and cannot look into it right now
-
-# build() {
-# 	cd $_pkgname-$pkgver
-# 	python -m build --wheel --skip-dependency-check --no-isolation
-# }
+  python -m build --wheel --outdir="$startdir/dist"
+}
 
 package() {
-	python -m installer --destdir="$pkgdir" *.whl
-	# install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  cd "$_pkgname-$pkgver"
+
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    "$_pkgname"
+
 }

--- a/packages/python-name-that-hash/PKGBUILD
+++ b/packages/python-name-that-hash/PKGBUILD
@@ -1,7 +1,8 @@
 # This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
 # See COPYING for license details.
 
-# This file is based on the AUR package by amadejpapez <amadej.papez@gmail.com>
+# This PKGBUILD was originally extracted from AUR.
+# AUR Maintainer: amadejpapez <amadej.papez@gmail.com>
 
 pkgname=python-name-that-hash
 _pkgname=Name-That-Hash

--- a/packages/python-name-that-hash/PKGBUILD
+++ b/packages/python-name-that-hash/PKGBUILD
@@ -15,7 +15,7 @@ depends=('python' 'python-click' 'python-rich')
 makedepends=('python-build' 'python-installer' 'python-pip' 'python-poetry-core' 'python-wheel')
 options=(!emptydirs)
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('SKIP')
+sha512sums=('f5fed6fa86985d69bc099eb12227a01ef83337524d06a5f0bcfb4b1c1f362e1d207deece7577b954d4a4949c949f10cef9c6823f784b02d90a17dcc76d6be342')
 
 build() {
   cd "$_pkgname-$pkgver"

--- a/packages/python-name-that-hash/PKGBUILD
+++ b/packages/python-name-that-hash/PKGBUILD
@@ -40,3 +40,4 @@ package() {
     "$_pkgname"
 
 }
+

--- a/packages/python-name-that-hash/PKGBUILD
+++ b/packages/python-name-that-hash/PKGBUILD
@@ -1,0 +1,32 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+# This file is based on the AUR package by amadejpapez <amadej.papez@gmail.com>
+
+pkgname=python-name-that-hash
+_pkgname=Name-That-Hash
+pkgver=1.11.0
+pkgrel=6
+pkgdesc="The Modern Hash Identification System."
+arch=("any")
+url="https://github.com/HashPals/Name-That-Hash"
+license=("GPL3")
+depends=("python" "python-click" "python-rich")
+makedepends=("python-installer" "python-poetry-core" "python-wheel")
+source=("https://files.pythonhosted.org/packages/19/7a/731c96302f39610f1ce6742a4e5b997d621b06f5608dc939f5cd48a639a0/name_that_hash-1.11.0-py3-none-any.whl")
+sha256sums=("59682a35714235d958e723d658c0874abb81edf77ceb9d81d7e6416bc2af3b84")
+
+
+# NOTE: for now install directly via wheel as I was getting the
+# 		ModuleNotFoundError: No module named 'name_that_hash'
+#       error after installation and cannot look into it right now
+
+# build() {
+# 	cd $_pkgname-$pkgver
+# 	python -m build --wheel --skip-dependency-check --no-isolation
+# }
+
+package() {
+	python -m installer --destdir="$pkgdir" *.whl
+	# install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
Used for LinkScope tool to avoid the usage of Python venv: https://github.com/BlackArch/blackarch/issues/3659