### PR TITLE
valhalla: rename to valhalla-api

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+valhalla-api

--- a/packages/valhalla-api/PKGBUILD
+++ b/packages/valhalla-api/PKGBUILD
@@ -1,7 +1,7 @@
 # This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
 # See COPYING for license details.
 
-pkgname=valhalla
+pkgname=valhalla-api
 _pkgname=valhallaAPI
 pkgver=87.c010a48
 pkgrel=5

--- a/packages/valhalla-api/PKGBUILD
+++ b/packages/valhalla-api/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=valhalla-api
 _pkgname=valhallaAPI
 pkgver=87.c010a48
-pkgrel=5
+pkgrel=6
 pkgdesc='Valhalla API Client.'
 arch=('any')
 groups=('blackarch' 'blackarch-automation' 'blackarch-misc')

--- a/packages/valhalla-api/PKGBUILD
+++ b/packages/valhalla-api/PKGBUILD
@@ -11,7 +11,7 @@ groups=('blackarch' 'blackarch-automation' 'blackarch-misc')
 url='https://github.com/NextronSystems/valhallaAPI'
 license=('Apache')
 depends=('python' 'python-requests' 'python-pytest' 'python-packaging')
-makedepends=('python-setuptools' 'git')
+makedepends=('git' 'python-setuptools')
 source=("git+https://github.com/NextronSystems/$_pkgname.git")
 sha512sums=('SKIP')
 


### PR DESCRIPTION
Close https://github.com/BlackArch/blackarch/issues/4209

I'm not sure if it is the right process. The `valhalla` package should be removed from the main mirror repo.