### PR TITLE
python-Wappalyzer: added package

### DIFF
--- a/packages/python-Wappalyzer/PKGBUILD
+++ b/packages/python-Wappalyzer/PKGBUILD
@@ -1,7 +1,7 @@
 # This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
 # See COPYING for license details.
 
-pkgname=python-Wappalyzer
+pkgname=python-python-wappalyzer
 _pkgname=python-Wappalyzer
 pkgver=0.3.1
 pkgrel=1

--- a/packages/python-Wappalyzer/PKGBUILD
+++ b/packages/python-Wappalyzer/PKGBUILD
@@ -13,7 +13,7 @@ depends=('python' 'python-beautifulsoup4' 'python-lxml' 'python-requests' 'pytho
 makedepends=('python-setuptools')
 options=(!emptydirs)
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('SKIP')
+sha512sums=('51d670aea77b9e8512c5f8d3377a37313c2c480568964fc2aba5857073e489c1504014dacfa9158ed0c98b081ee855d1f69a579070aa2127b40db347abe6ef9c')
 
 build() {
   cd "$_pkgname-$pkgver"

--- a/packages/python-Wappalyzer/PKGBUILD
+++ b/packages/python-Wappalyzer/PKGBUILD
@@ -1,0 +1,28 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-Wappalyzer
+_pkgname=python-Wappalyzer
+pkgver=0.3.1
+pkgrel=1
+pkgdesc='Python implementation of the Wappalyzer web application detection utility.'
+arch=('any')
+url='https://github.com/chorsley/python-Wappalyzer'
+license=('GPL3')
+depends=('python' 'python-beautifulsoup4' 'python-lxml' 'python-requests' 'python-aiohttp' 'python-cached-property')
+makedepends=('python-setuptools')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('SKIP')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py build
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+}


### PR DESCRIPTION
Used for LinkScope tool to avoid the usage of Python venv: https://github.com/BlackArch/blackarch/issues/3659