### PR TITLE
dhcpig: python3 support

### DIFF
--- a/packages/dhcpig/PKGBUILD
+++ b/packages/dhcpig/PKGBUILD
@@ -3,14 +3,14 @@
 
 pkgname=dhcpig
 pkgver=113.a140c62
-pkgrel=1
+pkgrel=2
 epoch=2
 pkgdesc='Enhanced DHCPv4 and DHCPv6 exhaustion and fuzzing script written in python using scapy network library.'
 groups=('blackarch' 'blackarch-scanner' 'blackarch-fuzzer' 'blackarch-dos')
 url='https://github.com/kamorin/DHCPig'
-license=('GPL2')
+license=('GPL-2.0-or-later')
 arch=('any')
-depends=('python2' 'python2-scapy')
+depends=('python' 'python-scapy' 'libpcap')
 makedepends=('git')
 source=("$pkgname::git+https://github.com/kamorin/DHCPig.git")
 sha512sums=('SKIP')
@@ -18,13 +18,12 @@ sha512sums=('SKIP')
 pkgver() {
   cd $pkgname
 
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
-}
-
-prepare() {
-  cd $pkgname
-
-  sed -i 's/python/python2/' pig.py
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null |
+      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" \
+      "$(git rev-parse --short=7 HEAD)"
+  )
 }
 
 package() {


### PR DESCRIPTION
Remove python2 dependencies and added python3 ones and libpcap deps.

The latest commit supports Python 3.x