### PR TITLE
python-dsinternals py11

### DIFF
--- a/packages/python-dsinternals/PKGBUILD
+++ b/packages/python-dsinternals/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=python-dsinternals
 _pkgname=dsinternals
 pkgver=1.2.4
-pkgrel=2
+pkgrel=3
 pkgdesc='A Python native library containing necessary classes, functions and structures to interact with Windows Active Directory..'
 arch=('any')
 url='https://pypi.org/project/dsinternals/#files'


### PR DESCRIPTION
Still using python 3.10 instead of 3.11

![image](https://github.com/BlackArch/blackarch/assets/16578570/8ef35bd5-1393-48be-9214-002adf7ec874)
