### PR TITLE
Fix trevorspray

### DIFF
--- a/packages/python-exchangelib/PKGBUILD
+++ b/packages/python-exchangelib/PKGBUILD
@@ -1,0 +1,48 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-exchangelib
+_pkgname=${pkgname#python-}
+pkgver=5.0.3
+pkgrel=1
+pkgdesc='Exchange Web Services client library.'
+arch=('any')
+url='https://github.com/ecederstrand/exchangelib'
+license=('BSD')
+depends=('python-cached-property' 'python-dnspython' 'python-oauthlib'
+         'python-defusedxml' 'python-isodate' 'python-lxml' 'python-pygments'
+         'python-pytzdata' 'python-tzlocal' 'python-requests-ntlm'
+         'python-requests-oauthlib')
+makedepends=('python-build' 'python-pip')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('17a79458fdeb7828ad5b1c32f0dba5d842b4ad9aec0bf795ac54dbbfa5a1eae04c430d047ac67195df72713354d600af921840e7246c7559c946f4e6fc52695d')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --outdir="$startdir/dist"
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    "$_pkgname"
+
+  cd $srcdir/"$_pkgname-$pkgver"
+
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+

--- a/packages/python-requests-ntlm/PKGBUILD
+++ b/packages/python-requests-ntlm/PKGBUILD
@@ -1,0 +1,45 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-requests-ntlm
+_pkgname=requests_ntlm
+pkgver=1.2.0
+pkgrel=1
+pkgdesc='HTTP NTLM authentication using the requests library.'
+arch=('any')
+url='https://github.com/requests/requests-ntlm'
+license=('ISC')
+depends=('python' 'python-requests' 'python-setuptools' 'python-pyspnego'
+         'python-cryptography')
+makedepends=('python-build' 'python-pip')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('557f4a4625dc74fc4023a8d74b480cfd61a64b88f6003f381bd0a5f160f4c8337b53a575b720f930cd8fe5c375c1508bbe36cff60e31df00bb9a7e3b19196678')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --outdir="$startdir/dist"
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    "$_pkgname"
+
+    cd $srcdir/$_pkgname-$pkgver
+
+    install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+

--- a/packages/python-requests-oauthlib/PKGBUILD
+++ b/packages/python-requests-oauthlib/PKGBUILD
@@ -1,0 +1,44 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-requests-oauthlib
+_pkgname=requests-oauthlib
+pkgver=1.3.1
+pkgrel=1
+pkgdesc='OAuth library support for Requests.'
+arch=('any')
+url='https://github.com/requests/requests-oauthlib'
+license=('ISC')
+depends=('python' 'python-requests' 'python-oauthlib')
+makedepends=('python-build' 'python-pip')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('fb4b52edf5f3e4f82f9bedc13b4bc4032e629fd17fef62e72c9eeb734d1963c08c081c9a96db464539637c678e1f5b7f4bf9bb618a8bc1b6aa2024c7b5c620ea')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --outdir="$startdir/dist"
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    "$_pkgname"
+
+    cd $srcdir/$_pkgname-$pkgver
+
+    install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+

--- a/packages/trevorproxy/PKGBUILD
+++ b/packages/trevorproxy/PKGBUILD
@@ -1,0 +1,38 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=trevorproxy
+pkgver=1.0.6
+pkgrel=1
+pkgdesc='A SOCKS proxy written in Python that randomizes your source IP address.'
+arch=('any')
+groups=('blackarch' 'blackarch-proxy')
+url='https://github.com/blacklanternsecurity/TREVORproxy'
+license=('GPL3')
+depends=('python' 'python-sh')
+makedepends=('python-build' 'python-pip')
+source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz")
+sha512sums=('6fae2f004ee4d0d11505ad623d1144ff7ac267aeb97dbd875da288a5126d78865d7ba0f152c6f6a0015ac3e226ea5f1450ffffffa11f0865afce6381b04a67e2')
+
+build() {
+  cd "$pkgname-$pkgver"
+
+  python -m build --wheel --outdir="$startdir/dist"
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    "$pkgname"
+}

--- a/packages/trevorspray/PKGBUILD
+++ b/packages/trevorspray/PKGBUILD
@@ -2,53 +2,38 @@
 # See COPYING for license details.
 
 pkgname=trevorspray
-pkgver=115.cbf72e6
+pkgver=2.0.9
 pkgrel=1
 pkgdesc='A modular password sprayer with threading, clever proxying, loot modules, and more!'
-groups=('blackarch' 'blackarch-cracker')
 arch=('any')
+groups=('blackarch' 'blackarch-cracker')
 url='https://github.com/blacklanternsecurity/TREVORspray'
 license=('GPL3')
-depends=('python' 'python-virtualenv')
-makedepends=('git')
-source=("$pkgname::git+https://github.com/blacklanternsecurity/TREVORspray.git"
-        'requirements.txt.patch')
-install="$pkgname.install"
-sha512sums=('SKIP'
-            '9661c32e9d75776ea1ef5aec1ce037842530d4d39ee87c2bdbcf6b8b85a0e49793b736c6f71d6a938664c2a38ea3faa248bbb1e36bd0af671830313e757c0066')
+depends=('trevorproxy' 'python-pysocks' 'python-tldextract'
+         'python-beautifulsoup4' 'python-exchangelib' )
+makedepends=('python-build' 'python-pip')
+source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz")
+sha512sums=('735d0d5046f9fa0610a9bc55b4cec2019abdf575880a9b8c8f147aab12bd4dd49bd4483cedb9cb6bc642e6551a5c58c54ea9c24abd9d314777c5e7748c7e2db4')
 
-pkgver() {
-  cd $pkgname
+build() {
+  cd "$pkgname-$pkgver"
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
-}
-
-prepare() {
-  cd $pkgname
-
-  patch -p0 < ../requirements.txt.patch
+  python -m build --wheel --outdir="$startdir/dist"
 }
 
 package() {
-  cd $pkgname
+  cd "$pkgname-$pkgver"
 
-  install -dm 755 "$pkgdir/usr/bin"
-  install -dm 755 "$pkgdir/usr/share/$pkgname"
-
-  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" *.md
-  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
-
-  rm *.md LICENSE
-
-  cp -a * "$pkgdir/usr/share/$pkgname/"
-
-  cat > "$pkgdir/usr/bin/$pkgname" << EOF
-#!/bin/sh
-cd /usr/share/$pkgname
-source venv/bin/activate
-exec python $pkgname/cli.py "\$@"
-EOF
-
-  chmod a+x "$pkgdir/usr/bin/$pkgname"
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    "$pkgname"
 }
-


### PR DESCRIPTION
- Add multiple dependencies
    - trevorproxy
    - python-exchangelib
    - python-requests-oauthlib
    - python-requests-ntlm
- move trevorspray from git to release version
- move from venv to pypi
- use PEP517