### PR TITLE
semgrep: move to standalone package

### DIFF
--- a/packages/semgrep/PKGBUILD
+++ b/packages/semgrep/PKGBUILD
@@ -2,56 +2,29 @@
 # See COPYING for license details.
 
 pkgname=semgrep
-pkgver=1.79.0
-_pyver=3.12
-_py=cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311
+pkgver=1.97.0
 pkgrel=1
 epoch=1
 pkgdesc='Lightweight static analysis for many languages.'
 arch=('x86_64')
 groups=('blackarch' 'blackarch-code-audit')
-url='https://pypi.org/project/semgrep/#files'
+url='https://pypi.org/project/semgrep/'
 license=('LGPL')
-depends=('python' 'python-attrs' 'python-boltons' 'python-colorama'
-         'python-click' 'python-click-option-group' 'python-glom' 'python-rich'
-         'python-requests' 'python-ruamel-yaml' 'python-tqdm' 'python-packaging'
-         'python-jsonschema' 'python-wcmatch' 'python-peewee' 'python-tomli'
-         'python-defusedxml' 'python-urllib3' 'python-typing_extensions'
-         'python-lsp-jsonrpc' 'python-exceptiongroup')
+depends=('python')
 makedepends=('python-build' 'python-pip' 'python-wheel')
 replaces=('python-semgrep')
-source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz"
-        "https://files.pythonhosted.org/packages/$_py/${pkgname::1}/$pkgname/${pkgname//-/_}-$pkgver-$_py-none-any.whl")
-sha512sums=('0439810cf107701297f3eabfd4e0a55dac2957c61bcf8248d527926a988cc5603d19e54971bb7a8c44fbad8591f663528fafca38f1c355093989a873a2670a95'
-            'a87a3692545df865a0a129fa64d6d9623af5adf55a8184b40a03bddcacf2715271779878e23e684cc9580a6114a2780dc7f68c1b57bd2e7623024066b3426598')
-
-build() {
-  cd "$pkgname-$pkgver"
-
-  export SEMGREP_CORE_BIN="$srcdir/$pkgname-$pkgver.data/purelib/$pkgname/bin/$pkgname-core"
-
-  python -m build --wheel --outdir="$startdir/dist"
-}
+install="$pkgname.install"
 
 package() {
-  cd "$pkgname-$pkgver"
+  install -dm 755 "$pkgdir/usr/bin"
+  install -dm 755 "$pkgdir/usr/share/$pkgname"
 
-  pip install \
-    --verbose \
-    --disable-pip-version-check \
-    --no-warn-script-location \
-    --ignore-installed \
-    --no-compile \
-    --no-deps \
-    --root="$pkgdir" \
-    --prefix=/usr \
-    --no-index \
-    --find-links="file://$startdir/dist" \
-    "$pkgname"
+  cat > "$pkgdir/usr/bin/$pkgname" << EOF
+#!/bin/sh
+source /usr/share/$pkgname/venv/bin/activate
+exec /usr/share/$pkgname/venv/bin/$pkgname "\$@"
+EOF
 
-  install -Dm 555 \
-    "$srcdir/$pkgname-$pkgver.data/purelib/$pkgname/bin/$pkgname-core" \
-    "$pkgdir/usr/lib/python$_pyver/site-packages/$pkgname/bin/$pkgname-core"
-  strip "$pkgdir/usr/lib/python$_pyver/site-packages/$pkgname/bin/$pkgname-core"
+  chmod a+x "$pkgdir/usr/bin/$pkgname"
 }
 

--- a/packages/semgrep/semgrep.install
+++ b/packages/semgrep/semgrep.install
@@ -1,0 +1,12 @@
+post_install() {
+  set -e
+  cd /usr/share/semgrep
+  python -m venv venv
+  source venv/bin/activate &&
+    pip install --isolated --root="/usr/share/semgrep" --prefix='venv' \
+      semgrep
+}
+
+post_upgrade() {
+  post_install "$@"
+}


### PR DESCRIPTION
- no more dependencies back and forth
- it's a binary package anyway, it's not possible to build from source
- that's will greatly facilitate maintenance

fix #4392