### PR TITLE
stegdetect: add default `stegbreak` rules and fix FTBFS

### DIFF
--- a/packages/stegdetect/0001-tree-wide-rename-progname-to-avoid-conflicts.patch
+++ b/packages/stegdetect/0001-tree-wide-rename-progname-to-avoid-conflicts.patch
@@ -1,0 +1,146 @@
+From 0ebf68ba435dc060acd475c1eeb6132635b29055 Mon Sep 17 00:00:00 2001
+From: Mole Shang <135e2@135e2.dev>
+Date: Thu, 5 Oct 2023 13:23:38 +0800
+Subject: [PATCH] tree-wide: rename `progname` to avoid conflicts
+
+Ian Darwin's libfile (in subdir /file) uses the `progname` symbol
+as an alias to argv[0], so even we are using it as a library, newer ld would
+complain about `progname` redefination at linking stage.
+Rather than modifying third party projects, it's better to patch our
+legacy `stegdetect` source code. :)
+
+* Patch modified from https://github.com/frankwxu/digital-forensics-lab/tree/7a846e371608bd45b3cebef4e7fcb4dd5e4f8e20/Illegal_Possession_Images/tools
+
+Signed-off-by: Mole Shang <135e2@135e2.dev>
+Co-authored-by: Frank Xu <frank.w.xu@gmail.com>
+---
+ stegbreak.c   | 6 +++---
+ stegcompare.c | 6 +++---
+ stegdeimage.c | 6 +++---
+ stegdetect.c  | 6 +++---
+ 4 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/stegbreak.c b/stegbreak.c
+index 4b0bd59..107b2c1 100644
+--- a/stegbreak.c
++++ b/stegbreak.c
+@@ -62,7 +62,7 @@
+ #define FLAG_DOJSTEG	0x0004
+ 
+ char *rules_name;
+-char *progname;
++char *prog_name;
+ char *wordlist = "/usr/share/dict/words";
+ 
+ int convert = 0;
+@@ -117,7 +117,7 @@ usage(void)
+ {
+ 	fprintf(stderr,
+ 		"Usage: %s [-V] [-r <rules>] [-f <wordlist>] [-t <schemes>] file.jpg ...\n",
+-		progname);
++		prog_name);
+ }
+ 
+ void
+@@ -470,7 +470,7 @@ main(int argc, char *argv[])
+ 	int ch;
+ 
+ 	rules_name = RULES_NAME;
+-	progname = argv[0];
++	prog_name = argv[0];
+ 
+ 	scans = FLAG_DOJPHIDE;
+ 
+diff --git a/stegcompare.c b/stegcompare.c
+index 6e8a9d7..dd99c78 100644
+--- a/stegcompare.c
++++ b/stegcompare.c
+@@ -47,7 +47,7 @@
+ 
+ #define VERSION "0.1"
+ 
+-char *progname;
++char *prog_name;
+ 
+ #define FLAG_DOOUTGUESS	0x0001
+ #define FLAG_DOJPHIDE	0x0002
+@@ -58,7 +58,7 @@ int scans = FLAG_DOJPHIDE;
+ void
+ usage(void)
+ {
+-	fprintf(stderr,	"Usage: %s orig.jpg modified.jpg\n", progname);
++	fprintf(stderr,	"Usage: %s orig.jpg modified.jpg\n", prog_name);
+ }
+ 
+ int hist[257];
+@@ -242,7 +242,7 @@ main(int argc, char *argv[])
+ 	extern int optind;
+ 	int i, ch;
+ 
+-	progname = argv[0];
++	prog_name = argv[0];
+ 
+ 	/* read command line arguments */
+ 	while ((ch = getopt(argc, argv, "Vht:")) != -1)
+diff --git a/stegdeimage.c b/stegdeimage.c
+index 42ec551..f63b473 100644
+--- a/stegdeimage.c
++++ b/stegdeimage.c
+@@ -47,12 +47,12 @@
+ 
+ #define VERSION "0.1"
+ 
+-char *progname;
++char *prog_name;
+ 
+ void
+ usage(void)
+ {
+-	fprintf(stderr,	"Usage: %s orig.jpg deimages.jpg\n", progname);
++	fprintf(stderr,	"Usage: %s orig.jpg deimages.jpg\n", prog_name);
+ }
+ 
+ void
+@@ -153,7 +153,7 @@ main(int argc, char *argv[])
+ 	extern int optind;
+ 	char ch;
+ 
+-	progname = argv[0];
++	prog_name = argv[0];
+ 
+ 	/* read command line arguments */
+ 	while ((ch = getopt(argc, argv, "V")) != -1)
+diff --git a/stegdetect.c b/stegdetect.c
+index d787bcc..b80e641 100644
+--- a/stegdetect.c
++++ b/stegdetect.c
+@@ -73,7 +73,7 @@
+ float chi2cdf(float chi, int dgf);
+ double detect_f5(char *);
+ 
+-char *progname;
++char *prog_name;
+ 
+ float DCThist[257];
+ float scale = 1;		/* Sensitivity scaling */
+@@ -1088,7 +1088,7 @@ usage(void)
+ 	fprintf(stderr,
+ 	    "Usage: %s [-nqV] [-s <float>] [-d <num>] [-t <tests>] [-C <num>]\n"
+ 	    "\t [file.jpg ...]\n",
+-		progname);
++		prog_name);
+ }
+ 
+ char *
+@@ -1407,7 +1407,7 @@ main(int argc, char *argv[])
+ 	extern int optind;
+ 	int ch;
+ 
+-	progname = argv[0];
++	prog_name = argv[0];
+ 
+ 	scans = FLAG_DOOUTGUESS | FLAG_DOJPHIDE | FLAG_DOJSTEG | FLAG_DOINVIS |
+ 	    FLAG_DOF5 | FLAG_DOAPPEND;
+-- 
+2.42.0
+

--- a/packages/stegdetect/PKGBUILD
+++ b/packages/stegdetect/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=stegdetect
 pkgver=20.28a4f07
-pkgrel=1
+pkgrel=2
 pkgdesc='An automated tool for detecting steganographic content in images.'
 groups=('blackarch' 'blackarch-stego' 'blackarch-defensive'
         'blackarch-forensic')
@@ -12,8 +12,12 @@ url='https://github.com/redNixon/stegdetect'
 license=('BSD')
 depends=('gdk-pixbuf2')
 makedepends=('git' 'automake')
-source=("git+https://github.com/redNixon/$pkgname.git")
-sha512sums=('SKIP')
+source=("git+https://github.com/redNixon/$pkgname.git"
+        "rules.ini"
+        "0001-tree-wide-rename-progname-to-avoid-conflicts.patch")
+sha512sums=('SKIP'
+            '8a7e13c7c5b44d731c7e9e904bef221ce8c248a426a64de797196cafb0c3a5950967a064cf281ec998e7c28f3b82adfb7f329a2c1e160c466d00b60df54428fe'
+            '11223fad5640304d99ab057510f8d99feb0e560c5a7c66eca1900d781f80fcd415cc25802e4f5d3f6908494db37dcfdf6513f7f9ca3abe41d408645f31f6a7ca')
 
 pkgver() {
   cd $pkgname
@@ -21,8 +25,14 @@ pkgver() {
   echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
 }
 
+prepare() {
+  patch -d "${pkgname}" -Np1 -i "${srcdir}/0001-tree-wide-rename-progname-to-avoid-conflicts.patch"
+}
+
 build() {
   cd $pkgname
+
+  autoreconf -f -i # regen new confs
 
   if [ $CARCH = "x86_64" ]
   then
@@ -36,6 +46,8 @@ build() {
 
 package() {
   cd $pkgname
+
+  install -Dm 644 "$srcdir/rules.ini" "$pkgdir/usr/share/stegbreak/rules.ini"
 
   install -dm 755 "$pkgdir/usr/share/$pkgname"
 

--- a/packages/stegdetect/rules.ini
+++ b/packages/stegdetect/rules.ini
@@ -1,0 +1,59 @@
+#
+# This file is part of John the Ripper password cracker,
+# Copyright (c) 1996-98 by Solar Designer
+#
+# Wordlist mode rules
+[List.Rules:Wordlist]
+# Try words as they are
+:
+# Lowercase every pure alphanumeric word
+-c >3!?XlQ
+# Capitalize every pure alphanumeric word
+-c >2(?a!?XcQ
+# Lowercase and pluralize pure alphabetic words
+<*>2!?Alp
+# Lowercase pure alphabetic words and append '1'
+<*>2!?Al$1
+# Capitalize pure alphabetic words and append '1'
+-c <*>2!?Ac$1
+# Duplicate reasonably short pure alphabetic words (fred -> fredfred)
+<7>1!?Ald
+# Lowercase and reverse pure alphabetic words
+>3!?AlMrQ
+# Prefix pure alphabetic words with '1'
+>2!?Al^1
+# Uppercase pure alphanumeric words
+-c >2!?XuQ
+# Lowercase pure alphabetic words and append a digit or simple punctuation
+<*>2!?Al$[2!37954860.?]
+# Words containing punctuation, which is then squeezed out, lowercase
+/?p@?p>3l
+# Words with vowels removed, lowercase
+/?v@?v>3l
+# Words containing whitespace, which is then squeezed out, lowercase
+/?w@?w>3l
+# Capitalize and duplicate short pure alphabetic words (fred -> FredFred)
+-c <7>1!?Acd
+# Capitalize and reverse pure alphabetic words (fred -> derF)
+-c <+>2!?Acr
+# Reverse and capitalize pure alphabetic words (fred -> Derf)
+-c >2!?AMrQc
+# Lowercase and reflect pure alphabetic words (fred -> fredderf)
+<7>1!?AlMrQrf
+# Uppercase the last letter of pure alphabetic words (fred -> freD)
+-c <+>2!?AMrQcr
+# Prefix pure alphabetic words with '2' or '4'
+>2!?Al^[24]
+# Capitalize pure alphabetic words and append a digit or simple punctuation
+-c <*>2!?Ac$[2!3957468.?0]
+# Prefix pure alphabetic words with digits
+>2!?Al^[379568]
+# Capitalize and pluralize pure alphabetic words of reasonable length
+-c <*>2!?Acp
+# Lowercase/capitalize pure alphabetic words of reasonable length and convert:
+# crack -> cracked, crack -> cracking
+<*>2!?Al[PI]
+-c <*>2!?Ac[PI]
+# Try the second half of split passwords
+-s x**
+-s-c x**MlQ


### PR DESCRIPTION
Fixes #3965.

---
Edit: I've reformatted the patch. Looks like my editor is automatically formatting C source files without asking 🙄🙄🙄