### PR TITLE
eyewitness: moving firefox dependency to optdepends

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+eyewitness

--- a/packages/eyewitness/PKGBUILD
+++ b/packages/eyewitness/PKGBUILD
@@ -15,7 +15,7 @@ depends=('python' 'python-pyqt4' 'python-netaddr' 'ghost-py' 'python-rdpy'
          'python-fuzzywuzzy' 'python-pillow' 'geckodriver'
          'python-easyprocess' 'python-pytesseract')
 makedepends=('git')
-optdepends=('firefox')
+optdepends=('firefox: Selenium module support')
 source=("$pkgname::git+https://github.com/FortyNorthSecurity/EyeWitness.git")
 sha512sums=('SKIP')
 

--- a/packages/eyewitness/PKGBUILD
+++ b/packages/eyewitness/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=eyewitness
 pkgver=1017.4d7736e
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-webapp' 'blackarch-recon' 'blackarch-misc')
 pkgdesc='Designed to take screenshots of websites, provide some server header info, and identify default credentials if possible.'
 arch=('any')
@@ -12,9 +12,10 @@ license=('GPL3')
 depends=('python' 'python-pyqt4' 'python-netaddr' 'ghost-py' 'python-rdpy'
          'python-selenium' 'python-rsa' 'xorg-server-xvfb'
          'python-beautifulsoup4' 'python-pyvirtualdisplay'
-         'python-fuzzywuzzy' 'python-pillow' 'geckodriver' 'firefox'
+         'python-fuzzywuzzy' 'python-pillow' 'geckodriver'
          'python-easyprocess' 'python-pytesseract')
 makedepends=('git')
+optdepends=('firefox')
 source=("$pkgname::git+https://github.com/FortyNorthSecurity/EyeWitness.git")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
For users using browsers different from firefox (i.e., chromium, brave, firefox-esr), I would avoid forcing the install of firefox as dependency.