### PR TITLE
smbmap: various upgrade

### DIFF
--- a/packages/smbmap/PKGBUILD
+++ b/packages/smbmap/PKGBUILD
@@ -2,15 +2,15 @@
 # See COPYING for license details.
 
 pkgname=smbmap
-pkgver=166.73c9907
+pkgver=v1.10.2.r0.gdc3f98a
 pkgrel=1
 groups=('blackarch' 'blackarch-scanner' 'blackarch-recon')
 pkgdesc='A handy SMB enumeration tool.'
 arch=('any')
 url='https://github.com/ShawnDEvans/smbmap'
 license=('GPL3')
-depends=('python' 'impacket' 'python-pycryptodomex' 'python-pyasn1'
-         'python-termcolor')
+depends=('python' 'impacket' 'python-pyasn1' 'python-pycryptodomex'
+         'python-configupdater' 'python-termcolor')
 makedepends=('python-build' 'python-pip' 'git')
 source=("git+https://github.com/ShawnDEvans/$pkgname.git")
 sha512sums=('SKIP')
@@ -18,7 +18,7 @@ sha512sums=('SKIP')
 pkgver() {
   cd $pkgname
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 build() {


### PR DESCRIPTION
- update to 1.10.2 https://github.com/ShawnDEvans/smbmap/tags
- add missing dependency https://github.com/ShawnDEvans/smbmap/blob/dc3f98aad9db709d609dc3e07428e29746fe6946/setup.py#L30
- move `pkgver()` to tags (no need for epoch https://semvercompare.azurewebsites.net/?version=166.73c9907&version=v1.10.2.r0.gdc3f98a)