### PR TITLE
apkleaks: add missing dependency

### DIFF
--- a/packages/apkleaks/PKGBUILD
+++ b/packages/apkleaks/PKGBUILD
@@ -3,13 +3,13 @@
 
 pkgname=apkleaks
 pkgver=v2.6.1.r8.gc7b510c
-pkgrel=1
+pkgrel=2
 pkgdesc='Scanning APK file for URIs, endpoints & secrets.'
 arch=('any')
 groups=('blackarch' 'blackarch-mobile' 'blackarch-misc')
 url='https://github.com/dwisiswant0/apkleaks'
 license=('Apache')
-depends=('python' 'pyaxmlparser')
+depends=('python' 'pyaxmlparser' 'jadx')
 makedepends=('git' 'python-setuptools')
 source=("git+https://github.com/dwisiswant0/$pkgname.git")
 sha512sums=('SKIP')


### PR DESCRIPTION
it requirs jadx at runtime to decompile