### PR TITLE
donpapi: upgrade to v2

### DIFF
--- a/packages/donpapi/PKGBUILD
+++ b/packages/donpapi/PKGBUILD
@@ -11,8 +11,10 @@ arch=('any')
 groups=('blackarch' 'blackarch-windows' 'blackarch-exploitation')
 url='https://github.com/login-securite/DonPAPI'
 license=('custom:unknown')
-depends=('python' 'impacket' 'python-pyasn' 'python-lnkparse3' 'python-wheel'
-         'python-m2crypto' 'python-pycryptodome' 'swig')
+depends=('python' 'impacket-ba' 'python-dploot' 'python-rich' 'python-sqlalchemy'
+         'python-termcolor' 'exrex' 'python-jinja' 'python-flask'
+         'python-marshmallow-sqlalchemy' 'python-flask-rich' 'python-flask-basicauth'
+         'python-flask-cors' 'python-jwt')
 makedepends=('git' 'python-build' 'python-pip')
 source=("git+https://github.com/login-securite/DonPAPI.git")
 sha512sums=('SKIP')

--- a/packages/donpapi/PKGBUILD
+++ b/packages/donpapi/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=donpapi
 _pkgname=DonPAPI
 pkgver=V1.2.0.r40.g61db37a
-pkgrel=1
+pkgrel=2
 epoch=1
 pkgdesc='Dumping revelant information on compromised targets without AV detection with DPAPI.'
 arch=('any')

--- a/packages/python-dploot/PKGBUILD
+++ b/packages/python-dploot/PKGBUILD
@@ -1,0 +1,30 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-dploot
+_pkgname=${pkgname#python-}
+pkgver=3.1.2
+pkgrel=1
+pkgdesc='DPAPI looting remotely.'
+arch=('any')
+url='https://github.com/zblurx/dploot'
+license=('MIT')
+depends=('python' 'impacket-ba' 'python-cryptography' 'python-pyasn1' 'python-lxml')
+makedepends=('python-build' 'python-installer' 'python-setuptools' 'python-wheel'
+             'python-poetry')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('2e9a45779a2df8daeffe3aa6d8d6edc8c4e8dab047d1697e02d004e6a07d8575f88cc4ddc3a06f3082440ab447d932564c06fd5c90bef793937066d4faed720e')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  python -m installer --destdir="$pkgdir" dist/*.whl
+}
+

--- a/packages/python-flask-rich/PKGBUILD
+++ b/packages/python-flask-rich/PKGBUILD
@@ -1,0 +1,40 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-flask-rich
+_pkgname=flask_rich
+pkgver=0.4.1
+pkgrel=1
+pkgdesc='Rich implementation for Flask.'
+arch=('any')
+url='https://github.com/zyf722/Flask-Rich'
+license=('MIT')
+depends=('python' 'python-flask' 'python-rich' 'python-stransi')
+makedepends=('python-build' 'python-pip' 'python-poetry')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('00b5551365eb6de26d9a0132b6096a18d3e2f56c217c40658647804927c23d737d79cb847b7a63b5f5d336e9722e184907198d6c06ea96a41bccc2642f3860d2')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --outdir="$startdir/dist"
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    $_pkgname
+}
+

--- a/packages/python-jwt/PKGBUILD
+++ b/packages/python-jwt/PKGBUILD
@@ -1,0 +1,22 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-jwt
+_pkgname=${pkgname#python-}
+pkgver=1.3.1
+pkgrel=1
+pkgdesc='JSON Web Token library.'
+arch=('any')
+url='https://github.com/GehirnInc/python-jwt'
+license=('Apache-2.0')
+depends=('python' 'python-cryptography')
+makedepends=('python-build' 'python-installer' 'python-setuptools' 'python-wheel')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/ad/66/1e792aef36645b96271b4d27c2a8cc9fc7bbbaf06277a849b9e1a6360e6a/$_pkgname-$pkgver-py3-none-any.whl")
+noextract=("$_pkgname-$pkgver-py3-none-any.whl")
+sha512sums=('16ca5228b85519eb238675d73a1abe0c8b42902974c38f2bc0f4cb28ad9133198b5d38c8db5c1fd280bf45c20982c3aae2e83a9f3c42dadd6aa2fb5ab3ca8292')
+
+package() {
+  python -m installer --destdir="$pkgdir" *.whl
+}
+

--- a/packages/python-ochre/PKGBUILD
+++ b/packages/python-ochre/PKGBUILD
@@ -1,0 +1,40 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-ochre
+_pkgname=${pkgname#python-}
+pkgver=0.4.0
+pkgrel=1
+pkgdesc='A tiny Python package for working with colors in a pragmatic way.'
+arch=('any')
+url='https://github.com/getcuia/ochre/'
+license=('MIT')
+depends=('python')
+makedepends=('python-build' 'python-pip' 'python-poetry')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('cb565afa02eab8a182038b228aac53a91ddefc97f858f7a38348ae47a10dec1cf3a3d9b05b8ed62270270973fd013fc9a754caff8d2a0810323d7e4c5926fef7')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --outdir="$startdir/dist"
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    $_pkgname
+}
+

--- a/packages/python-stransi/PKGBUILD
+++ b/packages/python-stransi/PKGBUILD
@@ -1,0 +1,40 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-stransi
+_pkgname=${pkgname#python-}
+pkgver=0.3.0
+pkgrel=1
+pkgdesc='A lightweight parser for ANSI escape sequences.'
+arch=('any')
+url='https://github.com/getcuia/stransi/'
+license=('MIT')
+depends=('python' 'python-ochre')
+makedepends=('python-build' 'python-pip' 'python-poetry')
+options=(!emptydirs)
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('3e2ba83b30fe31473801f10446d85ae4c93999272b0fe5160ff41ea8ed789fbc46caae4cfa7960026edc28c19ddaf1b9b63ff83c78b6bb8e930123147c5a63db')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --outdir="$startdir/dist"
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  pip install \
+    --verbose \
+    --disable-pip-version-check \
+    --no-warn-script-location \
+    --ignore-installed \
+    --no-compile \
+    --no-deps \
+    --root="$pkgdir" \
+    --prefix=/usr \
+    --no-index \
+    --find-links="file://$startdir/dist" \
+    $_pkgname
+}
+


### PR DESCRIPTION
## Related issue

fixes #4512

## Description

Refactor to upgrade to donpapi v2

https://x.com/_zblurx/status/1809228045435240583

it also brings dploot v3, as it's a dependency of donpapi now

https://x.com/_zblurx/status/1818645383943163938

several new transitive dependencies are introduces that could also be useful for other projects:

- python-flask-rich
- python-jwt
- python-ochre
- python-stransi

## Test

- ✅ `ba-dev -I ../python-ochre/python-ochre-0.4.0-1-any.pkg.tar.zst -I ../python-stransi/python-stransi-0.3.0-1-any.pkg.tar.zst -I ../python-flask-rich/python-flask-rich-0.4.1-1-any.pkg.tar.zst -I ../python-dploot/python-dploot-3.1.2-1-any.pkg.tar.zst -I ../python-jwt/python-jwt-1.3.1-1-any.pkg.tar.zst`
- ✅ `ba-dev -e 'donpapi' -p donpapi-1:V1.2.0.r40.g61db37a-1-any.pkg.tar.zst`
- ✅ `sudo pacman -U donpapi-1:V1.2.0.r40.g61db37a-1-any.pkg.tar.zst ../python-ochre/python-ochre-0.4.0-1-any.pkg.tar.zst ../python-stransi/python-stransi-0.3.0-1-any.pkg.tar.zst ../python-flask-rich/python-flask-rich-0.4.1-1-any.pkg.tar.zst ../python-dploot/python-dploot-3.1.2-1-any.pkg.tar.zst ../python-jwt/python-jwt-1.3.1-1-any.pkg.tar.zst --asdeps`
- ✅ `donpapi gui`

## Note

This was a lot of work but here we are. Nice to have a true web server rather than just generating an HTML file.