### PR TITLE
Fixed Tor-Browser package (again)

### DIFF
--- a/packages/tor-browser/PKGBUILD
+++ b/packages/tor-browser/PKGBUILD
@@ -17,7 +17,6 @@ pkgrel=1
 pkgdesc='Tor Browser Bundle: anonymous browsing using Firefox and Tor.'
 groups=('blackarch' 'blackarch-defensive')
 url='https://www.torproject.org/projects/torbrowser.html'
-arch=('x86_64')
 license=('GPL')
 depends=('libxt' 'startup-notification' 'mime-types' 'dbus-glib' 'alsa-lib'
          'desktop-file-utils' 'hicolor-icon-theme' 'libvpx' 'icu' 'libevent'
@@ -32,12 +31,14 @@ provides=("$pkgname")
 conflicts=("$pkgname")
 install="$pkgname.install"
 _urlbase="https://dist.torproject.org/torbrowser/${pkgver}"
-source=("$_urlbase/$pkgname-linux-x86_64-$pkgver.tar.xz"
+_archstr="x86_64"
+arch=("$_archstr")
+source=("$_urlbase/$pkgname-linux-$_archstr-$pkgver.tar.xz"
         "$pkgname.desktop.in"
         "$pkgname.in"
         "$pkgname.png"
         "$pkgname.svg")
-noextract=("$pkgname-linux-x86_64-$pkgver.tar.xz")
+noextract=("$pkgname-linux-$_archstr-$pkgver.tar.xz")
 sha512sums=('15e0fa7c1a26a6417fa02dbe02a37e9a7cfaba3bf9758254c8ee88fb5f29ac8e4cd835f3b22fd68f123b384432a7b78a8c333c4b70d11ad8818c383a5a9dbb17'
             '909d72393acbfe1123ead9450e14bef35fb570e5488982e46632a21734990a2cffdcba74f6e0d62eac78aa183c5778b57951ccd1095e46b910cbd860277f0259'
             '8c656941749238d1e4b0549cc0f2ca37c103a4e57422ac1f25ea147ab396b843c0613569ced0f3418ae9be5a8d5158d7d3da8be153a1da01f460625eced46e7e'
@@ -75,7 +76,7 @@ package() {
 	sed "$_sed_subst" "$pkgname.desktop.in" > \
 		"$pkgdir/usr/share/applications/$pkgname.desktop"
 
-	install -Dm 444 "$pkgname-linux-x86_64-$pkgver.tar.xz" \
-		"$pkgdir/opt/$pkgname/$pkgname-x86_64-$pkgver.tar.xz"
+	install -Dm 444 "$pkgname-linux-$_archstr-$pkgver.tar.xz" \
+		"$pkgdir/opt/$pkgname/$pkgname-$_archstr-$pkgver.tar.xz"
 }
 


### PR DESCRIPTION
Fixes that the arch variable doesn't get replaced in "tor-browser.in".

and btw simple question:
Do you even test this package? It's the second time, something broke.
(it hasn't found the tar.xz file, because the $PACKAGE_ARCH" was not replaced and because of that, it tryed to extract from a filepath, that does not exist)