### PR TITLE
Port of python2 blackarch tool simple-lan-scan to a python3 version

### DIFF
--- a/packages/simple-lan-scan3/PKGBUILD
+++ b/packages/simple-lan-scan3/PKGBUILD
@@ -1,0 +1,19 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=simple-lan-scan3
+pkgver=1.0.1
+pkgrel=1
+groups=('blackarch' 'blackarch-scanner' 'blackarch-recon' 'blackarch-networking')
+pkgdesc='A simple python3 script that leverages scapy for discovering live hosts on a network.'
+arch=('any')
+url='https://codeberg.org/jahway603/Simple-LAN-Scanner3'
+license=('custom:unknown')
+depends=('python' 'python-scapy')
+source=("$pkgname::$url/raw/branch/main/simple_lan_scan3.py")
+sha512sums=('3c35317a0092be729d79ec3e7d4a598d47d594a4550005d4f61af6d8085ebf01da2aaf796acce32c535bf92259eb16f55f77636304a01e41925e3b6e3f7d2b2e')
+
+package() {
+  install -Dm 755 $pkgname "$pkgdir/usr/bin/$pkgname"
+}
+


### PR DESCRIPTION
Ported the python2-written blackarch tool simple-lan-scan to a python3 version