### PR TITLE
python-httpx-ntlm: add package

### DIFF
--- a/packages/python-httpx-ntlm/PKGBUILD
+++ b/packages/python-httpx-ntlm/PKGBUILD
@@ -1,0 +1,26 @@
+# Originally from: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-httpx-ntlm
+
+pkgname=python-httpx-ntlm
+_pkgname=httpx-ntlm
+pkgver=1.4.0
+pkgrel=1
+pkgdesc='NTLM authentication support for HTTPX.'
+arch=('any')
+url='https://github.com/ulodciv/httpx-ntlm'
+license=('ISC')
+depends=('python')
+makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools')
+source=("$url/archive/refs/tags/$pkgver.tar.gz")
+sha512sums=('32d6705588de4142e7f357214733da6d4a3a5ba1dff83aec93bd584a12745308d11d15268e36361d6a9d3f1d8114acffa5f7cf44c27d91dcf03911ae03871b59')
+
+# https://wiki.archlinux.org/title/Python_package_guidelines#Standards_based_(PEP_517)
+build() {
+  cd "$_pkgname-$pkgver"
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+  install -Dm644 "$srcdir/$_pkgname-$pkgver/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  python -m installer --destdir="$pkgdir" dist/*.whl
+}


### PR DESCRIPTION
Originally from: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-httpx-ntlm