### PR TITLE
Adding missing perl-data-validate-ip dependency for witchxtool

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+perl-data-validate-ip

--- a/packages/perl-data-validate-ip/PKGBUILD
+++ b/packages/perl-data-validate-ip/PKGBUILD
@@ -12,7 +12,7 @@ options=('!emptydirs')
 depends=('perl' 'perl-netaddr-ip')
 url='https://metacpan.org/release/Data-Validate-IP'
 source=("https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/$_pkgname-$pkgver.tar.gz")
-sha512sums=('SKIP')
+sha256sums=('734aff86b6f9cad40e1c4da81f28faf18e0802c76a566d95e5613d4318182fc1')
 _distdir="$_pkgname-$pkgver"
 
 build() {

--- a/packages/perl-data-validate-ip/PKGBUILD
+++ b/packages/perl-data-validate-ip/PKGBUILD
@@ -1,0 +1,40 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=perl-data-validate-ip
+_pkgname=Data-Validate-IP
+pkgver=0.31
+pkgrel=1
+pkgdesc='IPv4 and IPv6 validation methods'
+arch=('any')
+license=('PerlArtistic' 'GPL')
+options=('!emptydirs')
+depends=('perl' 'perl-netaddr-ip')
+url='https://metacpan.org/release/Data-Validate-IP'
+source=("https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/$_pkgname-$pkgver.tar.gz")
+sha512sums=('SKIP')
+_distdir="$_pkgname-$pkgver"
+
+build() {
+  ( export PERL_MM_USE_DEFAULT=1 PERL5LIB="" \
+      PERL_AUTOINSTALL=--skipdeps \
+      PERL_MM_OPT="INSTALLDIRS=vendor DESTDIR='$pkgdir'" \
+      PERL_MB_OPT="--insalldirs vendor --destdir '$pkgdir'" \
+      MODULEBUILDRC=/dev/null
+
+    cd $_distdir
+
+    /usr/bin/perl Makefile.PL
+
+    make
+  )
+}
+
+package() {
+  cd $_distdir
+
+  make install
+
+  find "$pkgdir" -name .packlist -o -name perllocal.pod -delete
+}
+


### PR DESCRIPTION
Dependency no longer on Arch Linux repos and breaking `witchxtool`.