### PR TITLE
firefox-security-toolkit: moving firefox dependency to optdepends

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+firefox-security-toolkit

--- a/packages/firefox-security-toolkit/PKGBUILD
+++ b/packages/firefox-security-toolkit/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=firefox-security-toolkit
 pkgver=16.31dacf0
-pkgrel=1
+pkgrel=2
 pkgdesc='A tool that transforms Firefox browsers into a penetration testing suite.'
 groups=('blackarch' 'blackarch-misc')
 arch=('any')

--- a/packages/firefox-security-toolkit/PKGBUILD
+++ b/packages/firefox-security-toolkit/PKGBUILD
@@ -9,8 +9,9 @@ groups=('blackarch' 'blackarch-misc')
 arch=('any')
 url='https://github.com/mazen160/Firefox-Security-Toolkit'
 license=('MIT')
-depends=('bash' 'wget' 'firefox')
+depends=('bash' 'wget')
 makedepends=('git')
+optdepends=('firefox')
 source=("$pkgname::git+https://github.com/mazen160/Firefox-Security-Toolkit")
 sha512sums=('SKIP')
 

--- a/packages/firefox-security-toolkit/PKGBUILD
+++ b/packages/firefox-security-toolkit/PKGBUILD
@@ -11,7 +11,7 @@ url='https://github.com/mazen160/Firefox-Security-Toolkit'
 license=('MIT')
 depends=('bash' 'wget')
 makedepends=('git')
-optdepends=('firefox')
+optdepends=('firefox: supported browser')
 source=("$pkgname::git+https://github.com/mazen160/Firefox-Security-Toolkit")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
In case a user using a browser different from firefox (i.e., firefox-esr or brave), if it installs `blackarch-misc` group package, it won't have two different browsers installed.

I would follow the same approach of `firefox-decrypt`: if the user is expecting to install a package related to firefox, it should already have it installed.