### PR TITLE
python-zconfig: add package

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+python-zconfig

--- a/packages/python-zconfig/PKGBUILD
+++ b/packages/python-zconfig/PKGBUILD
@@ -1,0 +1,28 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-zconfig
+_pkgname=ZConfig
+pkgver=3.6.1
+pkgrel=1
+pkgdesc='A configuration library supporting a hierarchical schema-driven configuration model, and allowing a schema to specify data conversion routines written in Python.'
+arch=('any')
+url='https://github.com/zopefoundation/ZConfig'
+license=('ZPL')
+depends=('python')
+makedepends=('python-setuptools')
+checkdepends=('python-zope-testrunner' 'python-manuel' 'python-docutils' 'python-nose')
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('e8cf5805028208f2d33152efe244feb59a1ffbd8ce6135ab4febf8fc300bdf8ee81846a94070655490e130e74a92a6b6b86e7fe3ce06673cff2d854b25ba87ec')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py build
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+}


### PR DESCRIPTION
It is a dependency of `pwncat-caleb` tool. Currently, `pwncat-caleb` cannot be installed because this dependency is missing from repository. 