### PR TITLE
regripper: bump version

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+regripper

--- a/packages/regripper/PKGBUILD
+++ b/packages/regripper/PKGBUILD
@@ -2,12 +2,12 @@
 # See COPYING for license details.
 
 pkgname=regripper
-pkgver=104.5bb3c86
-pkgrel=2
+pkgver=106.89f3cac
+pkgrel=1
 pkgdesc='Open source forensic software used as a Windows Registry data extraction command line or GUI tool.'
 arch=('any')
 groups=('blackarch' 'blackarch-forensic')
-url="https://github.com/keydet89/RegRipper3.0"
+url='https://github.com/keydet89/RegRipper3.0'
 depends=('perl' 'perl-parse-registry')
 makedepends=('git')
 license=('MIT')
@@ -18,7 +18,12 @@ sha512sums=('SKIP')
 pkgver() {
   cd $pkgname
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null |
+      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" \
+      "$(git rev-parse --short=7 HEAD)"
+  )
 }
 
 prepare() {


### PR DESCRIPTION
The latest commit solves the issue related to the not found plugins directory when a binary wrapper is used.

Close https://github.com/BlackArch/blackarch/issues/4314