### PR TITLE
Change mirror url

### DIFF
--- a/mirror/mirror.lst
+++ b/mirror/mirror.lst
@@ -46,7 +46,8 @@ NL|https://mirror.serverion.com/blackarch/$repo/os/$arch|serverion
 NZ|http://nz-mirror.intergrid.com.au/blackarch/$repo/os/$arch|intergrid
 PL|http://ftp.icm.edu.pl/pub/Linux/dist/blackarch/$repo/os/$arch|ICMuniversity
 PL|https://ftp.icm.edu.pl/pub/Linux/dist/blackarch/$repo/os/$arch|ICMuniversity
-RU|http://mirror.surf/blackarch/$repo/os/$arch|mirror.surf
+RU|http://repository.su/blackarch/$repo/os/$arch|dmitry.sh
+RU|https://repository.su/blackarch/$repo/os/$arch|dmitry.sh
 RU|http://mirror.truenetwork.ru/blackarch/$repo/os/$arch|truenetwork
 RU|https://mirror.truenetwork.ru/blackarch/$repo/os/$arch|truenetwork
 RU|https://mirror.yandex.ru/mirrors/blackarch/$repo/os/$arch|yandex


### PR DESCRIPTION
Due to infrastructure changes, the URL changed from mirror.surf to repository.su.

New url:
https://repository.su/blackarch
http://repository.su/blackarch
rsync://repository.su/blackarch