### PR TITLE
Fixed Tor-Browser package

### DIFF
--- a/packages/tor-browser/PKGBUILD
+++ b/packages/tor-browser/PKGBUILD
@@ -24,19 +24,19 @@ source=("https://www.torproject.org/dist/torbrowser/$pkgver/tor-browser-linux64-
         "$pkgname.sh"
         "$pkgname.svg")
 sha512sums=('726f4e9de760a4c7091a1a3e7dac3f7f9ba21b315863ad589a0374af58592b3a734ee775dbc81829534bf0678994630601a18de1b556b848f4c141fdfa26069a'
-            '1318a652f7b65e30cdb0c607faf4391035288bcfcaffc50f7713de8eeb7d9151c115269fad1225fccd71d4d38537a804f05fba03b3df516afbce8a79d8988d7c'
+            '6990140cb4dfdbbe67bc09cfd9f16e8ed19001872a3f35e564ab2d8e951dfdeb269e416d8aeca7abf718368d8a8f9b3fb2ac77b0ffd19f20e94a570ffc478ce5'
             'e334c1f226235c30011e62602ec0c0bd549bfe411e37125a5ee47f2a2d187045bc261efcaf2a9490d01dc687878ecfe01827996adc62e76df39ee8146d76713e'
             '88c5d3035df46aa23cd98657e19b907a68ac233f92307556ea44b6a90bac2d04dfb5b23c7efaa3addd48a5def3daacf0c8731acb59b15a7390c4c3435427674a'
             '662b800e849f2fa369496974d0e22c68cb5f5666cb8d3f768d236daae40c693880fb051f860aacf347a0fc8491764a315053dc9bbcc149f820267d1466bd995a')
-noextract=("tor-browser-linux64-${pkgver}_en-US.tar.xz")
+noextract=("tor-browser-linux64-${pkgver}_ALL.tar.xz")
 install="$pkgname.install"
 
 prepare() {
   sed -i "s/REPL_NAME/$pkgname/g" "$pkgname.sh"
   sed -i "s/REPL_VERSION/$pkgver/g" "$pkgname.sh"
-  sed -i "s/REPL_LANGUAGE/en-US/g" "$pkgname.sh"
+  sed -i "s/REPL_LANGUAGE/ALL/g" "$pkgname.sh"
   sed -i "s/REPL_NAME/$pkgname/g" "$pkgname.desktop"
-  sed -i "s/REPL_LANGUAGE/en-US/g" "$pkgname.desktop"
+  sed -i "s/REPL_LANGUAGE/ALL/g" "$pkgname.desktop"
   sed -i "s/REPL_COMMENT/$pkgdesc/g" "$pkgname.desktop"
 }
 

--- a/packages/tor-browser/tor-browser.desktop
+++ b/packages/tor-browser/tor-browser.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=Tor Browser (REPL_LANGUAGE)
+Name=Tor Browser
 Exec=/usr/bin/REPL_NAME
 Icon=REPL_NAME
 Categories=Network;

--- a/packages/tor-browser/tor-browser.install
+++ b/packages/tor-browser/tor-browser.install
@@ -1,4 +1,4 @@
-pkgname="tor-browser-en"
+pkgname="tor-browser"
 
 pre_install() {
 	echo


### PR DESCRIPTION
Fixes the following error:
`
/usr/bin/tor-browser: Your version in /home/markustieger/.tor-browser is outdated or you do not have installed tor-browser yet.
/usr/bin/tor-browser: Extracting files to /home/markustieger/.tor-browser/INSTALL.
tar (child): /opt/tor-browser/tor-browser-linux64-12.5.4_en-US.tar.xz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
`

It trys to extract the /opt/tor-browser/tor-browser-linux64-12.5.4_en-US.tar.xz file, but it's called /opt/tor-browser/tor-browser-linux64-12.5.4_ALL.tar.xz. This is the fix