### PR TITLE
Split ldapdomaindump between python2 and 3

### DIFF
--- a/lists/python2-tools
+++ b/lists/python2-tools
@@ -245,7 +245,6 @@ kwetza
 laf
 lans
 ldap-brute
-ldapdomaindump
 leroy-jenkins
 letmefuckit-scanner
 leviathan

--- a/packages/aclpwn/PKGBUILD
+++ b/packages/aclpwn/PKGBUILD
@@ -10,7 +10,7 @@ groups=('blackarch' 'blackarch-exploitation')
 url='https://github.com/fox-it/aclpwn.py'
 license=('MIT')
 depends=('python' 'impacket' 'python-ldap3' 'python-neo4j-driver'
-         'python-requests' 'python-neotime' 'python-neobolt' 'ldapdomaindump')
+         'python-requests' 'python-neotime' 'python-neobolt' 'python-ldapdomaindump')
 makedepends=('git' 'python-setuptools')
 source=("$pkgname::git+https://github.com/fox-it/aclpwn.py.git")
 sha512sums=('SKIP')

--- a/packages/activedirectoryenum/PKGBUILD
+++ b/packages/activedirectoryenum/PKGBUILD
@@ -14,7 +14,7 @@ url='https://github.com/CasperGN/ActiveDirectoryEnumeration'
 license=('MIT')
 depends=('python' 'python-cffi' 'python-click' 'python-cryptography'
          'python-dnspython' 'python-flask' 'python-future' 'impacket'
-         'python-itsdangerous' 'python-jinja' 'python-ldap3' 'ldapdomaindump'
+         'python-itsdangerous' 'python-jinja' 'python-ldap3' 'python-ldapdomaindump'
          'python-markupsafe' 'python-progressbar' 'python-pyasn1'
          'python-pycparser' 'python-pycryptodomex' 'python-pyopenssl'
          'python-six' 'python-termcolor' 'python-werkzeug' 'bloodhound-python')

--- a/packages/bloodhound-python/PKGBUILD
+++ b/packages/bloodhound-python/PKGBUILD
@@ -11,7 +11,7 @@ groups=('blackarch' 'blackarch-recon' 'blackarch-windows')
 url='https://github.com/fox-it/BloodHound.py'
 license=('MIT')
 depends=('python' 'python-dnspython' 'impacket' 'python-ldap3' 'python-pyasn1'
-         'python-future' 'ldapdomaindump')
+         'python-future' 'python-ldapdomaindump')
 makedepends=('python-setuptools' 'git')
 source=("git+https://github.com/fox-it/$_pkgname.git")
 sha512sums=('SKIP')

--- a/packages/impacket-ba/PKGBUILD
+++ b/packages/impacket-ba/PKGBUILD
@@ -11,7 +11,7 @@ arch=('any')
 groups=('blackarch' 'blackarch-exploitation' 'blackarch-networking')
 license=('Apache')
 depends=('python' 'python-pyasn1' 'python-pycryptodomex' 'python-pyopenssl'
-         'python-six' 'python-ldap3' 'ldapdomaindump' 'python-flask'
+         'python-six' 'python-ldap3' 'python-ldapdomaindump' 'python-flask'
          'python-future' 'python-charset-normalizer' 'python-dsinternals'
          'python-setuptools') # Will be fixed in 0.12.0 https://github.com/fortra/impacket/issues/885#issuecomment-1197218746
 options=(!emptydirs)

--- a/packages/python-ldapdomaindump/PKGBUILD
+++ b/packages/python-ldapdomaindump/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: GI_Jack <GI_Jack@hackermail.com>
+
+pkgname=python-ldapdomaindump
+_pypiname=ldapdomaindump
+pkgver=0.9.4
+pkgrel=1
+pkgdesc="Active Directory information dumper via LDAP, written in python"
+url="https://github.com/dirkjanm/ldapdomaindump/"
+arch=('any')
+groups=('blackarch' 'blackarch-scanner' 'blackarch-networking')
+license=('MIT')
+depends=('python' 'python-future' 'python-dnspython' 'python-ldap3')
+makedepends=('python-build' 'python-installer' 'python-wheel')
+source=(${_pypiname}-${pkgver}.tar.gz::"https://github.com/dirkjanm/ldapdomaindump/archive/v${pkgver}.tar.gz")
+sha256sums=('43a0822c96d06b8f7a3e3f044deb1591344c84d273c9d7f5815347c88af300fa')
+
+build() {
+    cd ${_pypiname}-${pkgver}
+    python -m build --wheel --no-isolation
+}
+
+package() {
+    cd ${_pypiname}-${pkgver}
+    python -m installer --destdir="${pkgdir}" dist/*.whl
+}

--- a/packages/python2-ldapdomaindump/PKGBUILD
+++ b/packages/python2-ldapdomaindump/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgbase=ldapdomaindump
-pkgname=('ldapdomaindump' 'python2-ldapdomaindump')
+pkgname=('python2-ldapdomaindump')
 _pkgname=ldapdomaindump
 pkgver=0.9.4
 pkgrel=2
@@ -11,7 +11,7 @@ groups=('blackarch' 'blackarch-scanner' 'blackarch-networking')
 arch=('any')
 url='https://pypi.org/project/ldapdomaindump/#files'
 license=('MIT')
-makedepends=('python-setuptools' 'python2-setuptools')
+makedepends=('python2-setuptools')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$pkgname-$pkgver.tar.gz")
 sha512sums=('c5f66dc73f77cae041329ac17018dfd82c155dc7c4cca3fed2175680baeb3797776488aab6199498eefc4869121f556ede8558c784e71f1ff9573dd9634abee9')
 


### PR DESCRIPTION
This causes conflicts with a lot of aur packages. It also doesnt work for the python3 version nor does it have any good way to differentiate between them