### PR TITLE
airgeddon bump

### DIFF
--- a/packages/airgeddon/PKGBUILD
+++ b/packages/airgeddon/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=airgeddon
-pkgver=v11.21.r0.g6afc39d
+pkgver=v11.22.r0.gfe2c42b
 pkgrel=1
 epoch=1
 pkgdesc='Multi-use bash script for Linux systems to audit wireless networks.'


### PR DESCRIPTION
I know git package should be auto-bumped but as this one was not for 5 months I guess it's missing from the batch.