### PR TITLE
fix python-python-wappalyzer

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -2,3 +2,4 @@ manticore
 python-z3-solver-pep517
 python-wasm
 bagbak
+python-python-wappalyzer

--- a/packages/python-python-wappalyzer/PKGBUILD
+++ b/packages/python-python-wappalyzer/PKGBUILD
@@ -4,14 +4,14 @@
 pkgname=python-python-wappalyzer
 _pkgname=python-Wappalyzer
 pkgver=0.3.1
-pkgrel=3
+pkgrel=4
 pkgdesc='Python implementation of the Wappalyzer web application detection utility.'
 arch=('any')
-url='https://pypi.org/project/python-wappalyzer/#files'
+url='https://github.com/chorsley/python-Wappalyzer'
 license=('GPL3')
-depends=('python' 'python-beautifulsoup4' 'python-requests')
+depends=('python' 'python-beautifulsoup4' 'python-lxml' 'python-requests' 'python-aiohttp' 'python-cached-property')
 makedepends=('python-setuptools')
-source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/python-Wappalyzer-$pkgver.tar.gz")
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
 sha512sums=('51d670aea77b9e8512c5f8d3377a37313c2c480568964fc2aba5857073e489c1504014dacfa9158ed0c98b081ee855d1f69a579070aa2127b40db347abe6ef9c')
 
 build() {


### PR DESCRIPTION
add missing dependencies cf. https://github.com/chorsley/python-Wappalyzer/blob/cc2198377bf1e548f43e64815b1a135152d3a549/setup.py#L22-L26

replaces #3672