### PR TITLE
netexec: release

### DIFF
--- a/packages/netexec/PKGBUILD
+++ b/packages/netexec/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=netexec
 _pyver=3.11
-pkgver=TODO
+pkgver=v1.0.0.r0.g72e42e9
 pkgrel=1
 groups=('blackarch' 'blackarch-scanner' 'blackarch-exploitation'
         'blackarch-windows')

--- a/packages/netexec/PKGBUILD
+++ b/packages/netexec/PKGBUILD
@@ -1,0 +1,65 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=netexec
+_pyver=3.11
+pkgver=TODO
+pkgrel=1
+groups=('blackarch' 'blackarch-scanner' 'blackarch-exploitation'
+        'blackarch-windows')
+pkgdesc='A Windows / Active Directory environments pentest tool.'
+arch=('any')
+url='https://netexec.wiki/'
+license=('BSD')
+depends=('python' 'python-poetry')
+makedepends=('git')
+source=("$pkgname::git+https://github.com/Pennyw0rth/NetExec.git")
+sha512sums=('SKIP')
+install="$pkgname.install"
+
+pkgver() {
+  cd $pkgname
+
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+package() {
+  cd $pkgname
+
+  install -dm 755 "$pkgdir/usr/bin"
+  install -dm 755 "$pkgdir/usr/share/$pkgname"
+
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+  rm -rf LICENSE .github .git* .dockerignore Dockerfile Makefile *.nix
+
+  cp -a * "$pkgdir/usr/share/$pkgname/"
+
+  cat > "$pkgdir/usr/bin/$pkgname" << EOF
+#!/bin/sh
+poetry config cache-dir "/usr/share/$pkgname"
+poetry env use /usr/share/$pkgname/virtualenvs/*/bin/python$_pyver \\
+  --directory /usr/share/netexec
+poetry run --directory "/usr/share/$pkgname" $pkgname "\$@"
+EOF
+
+  cat > "$pkgdir/usr/bin/nxc" << EOF
+#!/bin/sh
+poetry config cache-dir "/usr/share/$pkgname"
+poetry env use /usr/share/$pkgname/virtualenvs/*/bin/python$_pyver \\
+  --directory /usr/share/netexec
+poetry run --directory "/usr/share/$pkgname" nxc "\$@"
+EOF
+
+  cat > "$pkgdir/usr/bin/nxcdb" << EOF
+#!/bin/sh
+poetry config cache-dir "/usr/share/$pkgname"
+poetry env use /usr/share/$pkgname/virtualenvs/*/bin/python$_pyver \\
+  --directory /usr/share/netexec
+poetry run --directory "/usr/share/$pkgname" nxcdb "\$@"
+EOF
+
+  chmod +x "$pkgdir/usr/bin/$pkgname" "$pkgdir/usr/bin/nxc" \
+    "$pkgdir/usr/bin/nxcdb"
+}
+

--- a/packages/netexec/netexec.install
+++ b/packages/netexec/netexec.install
@@ -1,0 +1,11 @@
+post_install() {
+  set -e
+  cd /usr/share/netexec
+  poetry config cache-dir /usr/share/netexec
+  poetry install --no-cache
+}
+
+post_upgrade() {
+  post_install "$@"
+}
+


### PR DESCRIPTION
fix #3948

NetExec is the community fork of CrackMapExec and where the project continue to live on. Porchetta Industries is dead and has been removed.

Prochetta repo was moved back to byt3bl33d3r that is inactive and will probably be abandoned.

So:

- https://github.com/Porchetta-Industries/CrackMapExec 🔴 dead, removed
- https://github.com/mpgn/CrackMapExec 🔴 dead, removed
- https://github.com/byt3bl33d3r/CrackMapExec 🟡 inactive, soon be abandoned, tag 6.0 and 6.1 is missing (but commits are present)
- https://github.com/Pennyw0rth/NetExec 🟢 active, community devs

For now, we can keep crackmapexec package is case but I provided the netexec package as well, there should be not conflict as all binaries and code were renamed:

- crackmapexec ➡️ netexec
- cme ➡️ nxc
- cmedb ➡️ nxcdb