### PR TITLE
pcileech: moved linux-headers dependency to optdepends

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+pcileech

--- a/packages/pcileech/PKGBUILD
+++ b/packages/pcileech/PKGBUILD
@@ -11,6 +11,7 @@ groups=('blackarch' 'blackarch-hardware' 'blackarch-reversing')
 url='https://github.com/ufrisk/pcileech/releases'
 license=('GPL3')
 depends=('libusb' 'leechcore')
+optdepends=('linux-headers' 'linux-lts-headers' 'linux-hardened-headers' 'linux-rt-headers' 'linux-rt-lts-headers' 'linux-zen-headers')
 options=('!strip')
 source=("https://github.com/ufrisk/pcileech/releases/download/v$pkgver/PCILeech_files_and_binaries_v$pkgver.2-linux_x64-$_pkgver.tar.gz")
 sha512sums=('b17f751b36918187d0744ed80c95878e014eae97979cd5ba0d9762a92253c5e262bf78bcd09151706b0cc24bc832c43a52b708f6e4345c0dfdcea47e56911e30')

--- a/packages/pcileech/PKGBUILD
+++ b/packages/pcileech/PKGBUILD
@@ -4,13 +4,13 @@
 pkgname=pcileech
 pkgver=4.15
 _pkgver=20230226
-pkgrel=3
+pkgrel=4
 pkgdesc='Tool, which uses PCIe hardware devices to read and write from the target system memory.'
 arch=('x86_64')
 groups=('blackarch' 'blackarch-hardware' 'blackarch-reversing')
 url='https://github.com/ufrisk/pcileech/releases'
 license=('GPL3')
-depends=('libusb' 'leechcore' 'linux-headers')
+depends=('libusb' 'leechcore')
 options=('!strip')
 source=("https://github.com/ufrisk/pcileech/releases/download/v$pkgver/PCILeech_files_and_binaries_v$pkgver.2-linux_x64-$_pkgver.tar.gz")
 sha512sums=('b17f751b36918187d0744ed80c95878e014eae97979cd5ba0d9762a92253c5e262bf78bcd09151706b0cc24bc832c43a52b708f6e4345c0dfdcea47e56911e30')


### PR DESCRIPTION
According to the project page, there is no request about the usage of `linux-headers` package. The install of this package could be dangerous for those systems using different kernel types. it could break the system.

The needed dependencies for pcileech are specified at https://github.com/ufrisk/pcileech/wiki/PCILeech-on-Linux