### PR TITLE
sherlock: version bump

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+sherlock

--- a/packages/sherlock/PKGBUILD
+++ b/packages/sherlock/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=sherlock
-pkgver=1921.9ea08b2
+pkgver=1961.5c1865f
 pkgrel=1
 pkgdesc='Find usernames across social networks.'
 groups=('blackarch' 'blackarch-social' 'blackarch-recon')


### PR DESCRIPTION
The current Sherlock in BlackArch uses `username_unclaimed` attribute so, when it is used, you will receive an error. This issue is solved on the latest version of Sherlock.