### PR TITLE
evil-winrm: Set environment variable instead of changing directory

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+evil-winrm

--- a/packages/evil-winrm/PKGBUILD
+++ b/packages/evil-winrm/PKGBUILD
@@ -44,10 +44,11 @@ package() {
   sed -zi "s/\[provider_sect\]\ndefault = default_sect/\[provider_sect\]\ndefault = default_sect\nlegacy = legacy_sect/" "$pkgdir/usr/share/$pkgname/openssl.cnf"
   sed -zi "s/\[default_sect\]\n# activate = 1/\[default_sect\]\nactivate = 1\n\[legacy_sect\]\nactivate = 1/" "$pkgdir/usr/share/$pkgname/openssl.cnf"
 
+  # Specify bundle's gemfile environment variable to avoid changing directories when running the program.
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
-cd /usr/share/$pkgname
-OPENSSL_CONF=/usr/share/$pkgname/openssl.cnf exec bundle exec $pkgname.rb "\$@"
+
+OPENSSL_CONF=/usr/share/$pkgname/openssl.cnf BUNDLE_GEMFILE=/usr/share/$pkgname/Gemfile exec bundle exec /usr/share/$pkgname/$pkgname.rb "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"


### PR DESCRIPTION
I added an extra environment variable to avoid changing directory when executing, because this causes issues with stuff like the download and upload function of the program.