### PR TITLE
scamper: version bump

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+scamper

--- a/packages/scamper/PKGBUILD
+++ b/packages/scamper/PKGBUILD
@@ -12,6 +12,7 @@ url='http://www.caida.org/tools/measurement/scamper/'
 license=('GPL2')
 depends=('openssl')
 makedepends=()
+optdepends=('linux-headers' 'linux-lts-headers' 'linux-hardened-headers' 'linux-rt-headers' 'linux-rt-lts-headers' 'linux-zen-headers')
 source=("http://www.caida.org/tools/measurement/$pkgname/code/$pkgname-cvs-$pkgver.tar.gz")
 sha512sums=('d67c7c850421d0281b5a7fc18e4cbe99026561383043020acc630796b7bcf23ce64eff62efd3bdb2fd2105a1ec4e64f7e1b165a75a46471a24b90e340bb6485b')
 

--- a/packages/scamper/PKGBUILD
+++ b/packages/scamper/PKGBUILD
@@ -2,18 +2,18 @@
 # See COPYING for license details.
 
 pkgname=scamper
-pkgver=20211212a
-pkgrel=2
+pkgver=20230323
+pkgrel=1
 pkgdesc='A tool that actively probes the Internet in order to analyze topology and performance.'
 groups=('blackarch' 'blackarch-scanner' 'blackarch-recon'
         'blackarch-networking')
 arch=('x86_64' 'aarch64')
 url='http://www.caida.org/tools/measurement/scamper/'
 license=('GPL2')
-depends=('linux-headers' 'openssl')
+depends=('openssl')
 makedepends=()
 source=("http://www.caida.org/tools/measurement/$pkgname/code/$pkgname-cvs-$pkgver.tar.gz")
-sha512sums=('966e7e9bb7dd7d46d7729fdb66a2d8a2813a0402056cbd2a374c9496a8ffcfe321f0f719d7326eb574255c62f5c81820573cd8111d202d862328bb4ead1cab89')
+sha512sums=('d67c7c850421d0281b5a7fc18e4cbe99026561383043020acc630796b7bcf23ce64eff62efd3bdb2fd2105a1ec4e64f7e1b165a75a46471a24b90e340bb6485b')
 
 build() {
   cd "$pkgname-cvs-$pkgver"
@@ -30,4 +30,3 @@ package() {
 
   install -Dm 644 COPYING "$pkgdir/usr/share/licenses/$pkgname/COPYING"
 }
-


### PR DESCRIPTION
scamper updated and removed `linux-headers` dependency because no needed.