### PR TITLE
fixed unix-privesc-check

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+unix-privesc-check

--- a/packages/unix-privesc-check/PKGBUILD
+++ b/packages/unix-privesc-check/PKGBUILD
@@ -3,14 +3,14 @@
 
 pkgname=unix-privesc-check
 pkgver=1.4
-pkgrel=6
+pkgrel=7
 groups=('blackarch' 'blackarch-automation' 'blackarch-scanner')
 pkgdesc='Tries to find misconfigurations that could allow local unprivilged users to escalate privileges to other users or to access local apps (e.g. databases).'
 url='http://pentestmonkey.net/tools/audit/unix-privesc-check'
 arch=('any')
 license=('GPL2')
 source=("http://pentestmonkey.net/tools/$pkgname/$pkgname-$pkgver.tar.gz")
-sha512sums=('ffda798426bd9ffb91fc69c3ac52ddbc1f25dbc1')
+sha512sums=('a15e35bca7e6a564613a3b982516294d16d1f3cd6bb0b1eb3fd49ada1093e93ed4ca78837dbded90c630de5583b84ff368df8e52da47cdc5cd446cab4654320a')
 
 package() {
   cd "$pkgname-$pkgver"
@@ -18,4 +18,3 @@ package() {
   install -Dm 755 $pkgname "$pkgdir/usr/bin/$pkgname"
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" CHANGELOG
 }
-


### PR DESCRIPTION
Fixed sha512 and binary name that was wrongly `unix-privsc-check`.