### PR TITLE
manticore: fix dependencies

### DIFF
--- a/lists/broken
+++ b/lists/broken
@@ -74,6 +74,8 @@ proxmark
 pyersinia
 pyqt3 # broken, discontinued, not needed anymore, see #3660
 pytbull # discontinued, better delete
+python2-pygoogle # abandoned since 2006, breaks pip, no longer required, see #3681
+python-pygoogle # abandoned since 2006, breaks pip, no longer required, see #3681
 qscintilla-qt3 # broken, discontinued, not needed anymore, see #3660
 qt3 # broken, discontinued, not needed anymore, see #3660
 r2-bindings

--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,3 @@
+manticore
+python-z3-solver-pep517
+python-wasm

--- a/packages/manticore/PKGBUILD
+++ b/packages/manticore/PKGBUILD
@@ -2,18 +2,18 @@
 # See COPYING for license details.
 
 pkgname=manticore
-pkgver=0.2.4.r399.g35744452
+pkgver=0.3.7.r67.g49e04385
 pkgrel=1
 pkgdesc='Symbolic execution tool.'
 arch=('any')
 groups=('blackarch' 'blackarch-binary')
 url='https://github.com/trailofbits/manticore'
 license=('AGPL3')
-depends=('python' 'python-pyevmasm' 'python-capstone' 'python-keystone'
-         'python-unicorn' 'python-ply' 'binaryninja-python' 'python-typing'
-         'python-pyelftools' 'python-z3-solver' 'python-pysha3' 'solidity'
-         'python-yaml' 'python-crytic-compile' 'python-rlp' 'python-pygoogle'
-         'python-prettytable')
+depends=('python' 'python-yaml' 'python-protobuf' 'python-pysha3'
+         'python-prettytable' 'python-ply' 'python-rlp' 'python-intervaltree'
+         'python-crytic-compile' 'python-wasm' 'python-dataclasses'
+         'python-pyevmasm' 'python-z3-solver-pep517' 'python-capstone'
+         'python-pyelftools' 'python-unicorn' 'python-redis')
 makedepends=('git' 'python-setuptools')
 source=("git+https://github.com/trailofbits/$pkgname.git")
 md5sums=('SKIP')
@@ -21,7 +21,7 @@ md5sums=('SKIP')
 pkgver() {
   cd $pkgname
 
-  git describe --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 build() {

--- a/packages/python-wasm/PKGBUILD
+++ b/packages/python-wasm/PKGBUILD
@@ -1,0 +1,31 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-wasm
+_pkgname=wasm
+pkgver=1.2
+pkgrel=1
+pkgdesc='WebAssembly decoder & disassembler.'
+arch=('any')
+url='URL pointing to download section of package'
+license=('MIT')
+depends=('python' 'python-setuptools')
+makedepends=('python-setuptools')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('3778a36a49132b95b3d057749d3c443d36709951b4787a1e2006967c352ff83aaf4a1f71057a3be645be96eee2e87574d0a58fcdc0df2fe92ce72aafe4922fbd')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py build
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+
+  find "$pkgdir" -type f -iname '*.pyc' -print -exec rm -f {} \;
+}
+

--- a/packages/python-z3-solver-pep517/PKGBUILD
+++ b/packages/python-z3-solver-pep517/PKGBUILD
@@ -1,0 +1,43 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+# https://github.com/trailofbits/manticore/issues/1426#issuecomment-1382352246
+pkgname=python-z3-solver-pep517
+_pkgname=z3-solver
+pkgver=4.11.2.0
+pkgrel=1
+pkgdesc='An efficient SMT solver library.'
+arch=('any')
+url='URL pointing to download section of package'
+license=('MIT')
+depends=('python')
+makedepends=('python-build' 'python-pip')
+conflicts=('python-z3-solver' 'z3')
+provides=('python-z3-solver' 'z3')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('905db8987d302e33ce54de340bb21c1a9abc4d379c2475f6b7bf0056ad47db510aa3947d4e4c26b9f0fc4a9c933fd058fd606fb067a4c872ea5e2b58bb91608b')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --outdir="$startdir/dist"
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    "$_pkgname"
+}
+


### PR DESCRIPTION
- fix pkgver
- updates dependencies (add new like python-wasm ones and remove uneeded like python-pygoogle)
- deprecate python-pygoogle because it's broken and manticore was the only package using it
- add a pep517 built version of python-z3-solver to workaround https://github.com/trailofbits/manticore/issues/1426
- manticore will still be broken because of requiring protobuf~=3.20 cf. https://github.com/trailofbits/manticore/issues/2559

fixes #3681

replaces #3682