### PR TITLE
python-pyparsing dependency needed to provide QuotedString

### DIFF
--- a/packages/wfuzz/PKGBUILD
+++ b/packages/wfuzz/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=wfuzz
 pkgver=1155.1b695ee
-pkgrel=5
+pkgrel=6
 groups=('blackarch' 'blackarch-fuzzer' 'blackarch-webapp')
 pkgdesc='Utility to bruteforce web applications to find their not linked resources.'
 url='https://github.com/xmendez/wfuzz'

--- a/packages/wfuzz/PKGBUILD
+++ b/packages/wfuzz/PKGBUILD
@@ -10,7 +10,7 @@ url='https://github.com/xmendez/wfuzz'
 arch=('any')
 license=('GPL2')
 depends=('python' 'python-lxml' 'python-pycurl' 'python-chardet' 'python-six'
-         'python-future' 'python-wxpython')
+         'python-future' 'python-wxpython' 'python-pyparsing')
 makedepends=('git')
 source=('git+https://github.com/xmendez/wfuzz.git')
 sha512sums=('SKIP')


### PR DESCRIPTION
I tried to install wfuzz from a fresh blackarch on Arch Linux and got a "QuotedString" NameError exception.

A `sudo pacman -S python-pyparsing` solved the issue which is why I propose to include it in the deps of the package