### PR TITLE
python-alive-progress: bump version

### DIFF
--- a/packages/python-alive-progress/PKGBUILD
+++ b/packages/python-alive-progress/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=python-alive-progress
 _pkgname=alive-progress
-pkgver=3.1.5
+pkgver=3.2.0
 _pyver=3.12
 pkgrel=1
 pkgdesc='A new kind of Progress Bar, with real-time throughput, ETA, and very cool animations.'
@@ -11,14 +11,14 @@ arch=('any')
 url='https://pypi.org/project/alive-progress/#files'
 license=('MIT')
 depends=('python' 'python-about-time' 'python-grapheme')
-makedepends=('python-setuptools')
+makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('9f9e049482f8e20c7d802d896470d826a35f9a398ba86d02905e642f9e4e6ab771ef2c92a9e09f459e8e53a9483bbfaba753211d6374e6e67e4b6b0327096018')
+sha512sums=('05129b5c46b43bbf91e052a88fd8a3ab499216c20c2948a2c99649bb9164e4ea4477a97b63788571ffa4ddc0f32ebd65d59ff55a335b02e14e79587c47e7e41f')
 
 build() {
   cd "$_pkgname-$pkgver"
 
-  python setup.py build
+  python -m build --wheel --no-isolation
 }
 
 package() {
@@ -26,7 +26,7 @@ package() {
 
   install -dm 755 "$pkgdir/usr/share/licenses/$pkgname"
 
-  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+  python -m installer --destdir="$pkgdir" dist/*.whl
 
   mv "$pkgdir/usr/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 


### PR DESCRIPTION
Version 3.2.0 was released of this
https://pypi.org/project/alive-progress/

Changed install to conform to PEP 517
https://wiki.archlinux.org/title/Python_package_guidelines#Standards_based_(PEP_517)

This resolves Issue https://github.com/BlackArch/blackarch/issues/4333