### PR TITLE
apktool: pkgver bump + fix build

### DIFF
--- a/packages/android-apktool/PKGBUILD
+++ b/packages/android-apktool/PKGBUILD
@@ -3,18 +3,18 @@
 
 pkgname=android-apktool
 _pkgname=Apktool
-pkgver=2.6.0
+pkgver=2.7.0
 pkgrel=1
 pkgdesc='A tool for reverse engineering Android apk files.'
 arch=('x86_64' 'aarch64')
 groups=('blackarch' 'blackarch-reversing' 'blackarch-disassembler')
 url='https://github.com/iBotPeaches/Apktool/releases'
 license=('Apache')
-depends=('java-environment')
+depends=('jdk17-openjdk') # java-environment, doesn't work with Java 19
 makedepends=('git')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/iBotPeaches/$_pkgname/archive/v$pkgver.tar.gz"
         'apktool')
-sha512sums=('3b634840bcedfc2757add569873cf07ba1a5531cab8d28fc893219381087ef5ffe420a68f9913c1e6e51a9972c45ea8c9b349b035f56f977fd43c53da4c83d8c'
+sha512sums=('97786fdb85c48c7d344775102e92de417ab5dbb908712d0230fce90a4c76c8a42d2df7f2f8d07f8589c42454cb1207dca1da87a048339fc143c1b0694c397877'
             'aa30257ea9bb6102893edab8f5926c7a4abbe94601e7b7e6273ddf89150969f99d27601a83d0e17a6163c3d5822df3479f9c1e84ab0e8bf6018e1e076fc275d4')
 
 prepare() {


### PR DESCRIPTION
- the build was failing so the binary version available was not 2.6.0 but 2.5.0, we have to fix java 17 as Gradle does not support java 19 yet
- bump to 2.7.0