### PR TITLE
dracnmap: moving firefox dependency to optdepends

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+dracnmap

--- a/packages/dracnmap/PKGBUILD
+++ b/packages/dracnmap/PKGBUILD
@@ -3,14 +3,15 @@
 
 pkgname=dracnmap
 pkgver=69.09d3945
-pkgrel=1
+pkgrel=2
 pkgdesc='Tool to exploit the network and gathering information with nmap help.'
 groups=('blackarch' 'blackarch-automation')
 arch=('any')
 url='https://github.com/screetsec/Dracnmap'
 license=('MIT')
-depends=('nmap' 'firefox' 'nano' 'xterm')
+depends=('nmap' 'nano' 'xterm')
 makedepends=('git')
+optdepends=('firefox')
 source=("$pkgname::git+https://github.com/screetsec/Dracnmap.git")
 sha512sums=('SKIP')
 

--- a/packages/dracnmap/PKGBUILD
+++ b/packages/dracnmap/PKGBUILD
@@ -11,7 +11,7 @@ url='https://github.com/screetsec/Dracnmap'
 license=('MIT')
 depends=('nmap' 'nano' 'xterm')
 makedepends=('git')
-optdepends=('firefox')
+optdepends=('firefox: XML file opening support')
 source=("$pkgname::git+https://github.com/screetsec/Dracnmap.git")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
dracnmap code uses firefox for only opening xml but installing one browser only for opening xml is not efficient for users using other browsers.