### PR TITLE
ci: update ubuntu runner version and actions/checkout version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,38 +1,48 @@
 name: CI
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@v3
-       - name: Build Package
-         run: |
-           CHANGED_FILES=($(git diff --name-only --diff-filter=d $THE_LAST_COMMIT HEAD))
-           for FILE in $CHANGED_FILES; do
-              if [[ $(basename $FILE) == "PKGBUILD" ]]; then
-                docker build -t builder -f travis/Dockerfile $(dirname $FILE)
-                docker run --rm builder
-              fi
-           done
-  pkgcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - name: Build Package
+        run: |
+          CHANGED_FILES=($(git diff --name-only --diff-filter=d $THE_LAST_COMMIT HEAD))
+          for FILE in $CHANGED_FILES; do
+             if [[ $(basename $FILE) == "PKGBUILD" ]]; then
+               docker build -t builder -f travis/Dockerfile $(dirname $FILE)
+               docker run --rm builder
+             fi
+          done
+
+  pkgcheck:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pkgcheck-arch --user
+
       - name: Check Styling
         run: |
-           COMMIT_RANGE=($(git diff --name-only --diff-filter=d $(git log -2 --format=%H | tr '\n' ' ')))
-           CHANGED_FILES=($(git diff --name-only $COMMIT_RANGE))
-           for FILE in $CHANGED_FILES; do
-              if [[ $(basename $FILE) == "PKGBUILD" ]]; then
-                pkgcheck $FILE
-              fi
-           done
+          COMMIT_RANGE=($(git diff --name-only --diff-filter=d $(git log -2 --format=%H | tr '\n' ' ')))
+          CHANGED_FILES=($(git diff --name-only $COMMIT_RANGE))
+          for FILE in $CHANGED_FILES; do
+             if [[ $(basename $FILE) == "PKGBUILD" ]]; then
+               pkgcheck $FILE
+             fi
+          done


### PR DESCRIPTION
The runner `ubuntu-20.04` has been deprecated since 2025-04-15, see https://github.com/actions/runner-images/issues/11101