### PR TITLE
faradaysec: remove restkit dependency

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+faradaysec

--- a/packages/faradaysec/PKGBUILD
+++ b/packages/faradaysec/PKGBUILD
@@ -13,7 +13,7 @@ url='http://www.faradaysec.com/'
 depends=('couchdb' 'python' 'gtk3' 'gobject-introspection' 'python-argparse'
          'gobject-introspection-runtime' 'python-gobject' 'vte3' 'zsh' 'curl'
          'python-couchdb' 'python-mockito' 'python-whoosh' 'python-ipy'
-         'python-restkit' 'python-requests' 'python-tornado' 'python-flask'
+         'python-requests' 'python-tornado' 'python-flask' 'python-anyascii'
          'python-colorama' 'java-environment' 'python-pip' 'python-dateutil'
          'pyqt3' 'libpqxx' 'python-psycopg2' 'ruby' 'python-apispec-webframeworks'
          'python-lxml' 'python-pysqlite3' 'python-sphinx' 'python-twisted'
@@ -33,7 +33,7 @@ depends=('couchdb' 'python' 'gtk3' 'gobject-introspection' 'python-argparse'
          'python-flask-restless' 'python-syslog-rfc5424-formatter'
          'python-flask-kvsession-fork' 'python-distro' 'python-faraday-plugins'
          'python-pendulum' 'python-prompt_toolkit' 'python-email-validator'
-         'python-anyascii' 'postgresql')
+         'postgresql')
 makedepends=('git')
 options=('!strip')
 license=('GPL')


### PR DESCRIPTION
Restkit dependency have been dropped from the project since 2018 as reported in the CHANGELOG project file.