### PR TITLE
findsploit: moving firefox dependency to optdepends

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+findsploit

--- a/packages/findsploit/PKGBUILD
+++ b/packages/findsploit/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=findsploit
 pkgver=87.3e61d8d
-pkgrel=1
+pkgrel=2
 pkgdesc='Find exploits in local and online databases instantly.'
 groups=('blackarch' 'blackarch-automation' 'blackarch-exploitation')
 arch=('any')

--- a/packages/findsploit/PKGBUILD
+++ b/packages/findsploit/PKGBUILD
@@ -11,7 +11,7 @@ url='https://github.com/1N3/findsploit'
 license=('custom:unknown')
 depends=('bash' 'metasploit' 'exploitdb')
 makedepends=('git')
-optdepends=('firefox')
+optdepends=('firefox: supported browser')
 source=("$pkgname::git+https://github.com/1N3/Findsploit.git")
 sha512sums=('SKIP')
 

--- a/packages/findsploit/PKGBUILD
+++ b/packages/findsploit/PKGBUILD
@@ -9,8 +9,9 @@ groups=('blackarch' 'blackarch-automation' 'blackarch-exploitation')
 arch=('any')
 url='https://github.com/1N3/findsploit'
 license=('custom:unknown')
-depends=('bash' 'metasploit' 'firefox' 'exploitdb')
+depends=('bash' 'metasploit' 'exploitdb')
 makedepends=('git')
+optdepends=('firefox')
 source=("$pkgname::git+https://github.com/1N3/Findsploit.git")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
For users using browsers different from firefox (i.e., chromium, brave, firefox-esr), I would avoid forcing the install of firefox as dependency.