### PR TITLE
Add South Korean Mirror

### DIFF
--- a/mirror/mirror.lst
+++ b/mirror/mirror.lst
@@ -42,6 +42,7 @@ JP|https://jp.mirrors.cicku.me/blackarch/$repo/os/$arch|CICKU
 JP|http://ftp.kddilabs.jp/Linux/packages/blackarch/$repo/os/$arch|kddilabs
 JP|https://ftp.kddilabs.jp/Linux/packages/blackarch/$repo/os/$arch|kddilabs
 JP|http://www.ftp.ne.jp/Linux/packages/blackarch/$repo/os/$arch|ne
+KR|https://mirror.amuksa.com/blackarch/$repo/os/$arch|DAXNET
 KR|http://kr.mirrors.cicku.me/blackarch/$repo/os/$arch|CICKU
 KR|https://kr.mirrors.cicku.me/blackarch/$repo/os/$arch|CICKU
 MD|http://md.mirrors.hacktegic.com/blackarch/$repo/os/$arch|hacktegic


### PR DESCRIPTION
Hello, we have newly added BlackArch and would like to register for the official mirror. The location is South Korea.

Contact email: mirror@mail.daxhub.net