### PR TITLE
Update COPYING - Removing unused AUTHORS sentence

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -11,9 +11,7 @@ modification, are permitted provided that the following conditions are met:
 	 materials provided with the distribution. Neither the name of the
 	 BlackArch group nor the names of its contributors may be used to
 	 endorse or promote products derived from this software without specific
-	 prior written permission. The list of authors (AUTHORS) must be
-	 distributed in its original form with all redistributions of the source
-	 code.
+	 prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED


### PR DESCRIPTION
Remove
```
The list of authors (AUTHORS) must be distributed in its original form with all redistributions of the source code.
```
because no applicable. 