### PR TITLE
bkcrack: enhance

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+bkcrack

--- a/packages/bkcrack/PKGBUILD
+++ b/packages/bkcrack/PKGBUILD
@@ -8,9 +8,10 @@ pkgdesc='Crack legacy zip encryption with Biham and Kocher known plaintext attac
 arch=('x86_64' 'aarch64')
 groups=('blackarch' 'blackarch-cracker')
 url='https://github.com/kimci86/bkcrack'
-license=('ZLIB')
-depends=('gcc-libs')
-makedepends=('git' 'cmake')
+license=('Zlib')
+depends=('gcc-libs' 'glibc')
+makedepends=('git' 'cmake' 'doxygen')
+optdepends=('python: deflate/inflate tools')
 source=("git+https://github.com/kimci86/$pkgname.git")
 sha512sums=('SKIP')
 
@@ -21,23 +22,46 @@ pkgver() {
 }
 
 build() {
-  cd $pkgname
+  local cmake_options=(
+    -B build
+    -S $pkgname
+    -W no-dev
+    -D CMAKE_BUILD_TYPE=None
+    -D CMAKE_INSTALL_PREFIX=/usr
+    -D BKCRACK_BUILD_DOC=ON
+    -D BKCRACK_BUILD_TESTING=ON
+  )
+  cmake "${cmake_options[@]}"
+  cmake --build build
+}
 
-  cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release .
-
-  make
+check() {
+  local excluded_tests=""
+  local ctest_flags=(
+    --test-dir build
+    # show the stdout and stderr when the test fails
+    --output-on-failure
+    # execute tests in parallel
+    --parallel $(nproc)
+    # exclude problematic tests
+    --exclude-regex "$excluded_tests"
+  )
+  ctest "${ctest_flags[@]}"
 }
 
 package() {
-  cd $pkgname
-
-  install -dm 755 "$pkgdir/usr/share/$pkgname/"
-
+  cd build
   install -Dm 755 "src/$pkgname" "$pkgdir/usr/bin/$pkgname"
 
-  install -Dm 644 license.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
-  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" *.md doc/*.md
+  install -dm 755 "$pkgdir/usr/share/doc/$pkgname"
+  cp -a doc/html "$pkgdir/usr/share/doc/$pkgname/"
 
-  cp -a tools example "$pkgdir/usr/share/$pkgname/"
+  cd ../$pkgname
+  install -Dm 644 license.txt -t "$pkgdir/usr/share/licenses/$pkgname"
+
+  cp -a example "$pkgdir/usr/share/doc/$pkgname"
+
+  install -dm 755 "$pkgdir/usr/share/$pkgname"
+  cp -a tools "$pkgdir/usr/share/$pkgname/"
 }
 


### PR DESCRIPTION
make build() align with Arch Cmake Package Guidelines

Use doxygen to build doc

Run test

Use SPDX license identifier

optdepends on python for tools

Install example to doc folder

depends on glibc