### PR TITLE
crackmapexec-poetry: add package

### DIFF
--- a/packages/crackmapexec-poetry/PKGBUILD
+++ b/packages/crackmapexec-poetry/PKGBUILD
@@ -1,0 +1,64 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=crackmapexec-poetry
+_pkgname=crackmapexec
+_pyver=3.10
+pkgver=v5.4.0.r27.g37acd57
+pkgrel=1
+epoch=1
+groups=('blackarch' 'blackarch-scanner' 'blackarch-exploitation' 'blackarch-windows')
+pkgdesc='A swiss army knife for pentesting Windows/Active Directory environments.'
+arch=('any')
+url='https://github.com/Porchetta-Industries/CrackMapExec'
+license=('BSD')
+depends=('python' 'python-poetry')
+makedepends=('git')
+provides=('crackmapexec')
+conflicts=('crackmapexec')
+source=("$_pkgname::git+https://github.com/Porchetta-Industries/CrackMapExec.git")
+sha512sums=('SKIP')
+install="$pkgname.install"
+
+pkgver() {
+  cd $_pkgname
+
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+package() {
+  cd $_pkgname
+
+  install -dm 755 "$pkgdir/usr/bin"
+  install -dm 755 "$pkgdir/usr/share/$_pkgname"
+
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$_pkgname/LICENSE"
+
+  rm -rf LICENSE .github .git* .dockerignore Dockerfile Makefile *.nix
+
+  cp -a * "$pkgdir/usr/share/$_pkgname/"
+
+  cat > "$pkgdir/usr/bin/$_pkgname" << EOF
+#!/bin/sh
+poetry config cache-dir "/usr/share/$_pkgname"
+poetry env use /usr/share/$_pkgname/virtualenvs/*/bin/python$_pyver --directory /usr/share/crackmapexec
+poetry run --directory "/usr/share/$_pkgname" $_pkgname "\$@"
+EOF
+
+  cat > "$pkgdir/usr/bin/cme" << EOF
+#!/bin/sh
+poetry config cache-dir "/usr/share/$_pkgname"
+poetry env use /usr/share/$_pkgname/virtualenvs/*/bin/python$_pyver --directory /usr/share/crackmapexec
+poetry run --directory "/usr/share/$_pkgname" cme "\$@"
+EOF
+
+  cat > "$pkgdir/usr/bin/cmedb" << EOF
+#!/bin/sh
+poetry config cache-dir "/usr/share/$_pkgname"
+poetry env use /usr/share/$_pkgname/virtualenvs/*/bin/python$_pyver --directory /usr/share/crackmapexec
+poetry run --directory "/usr/share/$_pkgname" cmedb "\$@"
+EOF
+
+  chmod a+x "$pkgdir/usr/bin/$_pkgname" "$pkgdir/usr/bin/cme" "$pkgdir/usr/bin/cmedb"
+}
+

--- a/packages/crackmapexec-poetry/crackmapexec-poetry.install
+++ b/packages/crackmapexec-poetry/crackmapexec-poetry.install
@@ -1,0 +1,11 @@
+post_install() {
+  set -e
+  cd /usr/share/crackmapexec
+  poetry config cache-dir /usr/share/crackmapexec
+  poetry install --no-cache
+}
+
+post_upgrade() {
+  post_install "$@"
+}
+


### PR DESCRIPTION
as crackmapexec is a dependency nightmare and it's nearly impossible to maintain a package for it without system dependency issue, I suggest an alternative package using a virtual environment with poetry