### PR TITLE
python-idna_ssl: add package

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+python-idna_ssl

--- a/packages/python-idna_ssl
+++ b/packages/python-idna_ssl
@@ -1,0 +1,28 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-idna_ssl
+_pkgname=idna-ssl
+pkgver=1.1.0
+pkgrel=1
+pkgdesc='Patch ssl.match_hostname for Unicode(idna) domains support.'
+arch=('any')
+url='https://github.com/aio-libs/idna-ssl'
+license=('MIT')
+depends=('flake8' 'python' 'python-idna' 'python-isort')
+makedepends=('python-setuptools')
+checkdepends=('python-aiohttp' 'python-pytest' 'python-pytest-asyncio' 'python-pytest-cov' 'python-pytest-runner')
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('f9db74cecabbbfddfd1817bbd8434ef2aafeea433c3eefff3f94c7e994da40e3f315fcda527f3a0c3743028f26bbc934f1dd21f94134123c3271975d0527cd35')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py build
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+}


### PR DESCRIPTION
python-idna_ssl has been removed from Arch community repository and it is a dependency of some BlackArch tools.