### PR TITLE
add exe2hex

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+exe2hexbat

--- a/packages/exe2hexbat/PKGBUILD
+++ b/packages/exe2hexbat/PKGBUILD
@@ -1,0 +1,42 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=exe2hexbat
+_pkgname=exe2hex
+pkgver=1.5.1
+pkgrel=1
+pkgdesc='Inline file transfer using in-built Windows tools (DEBUG.exe or PowerShell).'
+arch=('any')
+groups=('blackarch' 'blackarch-disassembler')
+url='https://github.com/g0tmi1k/exe2hex'
+license=('MIT')
+depends=('python')
+makedepends=('git')
+source=("git+https://github.com/g0tmi1k/$_pkgname.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $_pkgname
+  
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+package() {
+  cd $_pkgname
+
+  install -dm 755 "$pkgdir/usr/bin"
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" *.md
+
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+  rm -rf LICENSE *.md
+
+  cp -a * "$pkgdir/usr/share/$pkgname/"
+
+  cat > "$pkgdir/usr/bin/$pkgname" << EOF
+#!/bin/sh
+exec python /usr/share/$pkgname/exe2hex.py "\$@"
+EOF
+
+  chmod a+x "$pkgdir/usr/bin/$pkgname"
+}

--- a/packages/exe2hexbat/PKGBUILD
+++ b/packages/exe2hexbat/PKGBUILD
@@ -40,3 +40,4 @@ EOF
 
   chmod a+x "$pkgdir/usr/bin/$pkgname"
 }
+

--- a/packages/exe2hexbat/PKGBUILD
+++ b/packages/exe2hexbat/PKGBUILD
@@ -1,8 +1,7 @@
 # This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
 # See COPYING for license details.
 
-pkgname=exe2hexbat
-_pkgname=exe2hex
+pkgname=exe2hex
 pkgver=1.5.1.r6.ge563b35
 pkgrel=1
 pkgdesc='Inline file transfer using in-built Windows tools (DEBUG.exe or PowerShell).'
@@ -12,17 +11,17 @@ url='https://github.com/g0tmi1k/exe2hex'
 license=('MIT')
 depends=('python')
 makedepends=('git')
-source=("git+https://github.com/g0tmi1k/$_pkgname.git")
+source=("git+https://github.com/g0tmi1k/$pkgname.git")
 sha512sums=('SKIP')
 
 pkgver() {
-  cd $_pkgname
+  cd $pkgname
   
   git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 package() {
-  cd $_pkgname
+  cd $pkgname
 
   install -dm 755 "$pkgdir/usr/bin"
   install -dm 755 "$pkgdir/usr/share/$pkgname"
@@ -34,10 +33,10 @@ package() {
 
   cp -a * "$pkgdir/usr/share/$pkgname/"
 
-  cat > "$pkgdir/usr/bin/$_pkgname" << EOF
+  cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
 exec python /usr/share/$pkgname/exe2hex.py "\$@"
 EOF
 
-  chmod a+x "$pkgdir/usr/bin/$_pkgname"
+  chmod a+x "$pkgdir/usr/bin/$pkgname"
 }

--- a/packages/exe2hexbat/PKGBUILD
+++ b/packages/exe2hexbat/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=exe2hexbat
 _pkgname=exe2hex
-pkgver=1.5.1
+pkgver=1.5.1.r6.ge563b35
 pkgrel=1
 pkgdesc='Inline file transfer using in-built Windows tools (DEBUG.exe or PowerShell).'
 arch=('any')
@@ -25,6 +25,7 @@ package() {
   cd $_pkgname
 
   install -dm 755 "$pkgdir/usr/bin"
+  install -dm 755 "$pkgdir/usr/share/$pkgname"
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" *.md
 
   install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
@@ -33,10 +34,10 @@ package() {
 
   cp -a * "$pkgdir/usr/share/$pkgname/"
 
-  cat > "$pkgdir/usr/bin/$pkgname" << EOF
+  cat > "$pkgdir/usr/bin/$_pkgname" << EOF
 #!/bin/sh
 exec python /usr/share/$pkgname/exe2hex.py "\$@"
 EOF
 
-  chmod a+x "$pkgdir/usr/bin/$pkgname"
+  chmod a+x "$pkgdir/usr/bin/$_pkgname"
 }


### PR DESCRIPTION
Convert a Windows PE executable file to a batch file and vice versa. Ref:  https://www.kali.org/tools/exe2hexbat/
https://github.com/g0tmi1k/exe2hex/