### PR TITLE
eaphammer: fix dependencies

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+eaphammer

--- a/packages/eaphammer/PKGBUILD
+++ b/packages/eaphammer/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=eaphammer
-pkgver=323.91e8956
+pkgver=v1.14.1.r0.g91e8956
 pkgrel=1
 pkgdesc='Targeted evil twin attacks against WPA2-Enterprise networks. Indirect wireless pivots using hostile portal attacks.'
 groups=('blackarch' 'blackarch-wireless')
@@ -19,9 +19,11 @@ source=("git+https://github.com/s0lst1c3/$pkgname.git")
 sha512sums=('SKIP')
 
 pkgver() {
-  cd $pkgname
-
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  cd "$pkgname"
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null | sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+  )
 }
 
 build() {

--- a/packages/eaphammer/PKGBUILD
+++ b/packages/eaphammer/PKGBUILD
@@ -2,17 +2,18 @@
 # See COPYING for license details.
 
 pkgname=eaphammer
-pkgver=310.442ee78
-pkgrel=2
+pkgver=323.91e8956
+pkgrel=1
 pkgdesc='Targeted evil twin attacks against WPA2-Enterprise networks. Indirect wireless pivots using hostile portal attacks.'
 groups=('blackarch' 'blackarch-wireless')
 arch=('any')
 url='https://github.com/s0lst1c3/eaphammer'
 license=('GPL3')
-depends=('python' 'python-argparse' 'python-tqdm' 'dnsmasq' 'libnfnetlink'
+depends=('python' 'python-tqdm' 'dnsmasq' 'libnfnetlink'
          'libnl' 'openssl' 'python-pem' 'python-pyopenssl' 'apache' 'libpcap'
-         'curl' 'scapy' 'responder' 'hcxtools' 'hcxdumptool' 'python-flask'
-         'python-flask-cors' 'python-flask-socketio' 'python-pywebcopy')
+         'curl' 'scapy' 'responder' 'hcxtools' 'hcxdumptool' 'python-beautifulsoup4'
+         'python-flask' 'python-flask-cors' 'python-flask-socketio' 'python-gevent'
+         'python-lxml' 'python-requests' 'python-pywebcopy')
 makedepends=('git')
 source=("git+https://github.com/s0lst1c3/$pkgname.git")
 sha512sums=('SKIP')
@@ -49,4 +50,3 @@ EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"
 }
-

--- a/packages/eaphammer/PKGBUILD
+++ b/packages/eaphammer/PKGBUILD
@@ -50,3 +50,4 @@ EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"
 }
+


### PR DESCRIPTION
https://github.com/BlackArch/blackarch/issues/4182

Added Python 3.12 support.