### PR TITLE
fix xxeserv build

### DIFF
--- a/packages/xray/PKGBUILD
+++ b/packages/xray/PKGBUILD
@@ -30,15 +30,11 @@ build() {
 
   GOPATH="$srcdir" go get -d -t $_url
   GOPATH="$srcdir" go get -u github.com/jteeuwen/go-bindata/...
-  GOPATH="$srcdir" make get_glide
-  GOPATH="$srcdir" make install_dependencies
-  GOPATH="$srcdir" make build
+  make
 }
 
 package() {
   cd "src/$_url"
-
-  install -dm 755 "$pkgdir/usr/bin"
 
   install -Dm 755 "build/$pkgname" "$pkgdir/usr/bin/$pkgname"
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md

--- a/packages/xsss/PKGBUILD
+++ b/packages/xsss/PKGBUILD
@@ -17,6 +17,6 @@ package() {
   cd "$pkgname-$pkgver"
 
   install -Dm 755 $pkgname "$pkgdir/usr/bin/$pkgname"
-  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/README"
+  install -Dm 644 README "$pkgdir/usr/share/doc/$pkgname/README"
 }
 

--- a/packages/xxeserv/PKGBUILD
+++ b/packages/xxeserv/PKGBUILD
@@ -22,7 +22,6 @@ pkgver() {
 build() {
   cd $pkgname
 
-  GOPATH="$srcdir" go mod init go.mod
   GOPATH="$srcdir" go mod tidy
   GOPATH="$srcdir" go mod download
   GOPATH="$srcdir" go build \


### PR DESCRIPTION
go.mod already existed, so build() errored out.