### PR TITLE
WIP: angr-management: fix pkgbuild

### DIFF
--- a/packages/angr-management/PKGBUILD
+++ b/packages/angr-management/PKGBUILD
@@ -2,23 +2,21 @@
 # See COPYING for license details.
 
 pkgname=angr-management
-pkgver=9.1.11752
+pkgver=9.2.33
 pkgrel=1
 groups=('blackarch' 'blackarch-binary' 'blackarch-disassembler'
         'blackarch-reversing')
 pkgdesc='This is the GUI for angr.'
 arch=('any')
-url='https://pypi.org/project/angr-management/#files'
-license=('custom:unknown')
-depends=('angr' 'python' 'python-websocket-client' 'python-pyzmq' 'ipython'
-         'python-pyside' 'python-pygraphviz' 'python-enaml' 'python-simuvex'
-         'python-grandalf' 'python-qtconsole' 'python-atom' 'python-pygments'
-         'python-qtconsole' 'pyside2' 'python-requests' 'python-toml'
-         'python-sqlalchemy' 'python-pyxdg' 'python-jupyter_client'
-         'python-pyqodeng-core')
+url='https://github.com/angr/angr-management'
+license=('BSD')
+depends=('angr' 'python' 'pyside6' 'python-pyside6-qtads' 'python-qtawesome'
+         'python-qtpy' 'python-bidict' 'python-getmac' 'ipython'
+         'python-pyqodeng-core' 'python-pyxdg' 'python-qtconsole' 'python-qtterm'
+         'python-requests' 'python-tomlkit')
 makedepends=('git' 'python-setuptools')
-source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$pkgname-$pkgver.tar.gz")
-sha512sums=('53162c0ccc3eed4ba4eb6ce214542d7653dbdd0c87c741cbeaa278e2a293ceb047702a1739d960f156c6252ffd54b3ed57870f82499b09fd4a4473fbd9f26dca')
+source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz")
+sha512sums=('ea4e9085814fbf4e3c25045e79942d1e9181fdd7028eb08faa3a0a102bf88f3a39c23e967b47477d417bf807f9392f52404c253fc8afd7707bbcf468878441a8')
 
 build() {
   cd "$pkgname-$pkgver"

--- a/packages/python-pyside6-qtads/PKGBUILD
+++ b/packages/python-pyside6-qtads/PKGBUILD
@@ -1,0 +1,42 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-pyside6-qtads
+_pkgname=PySide6-QtAds
+pkgver=4.0.1
+pkgrel=1
+pkgdesc='PySide6 bindings to Qt Advanced Docking System.'
+arch=('any')
+url='https://github.com/mborgerson/pyside6_qtads/'
+license=('LGPL')
+depends=('python' 'pyside6')
+makedepends=('python-build' 'python-pip' 'python-setuptools' 'python-wheel'
+             'python-setuptools-scm' 'python-cmake-build-extension'
+             'shiboken6' 'shiboken6-generator')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('837791209351fd3d1db0f319036f3465a27e26290bc989d2df95d1c7f58988a73dde685a5d2b2afcf5b7681bec0ba3f523265d2996976dfa63ec611c6d6c3231')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --outdir="$startdir/dist"
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    "$_pkgname"
+}
+

--- a/packages/python-qtterm/PKGBUILD
+++ b/packages/python-qtterm/PKGBUILD
@@ -1,0 +1,30 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-qtterm
+_pkgname=qtterm
+pkgver=0.5.1
+pkgrel=1
+pkgdesc='Fork of Py3QTermWidget.'
+arch=('any')
+url='https://github.com/ConnorNelson/qtterm'
+# https://pypi.org/project/qtterm/
+license=('GPL3')
+depends=('python')
+makedepends=('python-setuptools')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('e08d431ed64bcf23fd0e5ddc298d521c5e6e5da4b38ae3a6e07c487ddc173ac0ae85892495a88ae3bf4fe4cfdeb4888064334b503fb712ede22c6cd79c6c631c')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py build
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+}
+


### PR DESCRIPTION
- pkgver++
- fix source
- closes #3662
- fix license
- fix build() and package() as setup.py was removed in profit to pyproject.toml and setup.cfg
- fix dependencies
- python-pyside6-qtads can't be built for now because shiboken6-generator is missing see https://bugs.archlinux.org/task/77117 and https://github.com/mborgerson/pyside6_qtads/blob/main/pyproject.toml#L9