### PR TITLE
paru sub3suite: added to release (paru version bump)

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,2 +1,2 @@
-osintgram
 paru
+sub3suite

--- a/lists/to-release
+++ b/lists/to-release
@@ -1,1 +1,2 @@
 osintgram
+paru


### PR DESCRIPTION
Just a reminder for compiling paru to the latest version as specified in its already updated [PKGBUILD](https://github.com/BlackArch/blackarch/blob/master/packages/paru/PKGBUILD). Currently, paru retrieved from BA repo still shows the bugged version 1.9.3-1.