### PR TITLE
bloodhound - Switched dep from nodejs-lts-gallium to nodejs

### DIFF
--- a/packages/bloodhound/PKGBUILD
+++ b/packages/bloodhound/PKGBUILD
@@ -9,7 +9,7 @@ groups=('blackarch' 'blackarch-recon' 'blackarch-windows')
 arch=('x86_64' 'aarch64')
 url='https://github.com/BloodHoundAD/BloodHound'
 license=('GPL3')
-depends=('nodejs-lts-gallium' 'neo4j-community' 'alsa-lib' 'gtk3' 'libxss' 'nss'
+depends=('nodejs' 'neo4j-community' 'alsa-lib' 'gtk3' 'libxss' 'nss'
          'gconf' 'libxtst' 'jre11-openjdk-headless')
 makedepends=('git' 'nodejs-electron-packager' 'npm' 'unzip')
 optdepends=('python: for some scripts' 'powershell: for PowerShell ingestion')


### PR DESCRIPTION
Proposal of change for avoiding the pkg conflicts. Bloodhound with nodejs has been tested and working correctly.