### PR TITLE
Create PKGBUILD

### DIFF
--- a/packages/hashpeek/PKGBUILD
+++ b/packages/hashpeek/PKGBUILD
@@ -1,0 +1,41 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=hashpeek
+pkgver=0.2.2
+pkgrel=1
+groups=('blackarch')
+pkgdesc= 'A fast Go-based CLI tool to identify, extract, and classify hash types from structured data/files with JSON/CSV output and Hashcat/John formatting details (a hash identifier).'
+arch=('x86_64' 'aarch64')
+url='https://github.com/ph4mished/hashpeek'
+license=('MIT')
+makedepends=('git' 'go')
+source=("git+https://github.com/ph4mished/$pkgname.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+build() {
+  cd $pkgname
+
+  GOPATH="$srcdir" go mod download
+  GOPATH="$srcdir" go build \
+    -trimpath \
+    -buildmode=pie \
+    -mod=readonly \
+    -modcacherw \
+    -ldflags "-s -w" \
+    -o $pkgname .
+}
+
+package() {
+  cd $pkgname
+
+  install -Dm 755 $pkgname "$pkgdir/usr/bin/$pkgname"
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+  }
+  


### PR DESCRIPTION
Hashpeek is a hash identifier that can also extract hashes from messy logs and structured data as well 