### PR TITLE
Fix retdec PKGBUILD

### DIFF
--- a/packages/retdec/PKGBUILD
+++ b/packages/retdec/PKGBUILD
@@ -12,7 +12,7 @@ license=('MIT')
 depends=('bc' 'graphviz' 'python' 'upx')
 makedepends=('autoconf' 'automake' 'bison' 'cmake' 'doxygen' 'flex' 'gcc' 'git'
              'graphviz' 'libtool' 'm4' 'make' 'openssl' 'perl' 'python' 'upx'
-             'zlib' 'wget' 'base-devel')
+             'zlib' 'wget')
 source=("$pkgname::git+https://github.com/avast/$pkgname.git")
 sha512sums=('SKIP')
 

--- a/packages/retdec/PKGBUILD
+++ b/packages/retdec/PKGBUILD
@@ -12,8 +12,8 @@ license=('MIT')
 depends=('bc' 'graphviz' 'python' 'upx')
 makedepends=('autoconf' 'automake' 'bison' 'cmake' 'doxygen' 'flex' 'gcc' 'git'
              'graphviz' 'libtool' 'm4' 'make' 'openssl' 'perl' 'python' 'upx'
-             'zlib' 'wget')
-source=("$pkgname::git+https://github.com/avast-tl/$pkgname.git")
+             'zlib' 'wget' 'base-devel')
+source=("$pkgname::git+https://github.com/avast/$pkgname.git")
 sha512sums=('SKIP')
 
 pkgver() {
@@ -40,8 +40,8 @@ package() {
 
   cd ..
 
-  for tool in 'retdec-archive-decompiler' 'retdec-color-c' 'retdec-config' \
-              'retdec-decompiler' 'retdec-fileinfo' \
+  for tool in 'retdec-archive-decompiler' \
+              'retdec-fileinfo' \
               'retdec-signature-from-library-creator' 'retdec-unpacker' \
               'retdec-utils'; do
     ln -fs "/usr/bin/$tool.py" "$pkgdir/usr/bin/$tool"


### PR DESCRIPTION
Avoid retdec-decompiler symlink overwriting the retdec-decompiler binary, add dependency for source compilation and clean empty symlinks.