### PR TITLE
go-windapsearch: improvement

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+go-windapsearch

--- a/packages/go-windapsearch/PKGBUILD
+++ b/packages/go-windapsearch/PKGBUILD
@@ -4,15 +4,13 @@
 pkgname=go-windapsearch
 _binname=windapsearch
 pkgver=v0.3.0.r22.ged05587
-pkgrel=1
+pkgrel=2
 pkgdesc='Utility to enumerate users, groups and computers from a Windows domain through LDAP queries.'
 arch=('x86_64' 'aarch64')
 groups=('blackarch' 'blackarch-recon' 'blackarch-windows')
 url='https://github.com/ropnop/go-windapsearch'
 license=('BSD')
 makedepends=('git' 'go' 'mage')
-conflicts=('windapsearch')
-provides=('windapsearch')
 source=("git+https://github.com/ropnop/$pkgname.git")
 sha512sums=('SKIP')
 
@@ -31,7 +29,7 @@ build() {
 package() {
   cd $pkgname
 
-  install -Dm 755 $_binname "$pkgdir/usr/bin/$_binname"
+  install -Dm 755 $_binname "$pkgdir/usr/bin/$pkgname"
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
   install -Dm 644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
- rename the binary with the go prefix so there is no conflict with windapsearch
- release because it's not available in repository

replace #3869