### PR TITLE
Add a new mirror in China

### DIFF
--- a/mirror/mirror.lst
+++ b/mirror/mirror.lst
@@ -9,6 +9,7 @@ CH|http://mirror.easyname.ch/blackarch/$repo/os/$arch|easyname
 CH|https://mirror.tillo.ch/ftp/blackarch/$repo/os/$arch|tillo
 CN|https://mirror.sjtu.edu.cn/blackarch/$repo/os/$arch|SJTUG
 CN|https://mirrors.tuna.tsinghua.edu.cn/blackarch/$repo/os/$arch|TUNA
+CN|https://mirrors.hust.edu.cn/blackarch/$repo/os/$arch|HUST
 CN|https://mirrors.ustc.edu.cn/blackarch/$repo/os/$arch|USTC
 CN|https://mirrors.nju.edu.cn/blackarch/$repo/os/$arch|nju
 CN|http://mirrors.nju.edu.cn/blackarch/$repo/os/$arch|nju


### PR DESCRIPTION
Hi, we host a new mirror in China and want to add it to official mirror list. 
Email: mirror_support@hust.edu.cn
Alternative email: tttturtleruss@hust.edu.cn