### PR TITLE
WIP bloodhound: upstream repository migration

### DIFF
--- a/packages/bloodhound/PKGBUILD
+++ b/packages/bloodhound/PKGBUILD
@@ -2,18 +2,18 @@
 # See COPYING for license details.
 
 pkgname=bloodhound
-pkgver=1663.a78dff3
+pkgver=v5.1.0.r16.ga4ea6f1
 pkgrel=1
 pkgdesc='Six Degrees of Domain Admin'
 groups=('blackarch' 'blackarch-recon' 'blackarch-windows')
 arch=('x86_64' 'aarch64')
-url='https://github.com/BloodHoundAD/BloodHound'
+url='https://github.com/SpecterOps/BloodHound'
 license=('GPL3')
 depends=('nodejs' 'neo4j-community' 'alsa-lib' 'gtk3' 'libxss' 'nss'
          'gconf' 'libxtst' 'jre11-openjdk-headless')
 makedepends=('git' 'nodejs-electron-packager' 'npm' 'unzip')
 optdepends=('python: for some scripts' 'powershell: for PowerShell ingestion')
-source=("$pkgname::git+https://github.com/BloodHoundAD/BloodHound.git")
+source=("$pkgname::git+https://github.com/SpecterOps/BloodHound.git")
 options=(!strip)
 sha512sums=('SKIP')
 install="$pkgname.install"
@@ -27,7 +27,7 @@ fi
 pkgver() {
   cd "$pkgname"
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 build() {


### PR DESCRIPTION
https://github.com/BloodHoundAD/BloodHound is deprecated and will be archived in the future, the dev now takes place at https://github.com/SpecterOps/BloodHound

the architecture and build toolchain sees to have changed but the production building steps are not straightforward

fix #3972