### PR TITLE
Remove python-flask-cors and python-flask-socketio

### DIFF
--- a/lists/to-remove
+++ b/lists/to-remove
@@ -1,2 +1,4 @@
+python-flask-cors - (PKGBUILD deleted but the pkg file still exists. This package is a duplicated of python2-flask-cors)
+python-flask-socketio - (PKGBUILD deleted but the pkg file still exists. This package is a duplicated of python2-flask-socketio)
 smartphone-pentest-framework - (deprecated - unmaintained > 6 years)
 zeus-scanner - (multiple upstream issues, unmaintained > 2 years)


### PR DESCRIPTION
These two packages are duplicated of python2-flask-cors and python2-flask-socketio. The related PKGBUILD have been removed but the related packages were not from the repository. Please, remove them because they are in conflict with the correct python2-related version ones.

The affected packages should be `rspet` and `trape` (this last one use as dependency `python-flask-cors` and `python-flask-socketio` that should be Python3 and not cloned Python2 deps.