### PR TITLE
Tool/seccomp tools

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+seccomp-tools

--- a/packages/seccomp-tools/0001-Add-.-lib-to-library-load-path.patch
+++ b/packages/seccomp-tools/0001-Add-.-lib-to-library-load-path.patch
@@ -1,0 +1,25 @@
+From c992641d97d0245fa419ca7c615488d0d8b77201 Mon Sep 17 00:00:00 2001
+From: Astro Angelfish <astroangelfish@orangemc.moe>
+Date: Fri, 28 Feb 2025 18:35:38 +0000
+Subject: [PATCH] Add ./lib to library load path
+
+---
+ bin/seccomp-tools | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/bin/seccomp-tools b/bin/seccomp-tools
+index 1a3c2cf..20844dc 100755
+--- a/bin/seccomp-tools
++++ b/bin/seccomp-tools
+@@ -1,6 +1,8 @@
+ #!/usr/bin/env ruby
+ # frozen_string_literal: true
+ 
++$LOAD_PATH << File.expand_path('../lib', File.dirname(__FILE__))
++
+ require 'seccomp-tools/cli/cli'
+ 
+ SeccompTools::CLI.work(ARGV)
+-- 
+2.48.1
+

--- a/packages/seccomp-tools/PKGBUILD
+++ b/packages/seccomp-tools/PKGBUILD
@@ -1,0 +1,62 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=seccomp-tools
+_pkgname=seccomp-tools
+pkgver=v1.6.1.r21.ge32a4fd
+pkgrel=1
+pkgdesc='Provide powerful tools for seccomp analysis.'
+arch=('any')
+groups=('blackarch' 'blackarch-reversing', 'blackarch-binary')
+url='https://github.com/david942j/seccomp-tools/tree/master'
+license=('MIT')
+depends=('ruby')
+makedepends=('git' 'make' 'gcc' 'ruby-bundler' 'patch')
+options=(!emptydirs)
+source=("git+https://github.com/david942j/seccomp-tools.git")
+sha512sums=('SKIP')
+install="$pkgname.install"
+
+pkgver() {
+  cd $_pkgname
+
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null |
+      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" \
+      "$(git rev-parse --short=7 HEAD)"
+  )
+}
+
+prepare() {
+  cd $_pkgname
+
+  # for mobility changes
+  patch -Np1 -i ../../0001-Add-.-lib-to-library-load-path.patch
+}
+
+package() {
+  cd $_pkgname
+  
+  install -dm 755 "$pkgdir/usr/bin"
+  install -dm 755 "$pkgdir/usr/share/$pkgname"
+
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname" *.md
+
+  # Only install license if required according to
+  # https://wiki.archlinux.org/index.php/PKGBUILD#license
+  install -Dm 644 "LICENSE" \
+    "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+  rm -rf doc/ *.md spec/ LICENSE
+
+  cp --no-preserve=ownership -a * "$pkgdir/usr/share/$pkgname/"
+
+  cat > "$pkgdir/usr/bin/$pkgname" << EOF
+#!/bin/sh
+exec env GEM_PATH="$GEM_PATH:/usr/share/$pkgname/vendor/bundle/ruby/3.3.0/" ruby /usr/share/$pkgname/bin/$pkgname "\$@"
+EOF
+
+  chmod +x "$pkgdir"/usr/bin/*
+}
+

--- a/packages/seccomp-tools/seccomp-tools.install
+++ b/packages/seccomp-tools/seccomp-tools.install
@@ -1,0 +1,14 @@
+post_install() {
+  set -e
+  cd /usr/share/seccomp-tools
+  rm -f Gemfile.lock
+  bundle config build.nokogiri --use-system-libraries
+  bundle config set --local path 'vendor/bundle'
+  bundle install
+  bundle exec rake sasm compile
+}
+
+post_upgrade() {
+  post_install "$@"
+}
+


### PR DESCRIPTION
Closes https://github.com/BlackArch/blackarch/issues/4475

It requires rake to compile binary module so I had to append `bundle exec rake` related things in `.install` file, without further code inspection that throws hundreds of warning and generates unwanted stuff

Patches are used to maintain the lib load path while pwd can be everywhere

Disk usage may still need to grind, I noticed multiple examples in spec directory, and still trying to figure out which file is safe to delete.

Sorry for my messy words as my mind was not clear the time when this PR created.