### PR TITLE
empire: add python-secretsocks dependency

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,2 @@
+python-secretsocks
+empire

--- a/packages/empire/PKGBUILD
+++ b/packages/empire/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=empire
 pkgver=3113.e46e61ae
-pkgrel=1
+pkgrel=2
 epoch=2
 pkgdesc='A PowerShell and Python post-exploitation agent.'
 groups=('blackarch' 'blackarch-automation')
@@ -33,7 +33,7 @@ depends=('python' 'python-urllib3' 'python-requests' 'python-iptools' 'tk'
          'python-platformdirs' 'python-pluggy' 'python-ply' 'python-pyasn1'
          'python-pyasn1-modules' 'python-pycparser' 'python-pycryptodome'
          'python-pygame' 'python-engineio' 'python-python-multipart'
-         'python-pyvnc' 'python-rsa' 'python-ruff' 'python-service-identity'
+         'python-pyvnc' 'python-rsa' 'python-ruff' 'python-secretsocks' 'python-service-identity'
          'python-sniffio' 'python-starlette' 'python-stone' 'python-toml'
          'python-tomli' 'python-twisted' 'python-typing-extensions'
          'python-wcwidth' 'python-websocket-client' 'python-websockets'

--- a/packages/python-secretsocks/PKGBUILD
+++ b/packages/python-secretsocks/PKGBUILD
@@ -1,0 +1,34 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-secretsocks
+_pkgname=PySecretSOCKS
+pkgver=23.43c0bed
+pkgrel=1
+pkgdesc='A Python socks server for tunneling a connection over another channel.'
+arch=('any')
+url='https://github.com/BC-SECURITY/PySecretSOCKS'
+license=('MIT')
+depends=('python')
+makedepends=('python-setuptools')
+options=(!emptydirs)
+source=("git+https://github.com/BC-SECURITY/PySecretSOCKS")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $_pkgname
+
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+build() {
+  cd "$_pkgname"
+
+  python setup.py build
+}
+
+package() {
+  cd "$_pkgname"
+
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+}


### PR DESCRIPTION
The command `empire-server` needs of PySecretSOCKS lib for working. The produced error is:
```
ModuleNotFoundError: No module named 'secretsocks'
```
It can be fixed by installing `python-secretsocks` that is added on BlackArch by this PR.