### PR TITLE
kerberoast: version bump

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+kerberoast

--- a/packages/kerberoast/PKGBUILD
+++ b/packages/kerberoast/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=kerberoast
-pkgver=0.2.0.r2.ged37402
+pkgver=0.2.0.r7.g025fe39
 pkgrel=1
 epoch=1
 pkgdesc='Kerberoast attack -pure python-.'


### PR DESCRIPTION
It solves the conflict issues due to the usage of `tests` folder in the root of Python3.10 folder. It has been solved on https://github.com/skelsec/kerberoast/pull/9