### PR TITLE
pkgcheck-arch: bump version

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+pkgcheck-arch

--- a/packages/pkgcheck-arch/PKGBUILD
+++ b/packages/pkgcheck-arch/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=pkgcheck-arch
 _pkgname=pkgcheck_arch
-pkgver=0.1.3
+pkgver=0.1.4
 pkgrel=1
 pkgdesc="A bashate fork for Arch Linux's PKGBUILDs."
 arch=('any')
@@ -12,7 +12,7 @@ license=('Apache')
 depends=('python-pbr')
 makedepends=('python-setuptools')
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('cae9fcb8bf3fa053338dd09b28200dbe98dc40a18ab488584241bf117553db0dfab54d3e6a8d6e6a8ccbc54e04da026e20ae9b97923594f1561d42e9d5646977')
+sha512sums=('7952373e63e894e32e1afeea23ee67b502339762d734f219ef917b9406df8ac6ff1b1a0b80be0c10ac88862afbc76fe4a0226410bd910531a1882b87a5e3937b')
 
 build() {
   cd "$_pkgname-$pkgver"

--- a/packages/pkgcheck-arch/PKGBUILD
+++ b/packages/pkgcheck-arch/PKGBUILD
@@ -2,25 +2,26 @@
 # See COPYING for license details.
 
 pkgname=pkgcheck-arch
-pkgver=0.1.2
-pkgrel=3
+_pkgname=pkgcheck_arch
+pkgver=0.1.3
+pkgrel=1
 pkgdesc="A bashate fork for Arch Linux's PKGBUILDs."
 arch=('any')
 url='https://github.com/FFY00/pkgcheck'
 license=('Apache')
 depends=('python-pbr')
 makedepends=('python-setuptools')
-source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz")
-sha512sums=('a864795afb926eaa33850f99b1fcbdd7923b5c5735f1cd3e34dc9f8f3a1cc3ac80f70430528e8981a9b840efcd78fde9a635aca15057da454e4c27d6a18a3dc8')
+source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('cae9fcb8bf3fa053338dd09b28200dbe98dc40a18ab488584241bf117553db0dfab54d3e6a8d6e6a8ccbc54e04da026e20ae9b97923594f1561d42e9d5646977')
 
 build() {
-  cd "$pkgname-$pkgver"
+  cd "$_pkgname-$pkgver"
 
   python setup.py build
 }
 
 package() {
-  cd "$pkgname-$pkgver"
+  cd "$_pkgname-$pkgver"
 
   python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
 }


### PR DESCRIPTION
Added support for Python 3.12, fixed typos and added check on base-devel dependencies.

Close https://github.com/BlackArch/blackarch/issues/3391