### PR TITLE
python-pysctp: fixed linux-headers in package()

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+python-pysctp

--- a/packages/python-pysctp/PKGBUILD
+++ b/packages/python-pysctp/PKGBUILD
@@ -32,7 +32,7 @@ build() {
 }
 
 package_python2-pysctp() {
-  depends=('python2' 'lksctp-tools' 'linux-headers')
+  depends=('python2' 'lksctp-tools')
 
   cd "$_pkgname-$pkgver-2"
 
@@ -42,7 +42,7 @@ package_python2-pysctp() {
 }
 
 package_python-pysctp() {
-  depends=('python' 'lksctp-tools' 'linux-headers')
+  depends=('python' 'lksctp-tools')
 
   cd "$_pkgname-$pkgver"
 


### PR DESCRIPTION
On the previous PR https://github.com/BlackArch/blackarch/pull/3753 I forgot to remove linux-headers from the package() functions since they have been already specified in optdepends at the beginning.