### PR TITLE
recoverdm: add package

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+recoverdm

--- a/packages/recoverdm/PKGBUILD
+++ b/packages/recoverdm/PKGBUILD
@@ -1,0 +1,33 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname='recoverdm'
+pkgver='0.20'
+pkgrel='4'
+pkgdesc='Recover damaged CD DVD and disks with bad sectors.'
+arch=('any')
+groups=('blackarch' 'blackarch-forensic')
+url='http://www.vanheusden.com/recoverdm/'
+license=('GPL')
+depends=('glibc')
+source=(
+  "http://web.archive.org/web/20150926094827if_/http://www.vanheusden.com/$pkgname/$pkgname-$pkgver.tgz"
+)
+sha512sums=('aa6d27e115986a94fdf589c9a10870d8170ecf6f3342c504cf974328c969d791986d5979fd2b9336a8c5b8424ca369321d76f09e4f4e2b14bec2080d171a734b')
+
+prepare() {
+  tar -xvf $pkgname-$pkgver.tgz
+}
+
+build() {
+  cd $pkgname-$pkgver
+
+  make
+}
+
+package() {
+  cd $pkgname-$pkgver
+
+  install -Dpm0755 'mergebad' 'recoverdm' -t "$pkgdir/usr/bin/"
+}
+


### PR DESCRIPTION
This tool is old but it uses simple libraries and it still works. It is used on new Kali Purple as purple team tool.

Feel free to add it or not.