### PR TITLE
hostapd-mana: add package

### DIFF
--- a/packages/hostapd-mana/PKGBUILD
+++ b/packages/hostapd-mana/PKGBUILD
@@ -10,14 +10,17 @@ groups=('blackarch' 'blackarch-wireless')
 url='https://github.com/sensepost/hostapd-mana'
 license=('custom:BSD/GPL v2 dual')
 depends=('openssl' 'libnl')
+optdepends=('asleap')
 makedepends=('git')
 source=("git+https://github.com/sensepost/$pkgname.git"
-        'hostapd.service')
+        "$pkgname.service"
+        "$pkgname@.service"
+        "$pkgname.tmpfiles")
 sha512sums=('SKIP'
-            '09627a637ceb034d21f1998e8aaaccd77f210f6b9cc1fd687e6ec6a363d06e6d5fe5cf34d22c23045f4e99d78516cd7ef2769553255b242e665b562096c8a99d')
+            '66af211164de09f6895e569085200a125c9497e583b5ab54b37ba8c4d8e8e87c39a9e0915eabe177c736ee0d9e551957707a978ef6d3e7255836283f015b9af8'
+            'ffd585fd0e6a00b45e68767cd073668736ddf108e1be8bcdf1f380397496a86e9ce488d835e478ea7df1c9a9d0e46df3790e5b725ed03ec41731fa92bf7c0f0e'
+            'e79a48525947410c9fde3c83abb4b74d15ca621263970b8a170a6c4d5388b3a3c5e6d0f0ad8757efc08745417834448df65726fe7b0192836f1d4de23a3a72e1')
 options=('emptydirs')
-conflicts=('hostapd')
-provides=('hostapd')
 
 pkgver() {
   cd $pkgname
@@ -30,25 +33,46 @@ pkgver() {
   )
 }
 
-build() {
+prepare() {
   cd "$pkgname/hostapd"
-  sed -i 's:/etc/hostapd:/etc/hostapd/hostapd:' hostapd.conf
 
-  cd ..
+  sed -i "s:/var/run/hostapd:/run/$pkgname:g" hostapd.conf
+  sed -i "s:/etc/hostapd:/etc/$pkgname/hostapd:g" hostapd.conf
+
+  cd ../crackapd
+
+  sed -i "s:mana-toolkit:$pkgname:g" crackapd.{conf,py}
+  sed -i -E 's:THEPATH=(.*):THEPATH=str("/etc/hostapd-mana/"):' crackapd.py
+}
+
+build() {
+  cd "$pkgname"
+
   make -C hostapd
 }
 
 package() {
   cd "$pkgname/hostapd"
 
-  install -Dm 755 -t "$pkgdir/usr/bin" hostapd hostapd_cli
+  # binaries
+  install -Dm 755 hostapd_cli "${pkgdir}"/usr/bin/${pkgname}_cli
+  install -Dm 755 hostapd "${pkgdir}"/usr/bin/$pkgname
 
-  install -Dm 644 -t "$pkgdir/usr/share/doc/hostapd/" hostapd.[a-z]* wired.conf hlr_auc_gw.milenage_db
+  # documentation
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" hostapd.[a-z]* wired.conf hlr_auc_gw.milenage_db
+  install -Dm 644 hostapd.8 "$pkgdir/usr/share/man/man8/$pkgname.8"
+  install -Dm 644 hostapd_cli.1 "$pkgdir/usr/share/man/man1/${pkgname}_cli.1"
 
-  install -dm 755 "$pkgdir/etc/hostapd"
-  install -Dm 644 hostapd.8 "$pkgdir/usr/share/man/man8/hostapd.8"
-  install -Dm 644 hostapd_cli.1 "$pkgdir/usr/share/man/man1/hostapd_cli.1"
-  install -Dm 644 ../COPYING "$pkgdir/usr/share/licenses/hostapd/COPYING"
-  install -Dm644 "$srcdir/hostapd.service" "$pkgdir/usr/lib/systemd/system/hostapd.service"
+  # config
+  install -dm 755 "$pkgdir/etc/$pkgname"
+  # license
+  install -Dm 644 ../COPYING "$pkgdir/usr/share/licenses/$pkgname/COPYING"
+
+  # systemd service
+  install -Dm644 "$srcdir/$pkgname.service" -t "$pkgdir/usr/lib/systemd/system/"
+  install -Dm644 "$srcdir/$pkgname@.service" -t "$pkgdir/usr/lib/systemd/system/"
+
+  # tmpfiles.d
+  install -Dm644 "$srcdir"/$pkgname.tmpfiles -t "$pkgdir/usr/lib/tmpfiles.d/"
 }
 

--- a/packages/hostapd-mana/hostapd-mana.service
+++ b/packages/hostapd-mana/hostapd-mana.service
@@ -3,7 +3,7 @@ Description=Modified hostapd for Wi-Fi attacks to create a rogue access point.
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/hostapd /etc/hostapd/hostapd.conf
+ExecStart=/usr/bin/hostapd /etc/hostapd-mana/hostapd.conf
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]

--- a/packages/hostapd-mana/hostapd-mana.tmpfiles
+++ b/packages/hostapd-mana/hostapd-mana.tmpfiles
@@ -1,0 +1,2 @@
+# create state dir
+d /var/lib/hostapd-mana 750 root root - -

--- a/packages/hostapd-mana/hostapd-mana@.service
+++ b/packages/hostapd-mana/hostapd-mana@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Modified hostapd for Wi-Fi attacks to create a rogue access point.
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/hostapd /etc/hostapd-mana/%i.conf
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
To test, one need to write a `/etc/hostapd/hostapd.conf`. To improve this package maybe we need to provide an example one. See https://github.com/sensepost/hostapd-mana/wiki/Simplest-hostapd.conf.

Also, there is maybe a way to make the mana fork not conflicting with original hostapd, but I didn't want to spend time on that.