### PR TITLE
add python-cerbeyra-api

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+python-cerbeyra-api

--- a/packages/cerbeyra-api/PKGBUILD
+++ b/packages/cerbeyra-api/PKGBUILD
@@ -1,0 +1,39 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-cerbeyra-api
+_pkgname=${pkgname#python-}
+pkgver=1.1b1
+pkgrel=1
+pkgdesc='High level interface for interacting with Cerbeyra APIs and retrieving cyber-threat information from them.'
+arch=('any')
+url='https://cerbeyra.com/'
+license=('MIT')
+depends=('python-openpyxl' 'python-requests')
+makedepends=('python-build' 'python-pip' 'python-setuptools')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('fd0f1505f79bbbcc25de52d390d93847de069b51d3cba41fdfbd74ec47b13bdb3d88c23b6f3b63e016fd132e642f924b6e98979372067a5cf20899993bbe96c9')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --outdir="$startdir/dist"
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    $_pkgname
+}


### PR DESCRIPTION
This library provides a high level interface for interacting with Cerbeyra’s APIs and retrieving cyber-threat’s information from them. Through such API’s, it is possible to get clues regarding vulnerability assessments, cyber feeds, governance, threat intelligence and much more.

Just not sure about the `python-setuptools` dependency specified in its `pyproject.toml` file. This dependency could be still needed to build the package even if it is not based on setup.py?