### PR TITLE
add impacket-ba

### DIFF
--- a/packages/impacket-ba/PKGBUILD
+++ b/packages/impacket-ba/PKGBUILD
@@ -1,0 +1,33 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=impacket-ba
+_pkgname=impacket
+pkgver=0.11.0
+pkgrel=1
+pkgdesc='Collection of classes for working with network protocols'
+url='https://github.com/fortra/impacket'
+arch=('any')
+groups=('blackarch' 'blackarch-exploitation' 'blackarch-networking')
+license=('Apache')
+depends=('python' 'python-pyasn1' 'python-pycryptodomex' 'python-pyopenssl'
+         'python-six' 'python-ldap3' 'ldapdomaindump' 'python-flask'
+         'python-future' 'python-charset-normalizer' 'python-dsinternals'
+         'python-setuptools') # Will be fixed in 0.12.0 https://github.com/fortra/impacket/issues/885#issuecomment-1197218746
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('8bd7baf3c9c4ca826d9bd472bc1842e4fc1b0a9eae643f247606b05f4b375416550b9e4445414ec51e6524422666ce0c869ee63a2aef59451b827feaccb0db7b')
+provides=('impacket')
+conflicts=('impacket')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py build
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+}


### PR DESCRIPTION
- AL package has not been updated since 2023-06-01 while no other packages depends on it.
- AL package is regularly out of date for a long time
- Some scripts are suffering some bugs that have been corrected in newer version, e.g. https://gitlab.archlinux.org/archlinux/packaging/packages/impacket/-/issues/1
- AL package is missing several dependencies required at runtime that are also declared upstream, see. https://gitlab.archlinux.org/archlinux/packaging/packages/impacket/-/issues/2

For all those reasons, I decided to provide our own package that will better reflects our standards and be updated more frequently. I added the `provides` and `conflicts` so we can choose from one or another in other package dependencies.