### PR TITLE
python-pip-shims: add package

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+python-pip-shims

--- a/packages/python-pip-shims/PKGBUILD
+++ b/packages/python-pip-shims/PKGBUILD
@@ -1,0 +1,30 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-pip-shims
+_pkgname=pip_shims
+pkgver=0.7.3
+pkgrel=1
+pkgdesc='Compatibility shims for pip versions 8 thru current.'
+arch=('any')
+url='https://github.com/sarugaku/pip-shims'
+license=('ISC')
+depends=('python')
+makedepends=('python-pip' 'python-wheel' 'python-setuptools')
+checkdepends=('python-pytest-runner' 'git')
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+        "$pkgname-pip-22.2.patch::https://github.com/sarugaku/pip-shims/pull/86.patch")
+sha512sums=('5951abac407d7127592d9107c51f62241ccca79d00840ef1193028490a35a5bee0e5933e39715485f87e13d7b4e3ee7420d5affd82633271fa96a35b6b46fc1f'
+            '025524336cad457e553e22d3c4cc32939fff9d7cc02ba74906330a0a63dfbeba942ce23834bc4a4e0bf91d0405b4e8999d76f8adee0af73a7cd1c67ad9095255')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py build
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+}


### PR DESCRIPTION
python-pip-shims has been removed from Arch repository and moved to AUR and it is used as dependency for some BlackArch tool.