### PR TITLE
semgrep: update and fix build

### DIFF
--- a/packages/semgrep/PKGBUILD
+++ b/packages/semgrep/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=semgrep
-pkgver=1.55.2
+pkgver=1.59.1
 _pyver=3.11
 _py=cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311
 pkgrel=1
@@ -21,8 +21,8 @@ makedepends=('python-build' 'python-pip' 'python-wheel')
 replaces=('python-semgrep')
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz"
         "https://files.pythonhosted.org/packages/$_py/${pkgname::1}/$pkgname/${pkgname//-/_}-$pkgver-$_py-none-any.whl")
-sha512sums=('fd3ff2fc846de44dfbab04530d07a513673f08114b6c79269f5277bd3724adecc8a68060f6c3375f9dbe14dca69b94706d5943ebb7bf13892e4e66ed9b2ab8b4'
-            'f33dc6369717c190ffe1170ff85b5a6494e1d86e99f992e2c4ed53cca5047e29f604e081a656df2233ca1155a55eb4c4dfc80a2827d6aea8d2562cdab52836a1')
+sha512sums=('ee9623d5c2fd8e7f49240e948f25531ccb65b53e44d92d63aaf4ce154d7a392c1bbd318bf0e0c95b5c38c3c767e0f9aa68087149f409e95b4fa77508adea36b5'
+            '15a8b106fa2364c4a62191f3c8330637dd55e59e3638afb63eef036e09a048cf543c767ca2494d21439cc7b675ce092c32b387416cd86b53e8379d841e3286c9')
 
 build() {
   cd "$pkgname-$pkgver"
@@ -52,9 +52,5 @@ package() {
     "$srcdir/$pkgname-$pkgver.data/purelib/$pkgname/bin/$pkgname-core" \
     "$pkgdir/usr/lib/python$_pyver/site-packages/$pkgname/bin/$pkgname-core"
   strip "$pkgdir/usr/lib/python$_pyver/site-packages/$pkgname/bin/$pkgname-core"
-
-  # semgrep sg binary conflicts with shadow sg binary
-  # https://github.com/semgrep/semgrep/issues/9571
-  mv "$pkgdir/usr/bin/sg" "$pkgdir/usr/bin/$pkgname-sg"
 }
 


### PR DESCRIPTION
auto-update was prevented by the tmp fix causing error as the binary wasn't there anymore

it has been handled upstream (see https://github.com/semgrep/semgrep/issues/9571) so the fix is no longer required.