### PR TITLE
modifycerttemplate: add package

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+modifycerttemplate

--- a/packages/modifycerttemplate/PKGBUILD
+++ b/packages/modifycerttemplate/PKGBUILD
@@ -1,0 +1,41 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=modifycerttemplate
+_pkgname=modifyCertTemplate
+pkgver=7.4c35708
+pkgrel=1
+pkgdesc='Aid operators in modifying ADCS certificate templates so that a created vulnerable state can be leveraged for privilege escalation.'
+arch=('any')
+groups=('blackarch' 'blackarch-windows')
+url='https://github.com/fortalice/modifyCertTemplate'
+license=('custom:unknown')
+depends=('python' 'python-ldap3' 'impacket')
+makedepends=('git')
+source=("git+https://github.com/fortalice/$_pkgname.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $_pkgname
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+package() {
+  cd $_pkgname
+
+  install -dm 755 "$pkgdir/usr/bin"
+  install -dm 755 "$pkgdir/usr/share/$pkgname"
+
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+
+  rm README.md .gitignore
+
+  cp -a * "$pkgdir/usr/share/$pkgname/"
+
+  cat > "$pkgdir/usr/bin/$pkgname" << EOF
+#!/bin/sh
+exec python /usr/share/$pkgname/modifyCertTemplate.py "\$@"
+EOF
+
+  chmod +x "$pkgdir/usr/bin/$pkgname"
+}

--- a/packages/modifycerttemplate/PKGBUILD
+++ b/packages/modifycerttemplate/PKGBUILD
@@ -28,7 +28,7 @@ package() {
 
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
 
-  rm README.md .gitignore
+  rm README.md .gitignore requirements.txt
 
   cp -a * "$pkgdir/usr/share/$pkgname/"
 


### PR DESCRIPTION
[modifyCertTemplate](https://github.com/fortalice/modifyCertTemplate) is designed to aid an operator in modifying ADCS certificate templates so that a created vulnerable state can be leveraged for privilege escalation (and then reset the template to its previous state afterwards).