### PR TITLE
qt5-webkit: version bump

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+qt5-webkit

--- a/packages/qt5-webkit/PKGBUILD
+++ b/packages/qt5-webkit/PKGBUILD
@@ -1,57 +1,85 @@
 # This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
 # See COPYING for license details.
-#
-# Old Maintainer: Felix Yan <felixonmars@archlinux.org>
-# Old Maintainer: Antonio Rojas <arojas@archlinux.org>
+
+# Initial PKGBUILD from AUR.
+# Old Maintainer: Fabio 'Lolix' Loli <fabio.loli@disroot.org>
+# Old Contributor: Zen Wen <zen.8841@gmail.com>
+# Old Contributor: Felix Yan <felixonmars@archlinux.org>
+# Old Contributor: Antonio Rojas <arojas@archlinux.org>
 # Old Contributor: Andrea Scarpino <andrea@archlinux.org>
 
 pkgname=qt5-webkit
 _pkgver=5.212.0-alpha4
 _basever=5.15.3
 pkgver=${_pkgver/-/}
-pkgrel=22
-arch=('x86_64' 'aarch64')
-url='https://github.com/qtwebkit/qtwebkit'
-license=('GPL3' 'LGPL3' 'FDL' 'custom')
-pkgdesc='Classes for a WebKit2 based implementation and a new QML API'
-source=("https://github.com/qtwebkit/qtwebkit/releases/download/qtwebkit-$_pkgver/qtwebkit-$_pkgver.tar.xz"
+pkgrel=26
+arch=(x86_64 aarch64)
+url="https://github.com/qtwebkit/qtwebkit"
+license=(LGPL2.1)
+pkgdesc="Classes for a WebKit2 based implementation and a new QML API"
+source=("https://github.com/qtwebkit/qtwebkit/releases/download/qtwebkit-$_pkgver/qtwebkit-${_pkgver}.tar.xz"
+        "https://src.fedoraproject.org/rpms/qt5-qtwebkit/raw/rawhide/f/qtwebkit-cstdint.patch"
+        "https://src.fedoraproject.org/rpms/qt5-qtwebkit/raw/rawhide/f/qtwebkit-fix-build-gcc14.patch"
+         https://src.fedoraproject.org/rpms/qt5-qtwebkit/raw/rawhide/f/webkit-offlineasm-warnings-ruby27.patch
+        "qt5-webkit-icu75.patch::https://github.com/qtwebkit/qtwebkit/commit/756e1c8f23dc2720471298281c421c0076d02df8.patch"
          icu68.patch
          glib-2.68.patch
-         qt5-webkit-python-3.9.patch::"https://github.com/qtwebkit/qtwebkit/commit/78360c01.patch"
-         qt5-webkit-bison-3.7.patch::"https://github.com/qtwebkit/qtwebkit/commit/d92b11fe.patch")
-depends=('qt5-location' 'qt5-sensors' 'qt5-webchannel' 'libwebp' 'libxslt'
-         'libxcomposite' 'gst-plugins-base' 'hyphen' 'woff2')
-makedepends=('cmake' 'ruby' 'gperf' 'python' 'qt5-doc' 'qt5-tools')
+         qt5-webkit-python-3.9.patch
+         qt5-webkit-bison-3.7.patch
+
+)
+depends=(qt5-location qt5-sensors qt5-webchannel libwebp libxcomposite gst-plugins-base hyphen woff2
+
+         # namcap implicit depends
+         glibc gcc-libs glib2 zlib libx11 sqlite gst-plugins-base-libs libjpeg-turbo icu libpng gstreamer libxml2
+         qt5-base qt5-declarative)
+         # libxslt
+depends+=(libicuuc.so libicui18n.so)
+makedepends=(cmake ruby ruby-erb gperf python qt5-doc qt5-tools)
 optdepends=('gst-plugins-good: Webm codec support')
-sha512sums=('33f11270bd030599beff9c1983a6c5ff2d61f407cc8a6825f7f405d46f9184c720fc7f60c7359f08f828db96a2170092875066a0d5c0a21ff09bc48a2603fbf6'
-            'c4714b40d9b516698490cc3f587f7fefe8097545a2310e144be1dfa39549ad056bf7bd67f5f89334e54c3a9bb95136876a62d0a392991a872030c4dff0d7c820'
-            'f8a49e24023431ac37cff2b5bdf6f88d632021eb777668404956a4c6e4f8744f256205093dc5077325a33ec2a050b6e159dcf5d8cf3c1dda7d26ec0b37db95c3'
-            'e4d4d4abfb8f2e9913c2f5cb7b3a73d5c613a8e8ced66ae1a7789faaa83a2bdf89ff29955d7e9b7bd7a0935ca2ddcad796cf371882e2bb38b4e69c1d528cfe75'
-            'd90e3bd03090d468f6d73bcee949593a9266de8c5d29f2879c53efa757e7be449db16eb7a563c6279ed2554e549f2dc6321a40cf855d6290e5bdded8f18a90e4')
 options=(!lto)
+sha256sums=('9ca126da9273664dd23a3ccd0c9bebceb7bb534bddd743db31caf6a5a6d4a9e6'
+            '4c71c958eae45cae65c9f002024eb1369d06029b668e595158138ff7971e64f1'
+            'eea38db22078700887bf22b6a49bb628fd8444cdb2e506770c993df883d0e8fb'
+            '8768433ff3f641b506962ed22cc596eaf57bf21b6d3402e0e73ad8c2afeaa502'
+            'b4d1ba1e99e28fd8cb1ec82252373c870ede683869a9cd43c8e465fe09531bcb'
+            '0b40ed924f03ff6081af610bb0ee01560b7bd1fb68f8af02053304a01d4ccdf0'
+            '4969dd03e482155e2490b50307dada81dda7bbc9e5398e3a53c20bc474f7c04e'
+            '6e0cee08e4fa57b04752e80817f33562f48aa42608a3a620930b6040259b4932'
+            '34f37b53ee0bc31c63ce85ebd1ae95543a8ba28483e387b20efd50574bd813be')
 
 prepare() {
-  cd "qtwebkit-$_pkgver"
-
+  cd "qtwebkit-${_pkgver}"
   patch -p0 -i ../icu68.patch # Fix build with ICU 68.x
   patch -p1 -i ../glib-2.68.patch # https://github.com/qtwebkit/qtwebkit/issues/1057
   patch -p1 -i ../qt5-webkit-python-3.9.patch # Fix build with python 3.9
   patch -p1 -i ../qt5-webkit-bison-3.7.patch # Fix build with bison 3.7
+  patch -p1 -i ../qtwebkit-cstdint.patch # gcc 11.1
+  patch -p1 -i ../qtwebkit-fix-build-gcc14.patch # GCC 14.1
+  patch -p1 -i ../qt5-webkit-icu75.patch
+
+  #patch -Np1 -i ../qtwebkit-ruby3.2.patch
+  #echo "Done patch for Ruby 3.2"
+
+  patch -Np1 -i ../webkit-offlineasm-warnings-ruby27.patch
+  echo "Done patch for Ruby 3.2"
 }
 
 build() {
-  cmake -B build -S qtwebkit-$_pkgver \
+  cmake -B build -S "qtwebkit-${_pkgver}" -Wno-dev \
+    -DCMAKE_BUILD_TYPE=None \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS} -DNDEBUG" \
     -DPORT=Qt \
+    -DUSE_LD_GOLD=OFF \
+    -DENABLE_XSLT=OFF \
     -DENABLE_TOOLS=OFF
   cmake --build build
+
+# disabling XSLT to build https://github.com/qtwebkit/qtwebkit/issues/1097
 }
 
 package() {
-  DESTDIR="$pkgdir" cmake --install build
-
-  install -d "$pkgdir"/usr/share/licenses
-  ln -s /usr/share/licenses/qt5-base "$pkgdir/usr/share/licenses/$pkgname"
+  DESTDIR="${pkgdir}" cmake --install build
 }
 

--- a/packages/qt5-webkit/qt5-webkit-icu75.patch
+++ b/packages/qt5-webkit/qt5-webkit-icu75.patch
@@ -1,0 +1,31 @@
+From 756e1c8f23dc2720471298281c421c0076d02df8 Mon Sep 17 00:00:00 2001
+From: Konstantin Tokarev <annulen@yandex.ru>
+Date: Mon, 27 May 2024 23:23:11 +0300
+Subject: [PATCH] Partial backport of r260554 (79fe19caf)
+
+In particular, we need -DU_SHOW_CPLUSPLUS_API=0 to avoid compilation
+errors in C++ parts of ICU headers which we are not using anyway.
+
+Change-Id: Ib45c74e3caad148fbd778d0c07330127f7dab5ec
+---
+ Source/WTF/wtf/Platform.h | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/Source/WTF/wtf/Platform.h b/Source/WTF/wtf/Platform.h
+index a7b0f74bb7d17..af85a675266f8 100644
+--- a/Source/WTF/wtf/Platform.h
++++ b/Source/WTF/wtf/Platform.h
+@@ -1138,6 +1138,13 @@
+ #define ENABLE_PLATFORM_FONT_LOOKUP 1
+ #endif
+ 
++/* FIXME: This does not belong in Platform.h and should instead be included in another mechanism (compiler option, prefix header, config.h, etc) */
++/* ICU configuration. Some of these match ICU defaults on some platforms, but we would like them consistently set everywhere we build WebKit. */
++#define U_SHOW_CPLUSPLUS_API 0
++#ifdef __cplusplus
++#define UCHAR_TYPE char16_t
++#endif
++
+ #if COMPILER(MSVC)
+ #undef __STDC_LIMIT_MACROS
+ #define __STDC_LIMIT_MACROS


### PR DESCRIPTION
Fix https://github.com/BlackArch/blackarch/issues/4165

After merging this update, I think that [wkhtmltopdf](https://github.com/BlackArch/blackarch/blob/master/packages/wkhtmltopdf/PKGBUILD) needs to be rebuilt in order to refer to the new libraries.