### PR TITLE
sslyze: Fix sslyze and dependency

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,2 +1,4 @@
 python-secretsocks
 empire
+python-tls-parser
+sslyze

--- a/packages/python-tls-parser/PKGBUILD
+++ b/packages/python-tls-parser/PKGBUILD
@@ -1,38 +1,22 @@
 # This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
 # See COPYING for license details.
 
-pkgbase=python-tls-parser
-pkgname=('python2-tls-parser' 'python-tls-parser')
+pkgname=python-tls-parser
 _pkgname='tls_parser'
 pkgver=2.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Small library to parse TLS records.'
-arch=('any')
+arch=('x86_64' 'aarch64')
 url='https://pypi.python.org/pypi/tls-parser/'
 license=('custom:unknown')
-makedepends=('python2-setuptools' 'python-setuptools')
+makedepends=('python-setuptools')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/tls_parser-$pkgver.tar.gz")
 sha512sums=('693d18f0f3baaa8bf122f0166a9041cfe816772930dcfb73cfc1e16b0cedef2cfd19623d91a6d9e745bfcc1d2cbfb001a031d8c0d6fe1dd46319c3469ba60812')
 
-prepare() {
-  cp -a "tls_parser-$pkgver" "tls_parser2-$pkgver"
-}
-
 build() {
-  cd "tls_parser2-$pkgver"
-
-  python2 setup.py build
-
   cd "$srcdir/tls_parser-$pkgver"
 
   python setup.py build
-}
-
-package_python2-tls-parser() {
-  cd "tls_parser2-$pkgver"
-
-  python2 setup.py install --prefix=/usr --root="$pkgdir" --optimize=1 \
-    --skip-build
 }
 
 package_python-tls-parser() {

--- a/packages/python-tls-parser/PKGBUILD
+++ b/packages/python-tls-parser/PKGBUILD
@@ -9,20 +9,29 @@ pkgdesc='Small library to parse TLS records.'
 arch=('x86_64' 'aarch64')
 url='https://pypi.python.org/pypi/tls-parser/'
 license=('custom:unknown')
-makedepends=('python-setuptools')
+makedepends=('python-build' 'python-pip')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/tls_parser-$pkgver.tar.gz")
 sha512sums=('693d18f0f3baaa8bf122f0166a9041cfe816772930dcfb73cfc1e16b0cedef2cfd19623d91a6d9e745bfcc1d2cbfb001a031d8c0d6fe1dd46319c3469ba60812')
 
 build() {
-  cd "$srcdir/tls_parser-$pkgver"
+  cd "$srcdir/$_pkgname-$pkgver"
 
-  python setup.py build
+  python -m build --wheel --outdir="$startdir/dist"
 }
 
 package_python-tls-parser() {
-  cd "tls_parser-$pkgver"
-
-  python setup.py install --prefix=/usr --root="$pkgdir" --optimize=1 \
-    --skip-build
+  cd "$_pkgname-$pkgver"
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    "$_pkgname"
 }
 

--- a/packages/sslyze/PKGBUILD
+++ b/packages/sslyze/PKGBUILD
@@ -11,7 +11,7 @@ arch=('x86_64' 'aarch64')
 url='https://github.com/nabla-c0d3/sslyze'
 license=('GPL2')
 depends=('python' 'python-tls-parser' 'python-cryptography' 'python-nassl'
-         'python-typing_extensions' 'python-pydantic')
+         'python-typing_extensions' 'python-pydantic' 'python-pyopenssl')
 makedepends=('python-setuptools')
 source=("https://github.com/nabla-c0d3/$pkgname/archive/$pkgver.zip")
 sha512sums=('d09df69de90e93f64b1742594aa9f0cb8720f2b4fba97fabdfa1495732221fb02b14b0cb48444419bca84fcc21db7bb141e8eae0dbfda9ed6814e780041a2a04')

--- a/packages/sslyze/PKGBUILD
+++ b/packages/sslyze/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=sslyze
 pkgver=5.1.3
 _pyver=3.11
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-crypto' 'blackarch-scanner')
 pkgdesc='Python tool for analyzing the configuration of SSL servers and for identifying misconfigurations.'
 arch=('x86_64' 'aarch64')
@@ -12,14 +12,14 @@ url='https://github.com/nabla-c0d3/sslyze'
 license=('GPL2')
 depends=('python' 'python-tls-parser' 'python-cryptography' 'python-nassl'
          'python-typing_extensions' 'python-pydantic' 'python-pyopenssl')
-makedepends=('python-setuptools')
+makedepends=('python-build' 'python-pip')
 source=("https://github.com/nabla-c0d3/$pkgname/archive/$pkgver.zip")
 sha512sums=('d09df69de90e93f64b1742594aa9f0cb8720f2b4fba97fabdfa1495732221fb02b14b0cb48444419bca84fcc21db7bb141e8eae0dbfda9ed6814e780041a2a04')
 
 build() {
   cd "$pkgname-$pkgver"
 
-  python setup.py build
+  python -m build --wheel --outdir="$startdir/dist"
 }
 
 prepare() {
@@ -31,7 +31,18 @@ prepare() {
 package() {
   cd "$pkgname-$pkgver"
 
-  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    "$pkgname"
 
   install -Dm 644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 


### PR DESCRIPTION
python-tls-parser:
-  hasn't been build for python 3.11 which made sslyze fail. 
- remove python2 instructions as no package in our repo is using it

sslyze:
- was missing a dependency (python-pyopenssl).

change both packages to PEP517