### PR TITLE
NetworkMiner 2.9 Released

### DIFF
--- a/packages/networkminer/PKGBUILD
+++ b/packages/networkminer/PKGBUILD
@@ -15,7 +15,8 @@ _srcname="NetworkMiner_${pkgver//\./-}"
 source=("$pkgname-$pkgver.zip::https://www.netresec.com/?download=NetworkMiner"
         "$pkgname.desktop")
 sha512sums=('b385e1e6a67e2c4759058c95677f79fc6ce32594c6db95192f0f13fda7434e38375b66a0c7e862ade8a2874874dea3ee6bf14ac1349753067eda86e9ab7455fd'
-            '335f559232174274259207c039f362c59c80ab0e1eef0c58b5d09692841afb7fe92563bc40cd41bd68f7a7c7c630decd0cc1f242bc2bfe0f1e18ff7264b38be1')
+            '335f559232174274259207c039f362c59c80ab0e1eef0c58b5d09692841afb7fe92563bc40cd41bd68f7a7c7c630decd0cc1f242bc2bfe0f1e18ff7264b38be1'
+            '4e1f68f6c23e13cd67ca1ce11d219455399d5cff8fdafe42a689d472125805ee7d885e15974baf6e5ea467f37547bf2b0192353ddc5de3944d3c7be9a0663976')
 
 package() {
   cd "${_pkgname}_${pkgver//\./-}"


### PR DESCRIPTION
* TZSP support
* StealC extractor
* Improved Modbus parser
* JA4 support
* GTP decapsulation
 
https://www.netresec.com/?page=Blog&month=2024-05&post=NetworkMiner-2-9-Released