### PR TITLE
Replace linux-headers dependency to optdepends headers list

### DIFF
--- a/packages/binflow/PKGBUILD
+++ b/packages/binflow/PKGBUILD
@@ -9,15 +9,22 @@ pkgdesc='POSIX function tracing. Much better and faster than ftrace.'
 arch=('x86_64' 'aarch64')
 url='https://github.com/elfmaster/binflow'
 license=('custom:unknown')
-depends=('glibc' 'linux-headers' 'capstone')
+depends=('glibc' 'capstone')
+optdepends=('linux-headers' 'linux-lts-headers' 'linux-hardened-headers'
+            'linux-rt-headers' 'linux-rt-lts-headers' 'linux-zen-headers')
 makedepends=('git')
 source=("git+https://github.com/elfmaster/$pkgname.git")
 sha512sums=('SKIP')
 
 pkgver() {
-  cd $pkgname
+  cd $_pkgname
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null |
+      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" \
+      "$(git rev-parse --short=7 HEAD)"
+  )
 }
 
 #prepare() {

--- a/packages/binflow/PKGBUILD
+++ b/packages/binflow/PKGBUILD
@@ -3,21 +3,21 @@
 
 pkgname=binflow
 pkgver=5.7fb02a9
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-binary' 'blackarch-debugger')
 pkgdesc='POSIX function tracing. Much better and faster than ftrace.'
 arch=('x86_64' 'aarch64')
 url='https://github.com/elfmaster/binflow'
 license=('custom:unknown')
 depends=('glibc' 'capstone')
+makedepends=('git')
 optdepends=('linux-headers' 'linux-lts-headers' 'linux-hardened-headers'
             'linux-rt-headers' 'linux-rt-lts-headers' 'linux-zen-headers')
-makedepends=('git')
 source=("git+https://github.com/elfmaster/$pkgname.git")
 sha512sums=('SKIP')
 
 pkgver() {
-  cd $_pkgname
+  cd $pkgname
 
   ( set -o pipefail
     git describe --long --tags --abbrev=7 2>/dev/null |


### PR DESCRIPTION
To not create conflicts with systems with different kernels by the vanilla one.