### PR TITLE
Add blackarch-helper package

### DIFF
--- a/packages/blackarch-helper/.SRCINFO
+++ b/packages/blackarch-helper/.SRCINFO
@@ -1,0 +1,22 @@
+pkgbase = blackarch-helper
+	pkgdesc = TUI/CLI helper to manage and install tools from the BlackArch repository
+	pkgver = 1.1.0
+	pkgrel = 1
+	url = https://github.com/x0rgus/blackarch-helper
+	arch = any
+	groups = blackarch
+	license = MIT
+	depends = bash
+	depends = fzf
+	source = blackarch-helper
+	source = LICENSE
+	source = blackarch-helper.1
+	source = blackarch-helper.bash-completion
+	source = _blackarch-helper
+	sha512sums = SKIP
+	sha512sums = SKIP
+	sha512sums = SKIP
+	sha512sums = SKIP
+	sha512sums = SKIP
+
+pkgname = blackarch-helper

--- a/packages/blackarch-helper/LICENSE
+++ b/packages/blackarch-helper/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Lucas Procópio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/blackarch-helper/PKGBUILD
+++ b/packages/blackarch-helper/PKGBUILD
@@ -1,0 +1,30 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=blackarch-helper
+pkgver=1.1.0
+pkgrel=1
+pkgdesc='TUI/CLI helper to manage and install tools from the BlackArch repository'
+arch=('any')
+url='https://github.com/x0rgus/blackarch-helper'
+license=('MIT')
+groups=('blackarch')
+depends=('bash' 'fzf')
+source=('blackarch-helper'
+        'LICENSE'
+        'blackarch-helper.1'
+        'blackarch-helper.bash-completion'
+        '_blackarch-helper')
+sha512sums=('SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP')
+
+package() {
+    install -Dm755 "$srcdir/blackarch-helper" "$pkgdir/usr/bin/blackarch-helper"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    install -Dm644 "$srcdir/blackarch-helper.1" "$pkgdir/usr/share/man/man1/$pkgname.1"
+    install -Dm644 "$srcdir/blackarch-helper.bash-completion" "$pkgdir/usr/share/bash-completion/completions/$pkgname"
+    install -Dm644 "$srcdir/_blackarch-helper" "$pkgdir/usr/share/zsh/site-functions/_$pkgname"
+}

--- a/packages/blackarch-helper/_blackarch-helper
+++ b/packages/blackarch-helper/_blackarch-helper
@@ -1,0 +1,85 @@
+#compdef blackarch-helper
+
+_blackarch_helper() {
+    local -a commands
+    local -a category_subcommands
+    local -a tool_subcommands
+    local state
+
+    # Options with descriptions
+    local -a global_opts
+    global_opts=(
+        '(-v --verbose)'{-v,--verbose}'[Enable verbose output]'
+        '(-h --help)'{-h,--help}'[Show help message]'
+    )
+
+    # Commands with descriptions
+    commands=(
+        'category:Manage tool categories'
+        'tool:Manage individual tools'
+        'interactive:Open the interactive menu'
+        'help:Show the help message'
+    )
+    category_subcommands=(
+        'list:List all categories'
+        'install:Install an entire category'
+    )
+    # UPDATED tool subcommands
+    tool_subcommands=(
+        'list:List all tools in the repository'
+        'list-installed:List all installed BlackArch packages'
+        'search:Search for a tool by keyword'
+        'info:Show info for a specific tool'
+        'install:Install a specific tool'
+        'upgrade:Upgrade all installed BlackArch packages'
+    )
+
+    _arguments -C \
+        $global_opts \
+        '1: :->command' \
+        '2: :->subcommand' \
+        '3: :->argument'
+
+    case $state in
+        command)
+            _describe "command" commands
+            ;;
+        subcommand)
+            case $words[2] in
+                category)
+                    _describe "category subcommand" category_subcommands
+                    ;;
+                tool)
+                    _describe "tool subcommand" tool_subcommands
+                    ;;
+            esac
+            ;;
+        argument)
+            case $words[2] in
+                category)
+                    case $words[3] in
+                        install)
+                            # Dynamically generate category list
+                            local -a categories
+                            categories=($(pacman -Sg 2>/dev/null | grep '^blackarch-' | cut -d' ' -f1 | sort -u))
+                            _describe -t categories "category" categories
+                            ;;
+                    esac
+                    ;;
+                tool)
+                    case $words[3] in
+                        info|install)
+                            # Generating a list of all tools is too slow for completion.
+                            _message "tool name (use 'tool search' to find one)"
+                            ;;
+                        search)
+                            _message "keyword to search for"
+                            ;;
+                    esac
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_blackarch_helper "$@"

--- a/packages/blackarch-helper/blackarch-helper
+++ b/packages/blackarch-helper/blackarch-helper
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+#
+# blackarch-helper
+# Simple CLI helper for BlackArch tools
+# Author: Lucas "x0rgus"
+# License: MIT
+# Repository: https://github.com/x0rgus/blackarch-helper
+#
+# --- Configuration ---
+# Set VERBOSE to "false" by default. It can be overridden by a command-line flag.
+VERBOSE=false
+
+## --- Color and Symbol Configuration ---
+COLOR_RESET=$'\033[0m'
+COLOR_GREEN=$'\033[0;32m'
+COLOR_YELLOW=$'\033[0;33m'
+COLOR_RED=$'\033[0;31m'
+COLOR_CYAN=$'\033[0;36m'
+COLOR_BOLD=$'\033[1m'
+
+# --- Logging Functions ---
+# Helper functions to standardize message output.
+
+einfo() { echo -e "${COLOR_GREEN}[INFO]${COLOR_RESET} $1"; }
+ewarn() { echo -e "${COLOR_YELLOW}[WARN]${COLOR_RESET} $1"; } >&2
+eerror() { echo -e "${COLOR_RED}[ERROR]${COLOR_RESET} $1"; } >&2
+edie() { eerror "$1"; exit 1; }
+
+# --- Core Functions ---
+
+# Check if the BlackArch repository is configured in pacman.conf
+check_blackarch_repo() {
+    if ! grep -q '^\[blackarch\]' /etc/pacman.conf; then
+        eerror "BlackArch repository not found in /etc/pacman.conf."
+        echo -e "\nPlease follow the installation instructions at:"
+        echo -e "${COLOR_CYAN}https://blackarch.org/guide.html${COLOR_RESET}\n"
+        exit 1
+    fi
+}
+
+# Check if fzf is installed
+check_fzf() {
+    if ! command -v fzf &>/dev/null; then
+        edie "fzf not found. Please install it with: sudo pacman -S fzf"
+    fi
+}
+
+# --- Logic Functions (Backend) ---
+
+# List all available BlackArch categories, hiding stderr by default.
+_list_all_categories() {
+    pacman -Sg 2>/dev/null | grep '^blackarch-' | cut -d' ' -f1 | sort -u
+}
+
+# List all tools in the BlackArch repository, hiding stderr by default.
+_list_all_tools() {
+    pacman -Sgg 2>/dev/null | grep '^blackarch-' | cut -d' ' -f2 | sort -u
+}
+
+# List tools in a specific category, hiding stderr by default.
+_list_tools_in_category() {
+    pacman -Sg "$1" 2>/dev/null | awk '{print $2}'
+}
+
+# NEW: Pre-processes the tool list to show which are already installed.
+_get_tools_with_install_status() {
+    local category="$1"
+    # Get all installed blackarch packages once.
+    local installed_pkgs
+    installed_pkgs=$(pacman -Qqg blackarch 2>/dev/null)
+
+    # Get all tools in the given category.
+    _list_tools_in_category "$category" | while read -r tool; do
+        # Check if the tool is in the list of installed packages.
+        if grep -q -w "^${tool}$" <<< "$installed_pkgs"; then
+            # If installed, prepend a check mark.
+            printf "✔ %s\n" "$tool"
+        else
+            # If not, prepend spaces for alignment.
+            printf "  %s\n" "$tool"
+        fi
+    done
+}
+
+# --- Verbose-aware Command Execution ---
+
+# Shows a spinner while a command runs in the background.
+_spinner() {
+    local msg="$1"
+    shift
+    local cmd=("$@")
+    local spinner_chars="/-\\|"
+    
+    "${cmd[@]}" &
+    local pid=$!
+    trap 'kill $pid 2>/dev/null' SIGINT
+
+    einfo "$msg"
+    while kill -0 $pid 2>/dev/null; do
+        for (( i=0; i<${#spinner_chars}; i++ )); do
+            echo -ne "${COLOR_GREEN}[BUSY]${COLOR_RESET} ${spinner_chars:$i:1}\r"
+            sleep 0.1
+        done
+    done
+    echo -e "\r${COLOR_GREEN}[DONE]${COLOR_RESET} Operation finished.   "
+
+    wait $pid
+    return $?
+}
+
+# Installs or upgrades packages.
+_run_pacman_S() {
+    if [[ "$VERBOSE" == "true" ]]; then
+        einfo "Running pacman in verbose mode..."
+        # shellcheck disable=SC2086
+        sudo pacman -S --needed --noconfirm "$@"
+    else
+        _spinner "Running pacman (output hidden)..." sudo pacman -S --needed --noconfirm "$@" >/dev/null 2>&1
+    fi
+
+    if [[ $? -ne 0 ]]; then
+        eerror "An error occurred during the pacman operation."
+        ewarn "Try running with the --verbose flag to see detailed output."
+        return 1
+    fi
+    return 0
+}
+
+
+# --- Subcommand Functions (User Interface) ---
+
+# Handler for the 'category' command
+handle_category() {
+    local action="$1"
+    local category_name="$2"
+
+    case "$action" in
+        list)
+            einfo "Listing all BlackArch categories:"
+            _list_all_categories
+            ;;
+        install)
+            [[ -z "$category_name" ]] && edie "Usage: $0 category install <category-name>"
+            einfo "Preparing to install all tools from the '$category_name' category..."
+            # shellcheck disable=SC2046
+            _run_pacman_S $(_list_tools_in_category "$category_name")
+            einfo "Installation of category '$category_name' complete."
+            ;;
+        *)
+            eerror "Invalid subcommand for 'category'. Use 'list' or 'install'."
+            usage
+            exit 1
+            ;;
+    esac
+}
+
+# Handler for the 'tool' command
+handle_tool() {
+    local action="$1"
+    local tool_name="$2"
+
+    case "$action" in
+        list)
+            einfo "Listing all tools in the BlackArch repository..."
+            _list_all_tools
+            ;;
+        list-installed)
+            einfo "Listing all installed BlackArch packages:"
+            pacman -Qg blackarch --color=never
+            ;;
+        search)
+            [[ -z "$tool_name" ]] && edie "Usage: $0 tool search <keyword>"
+            einfo "Searching for tools with the keyword '$tool_name':"
+            _list_all_tools | grep -i --color=auto "$tool_name"
+            ;;
+        info)
+            [[ -z "$tool_name" ]] && edie "Usage: $0 tool info <tool-name>"
+            einfo "Displaying information for the tool '$tool_name':"
+            pacman -Si "$tool_name"
+            ;;
+        install)
+            [[ -z "$tool_name" ]] && edie "Usage: $0 tool install <package-name>"
+            einfo "Attempting to install '$tool_name'..."
+            _run_pacman_S "$tool_name"
+            ;;
+        upgrade)
+            einfo "Checking for installed BlackArch packages to upgrade..."
+            local installed_packages
+            installed_packages=$(comm -12 <(pacman -Slq blackarch | sort) <(pacman -Qq | sort))
+            
+            if [[ -z "$installed_packages" ]]; then
+                einfo "No BlackArch packages are installed. Nothing to upgrade."
+                exit 0
+            fi
+            
+            einfo "The following installed BlackArch packages will be checked for updates:"
+            echo -e "${COLOR_CYAN}${installed_packages}${COLOR_RESET}"
+            
+            read -p $'\e[33m[WARN]\e[0m Do you want to proceed with the upgrade? (y/N) ' -n 1 -r reply
+            echo
+            
+            if [[ "$reply" =~ ^[Yy]$ ]]; then
+                einfo "Starting upgrade..."
+                # shellcheck disable=SC2086
+                _run_pacman_S $installed_packages
+                einfo "Upgrade process complete."
+            else
+                ewarn "Upgrade cancelled by the user."
+            fi
+            ;;
+        *)
+            eerror "Invalid subcommand for 'tool'. Use 'list', 'search', 'info', 'install', 'upgrade', or 'list-installed'."
+            usage
+            exit 1
+            ;;
+    esac
+}
+
+# Interactive menu with FZF
+interactive_menu() {
+    check_fzf
+    
+    while true; do
+        einfo "Select a category to explore (ESC to exit)"
+        local category
+        category=$(_list_all_categories | fzf --prompt="▶ Category: " --height=40% --border --header="Press ESC to exit the program.")
+        
+        [[ -z "$category" ]] && break
+
+        while true; do
+            einfo "Category: ${COLOR_CYAN}$category${COLOR_RESET}"
+            local fzf_output
+            # UPDATED: Major changes to the fzf command for better UX.
+            fzf_output=$(_get_tools_with_install_status "$category" | fzf \
+                --multi \
+                --prompt="▶ Tool: " \
+                --border \
+                --header="✔=Installed | TAB to select | ENTER to install | CTRL-I for info | ESC to go back" \
+                --preview-window 'right:50%:border-left' \
+                --preview 'pacman -Si $(echo {} | awk "{print \$NF}")' \
+                --bind 'ctrl-i:toggle-preview' \
+                --expect=esc)
+
+            [[ -z "$fzf_output" ]] && break 2
+
+            local key_pressed
+            key_pressed=$(head -n1 <<< "$fzf_output")
+            
+            if [[ "$key_pressed" == "esc" ]]; then
+                break
+            fi
+
+            local selected_tools
+            # UPDATED: Strip the status indicator (✔) and spaces from the selection.
+            selected_tools=$(tail -n +2 <<< "$fzf_output" | awk '{print $NF}')
+
+            if [[ -z "$selected_tools" ]]; then
+                ewarn "No tools selected. Press ESC to go back."
+                sleep 1
+                continue
+            fi
+
+            einfo "The following tools will be installed:"
+            echo -e "${COLOR_CYAN}${selected_tools}${COLOR_RESET}"
+            
+            read -p $'\e[33m[WARN]\e[0m Do you want to proceed with the installation? (y/N) ' -n 1 -r reply
+            echo
+
+            if [[ "$reply" =~ ^[Yy]$ ]]; then
+                _run_pacman_S "${selected_tools}"
+                einfo "Installation complete. Press any key to continue."
+                read -n 1 -s
+            else
+                ewarn "Installation cancelled by the user."
+            fi
+            
+            continue 
+        done
+    done
+
+    einfo "Exiting blackarch-helper."
+}
+
+# Help/usage function
+usage() {
+    cat <<EOF
+
+${COLOR_BOLD}blackarch-helper${COLOR_RESET}: A CLI tool to explore the BlackArch repository.
+
+${COLOR_BOLD}USAGE:${COLOR_RESET}
+    blackarch-helper [options] <command> <subcommand> [arguments]
+
+${COLOR_BOLD}OPTIONS:${COLOR_RESET}
+    ${COLOR_YELLOW}-v, --verbose${COLOR_RESET}   Enable verbose output for commands like installations.
+
+${COLOR_BOLD}COMMANDS:${COLOR_RESET}
+    ${COLOR_CYAN}category${COLOR_RESET}    Manage tool categories.
+        ${COLOR_YELLOW}list${COLOR_RESET}          Lists all available categories.
+        ${COLOR_YELLOW}install${COLOR_RESET} <cat>  Installs all tools from a category.
+
+    ${COLOR_CYAN}tool${COLOR_RESET}        Manage individual tools.
+        ${COLOR_YELLOW}list${COLOR_RESET}          Lists all tools in the repository.
+        ${COLOR_YELLOW}list-installed${COLOR_RESET}  Lists all installed BlackArch packages.
+        ${COLOR_YELLOW}search${COLOR_RESET}  <str>  Searches for tools by keyword.
+        ${COLOR_YELLOW}info${COLOR_RESET}    <pkg>  Shows information about a tool (package).
+        ${COLOR_YELLOW}install${COLOR_RESET} <pkg>  Installs a specific BlackArch package.
+        ${COLOR_YELLOW}upgrade${COLOR_RESET}       Upgrades all installed BlackArch packages.
+
+    ${COLOR_CYAN}interactive${COLOR_RESET}   Opens an interactive FZF menu to explore categories and tools.
+    ${COLOR_CYAN}help${COLOR_RESET}          Shows this help message.
+
+${COLOR_BOLD}EXAMPLES:${COLOR_RESET}
+    blackarch-helper category list
+    blackarch-helper tool search nmap
+    blackarch-helper tool install metasploit
+    sudo blackarch-helper tool upgrade
+    sudo blackarch-helper --verbose category install blackarch-scanner
+
+EOF
+}
+
+# --- Main Execution ---
+
+# Initial check
+check_blackarch_repo
+
+# --- Argument Parsing for Flags ---
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+
+# If no arguments are left, default to the interactive menu.
+if [[ $# -eq 0 ]]; then
+    interactive_menu
+    exit 0
+fi
+
+# Command Dispatcher
+case "$1" in
+    category)
+        handle_category "${@:2}"
+        ;;
+    tool)
+        handle_tool "${@:2}"
+        ;;
+    interactive | fzf)
+        interactive_menu
+        ;;
+    help | --help | -h)
+        usage
+        ;;
+    *)
+        eerror "Unknown command '$1'."
+        echo -e "\nValid commands are: ${COLOR_CYAN}category, tool, interactive, help${COLOR_RESET}"
+        exit 1
+        ;;
+esac

--- a/packages/blackarch-helper/blackarch-helper.1
+++ b/packages/blackarch-helper/blackarch-helper.1
@@ -1,0 +1,87 @@
+.TH blackarch-helper 1 "July 2025" "1.2.0" "blackarch-helper Manual"
+
+.SH NAME
+blackarch-helper \- A CLI helper to explore and install tools from the BlackArch repository.
+
+.SH SYNOPSIS
+.B blackarch-helper
+[\fI--verbose\fR] [\fI-v\fR] <command> <subcommand> [arguments]
+.br
+.B blackarch-helper
+[interactive | fzf | --help | -h]
+
+.SH DESCRIPTION
+\fBblackarch-helper\fR is a command-line utility designed to simplify the exploration and management of packages from the BlackArch repository. It offers both a subcommand-based interface for scripting and a powerful interactive mode for navigation.
+
+If run without arguments, it starts the interactive mode by default.
+
+The interactive mode, powered by \fBfzf\fR, allows for a fluid menu-driven experience. The user can first select a category, then view the tools within it. Packages already installed are marked with a '✔'. A preview pane on the right shows detailed package information, which can be toggled with \fBCTRL-I\fR. It's possible to use the \fBTAB\fR key to select one or multiple tools, press \fBENTER\fB to begin the installation process, and press \fBESC\fR to go back.
+
+.SH OPTIONS
+.TP
+.B -v, --verbose
+Enable verbose mode. When this flag is used, commands like 'install' will display the full output from pacman instead of hiding it behind a loading spinner.
+
+.SH COMMANDS
+Commands are structured in a tree format.
+
+.TP
+.B category
+Manage tool categories.
+.RS
+.TP
+.B list
+Lists all available BlackArch categories.
+.TP
+.B install <category-name>
+Installs all packages belonging to the specified category. Requires superuser privileges.
+.RE
+
+.TP
+.B tool
+Manage individual tools.
+.RS
+.TP
+.B list
+Lists all individual tools available in the BlackArch repository.
+.TP
+.B list-installed
+Lists all installed packages from the BlackArch repository.
+.TP
+.B search <keyword>
+Searches for tools whose name contains the keyword. The search is case-insensitive.
+.TP
+.B info <tool-name>
+Displays detailed information about a specific package.
+.TP
+.B install <package-name>
+Installs a specific package. Requires superuser privileges.
+.TP
+.B upgrade
+Checks for updates for all installed BlackArch packages and prompts for installation. Requires superuser privileges.
+.RE
+
+.TP
+.B interactive
+(Also accessible via \fBfzf\fR). Starts the interactive menu described in the DESCRIPTION section. This is the default behavior if no command is provided.
+
+.TP
+.B help
+(Also accessible via \fB--help\fR or \fB-h\fR). Displays the usage message.
+
+.SH EXAMPLES
+.TP
+To search for tools related to 'wireless':
+.B $ blackarch-helper tool search wireless
+.TP
+To install 'metasploit':
+.B $ sudo blackarch-helper tool install metasploit
+.TP
+To upgrade all your installed BlackArch tools:
+.B $ sudo blackarch-helper tool upgrade
+.TP
+To install all tools from the 'blackarch-scanner' category with detailed output:
+.B $ sudo blackarch-helper --verbose category install blackarch-scanner
+
+.SH AUTHOR
+Written by Lucas "x0rgus".

--- a/packages/blackarch-helper/blackarch-helper.bash-completion
+++ b/packages/blackarch-helper/blackarch-helper.bash-completion
@@ -1,0 +1,45 @@
+# bash-completion for blackarch-helper
+
+_blackarch_helper_completions() {
+    local cur prev words cword
+    _get_comp_words_by_ref -n : cur prev words cword
+
+    # Variables
+    local commands="category tool interactive help --help -h --verbose -v"
+    local category_subcommands="list install"
+    local tool_subcommands="list list-installed search info install upgrade"
+
+    # Main command completion
+    if [[ ${cword} -eq 1 ]]; then
+        COMPREPLY=($(compgen -W "${commands}" -- "${cur}"))
+        return 0
+    fi
+
+    # Subcommand completion
+    local command="${words[1]}"
+    case "${command}" in
+        category)
+            if [[ ${cword} -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "${category_subcommands}" -- "${cur}"))
+            elif [[ ${cword} -eq 3 && "${words[2]}" == "install" ]]; then
+                # Define a local function to avoid polluting the global scope
+                _list_all_categories_for_comp() {
+                    pacman -Sg 2>/dev/null | grep '^blackarch-' | cut -d' ' -f1 | sort -u
+                }
+                local categories=$(_list_all_categories_for_comp)
+                COMPREPLY=($(compgen -W "${categories}" -- "${cur}"))
+            fi
+            ;;
+        tool)
+            if [[ ${cword} -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "${tool_subcommands}" -- "${cur}"))
+            elif [[ ${cword} -eq 3 && ("${words[2]}" == "info" || "${words[2]}" == "search" || "${words[2]}" == "install") ]]; then
+                # Autocompleting all tool names is too slow.
+                # Default to file directory completion.
+                _filedir
+            fi
+            ;;
+    esac
+}
+
+complete -F _blackarch_helper_completions blackarch-helper


### PR DESCRIPTION
- **Name**: blackarch-helper
- **Source URL**: https://github.com/x0rgus/blackarch-helper
- **Description**: A lightweight Bash TUI/CLI to explore, search and install tools from the BlackArch repository.

This tool provides an interactive fzf-powered TUI interface as well as traditional CLI subcommands. It replaces the now deprecated `blackman` tool, which is still referenced in official documentation but no longer maintained or recommended.
<img width="1890" height="991" alt="s2" src="https://github.com/user-attachments/assets/9362c29b-6b19-4e19-98ed-182a06ea7566" />
<img width="1809" height="448" alt="s1" src="https://github.com/user-attachments/assets/f25142c6-4538-4184-b312-718c6fb77906" />

License: MIT
