### PR TITLE
delete: pwntools

### DIFF
--- a/lists/to-remove
+++ b/lists/to-remove
@@ -1,2 +1,3 @@
+pwntools - (added in Arch Linux Extra repository)
 smartphone-pentest-framework - (deprecated - unmaintained > 6 years)
 zeus-scanner - (multiple upstream issues, unmaintained > 2 years)


### PR DESCRIPTION
[python-pwntools](https://archlinux.org/packages/extra/any/python-pwntools/) added in Arch Linux Extra repository on May 2023. BA `pwntools` no need anymore. All tools dependent on `pwntools` have been switched to `python-pwntools`.

It solves https://github.com/BlackArch/blackarch/issues/3859