### PR TITLE
sniffle: add package

### DIFF
--- a/packages/sniffle/PKGBUILD
+++ b/packages/sniffle/PKGBUILD
@@ -1,0 +1,53 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=sniffle
+_pkgname=Sniffle
+pkgver=v1.10.0.r102.g9c57a71
+pkgrel=1
+pkgdesc='A sniffer for Bluetooth 5 and 4.x LE.'
+arch=('aarch64')
+groups=('blackarch' 'blackarch-bluetooth')
+url='https://github.com/nccgroup/Sniffle'
+license=('GPL-3.0')
+depends=('python' 'python-pyserial' 'uniflash')
+makedepends=('git' 'arm-none-eabi-gcc' 'cmake')
+source=("git+https://github.com/nccgroup/$_pkgname.git"
+        "https://dr-download.ti.com/software-development/software-development-kit-sdk/MD-BPlR3djvTV/7.41.00.17/simplelink_cc13xx_cc26xx_sdk_7_41_00_17.run")
+sha512sums=('SKIP'
+            '255f90b03deffde785385c5e4606fa159f4cc49d9fdf847ee53cc7cf0bd6eb03155e5f8a937174d852416bb708c39b910536f1fb3a8d41a1770b24dd89eb7465')
+
+pkgver() {
+  cd $_pkgname
+
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null |
+      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" \
+      "$(git rev-parse --short=7 HEAD)"
+  )
+}
+
+prepare() {
+  chmod +x simplelink_cc13xx_cc26xx_sdk_7_41_00_17.run
+  ./simplelink_cc13xx_cc26xx_sdk_7_41_00_17.run --prefix "$srcdir" --mode unattended
+}
+
+build() {
+  cd simplelink_cc13xx_cc26xx_sdk_7_41_00_17
+
+  make build-gcc XDC_INSTALL_DIR="../xdctools_3_62_01_15_core" \
+                 SYSCONFIG_TOOL="../sysconfig_1.18.1/sysconfig_cli.sh" \
+                 CMAKE="cmake" \
+                 PYTHON="python" \
+                 GCC_ARMCOMPILER="/usr"
+}
+
+package() {
+  cd $_pkgname/fw
+
+  make DESTDIR="$pkgdir"
+
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" *.md
+}
+


### PR DESCRIPTION
Close: https://github.com/BlackArch/blackarch/issues/2830

During the building, if you get an error like:
```
-- Configuring done (0.7s)
CMake Error in source/ti/drivers/CMakeLists.txt:
  Target "tfm_dependencies_cc26x4" INTERFACE_INCLUDE_DIRECTORIES property
  contains path:

    "/home/user/Documents/simplelink_cc13xx_cc26xx_sdk_7_41_00_17/tfm_s/cc26x4/build_dependencies"

  which is prefixed in the source directory.
```
remember to `make clean` or to delete the `build` folder. It occurs only if during your building test you build by wrong parameters.