### PR TITLE
bloodhound: removing unused dependencies

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+bloodhound

--- a/packages/bloodhound/PKGBUILD
+++ b/packages/bloodhound/PKGBUILD
@@ -3,15 +3,14 @@
 
 pkgname=bloodhound
 pkgver=v4.3.1.r60.g226f497
-pkgrel=1
+pkgrel=2
 epoch=1
 pkgdesc='Six Degrees of Domain Admin'
 groups=('blackarch' 'blackarch-recon' 'blackarch-windows')
 arch=('x86_64' 'aarch64')
 url='https://github.com/SpecterOps/BloodHound-Legacy'
 license=('GPL3')
-depends=('nodejs' 'neo4j-community' 'alsa-lib' 'gtk3' 'libxss' 'nss'
-         'gconf' 'libxtst' 'jre17-openjdk-headless')
+depends=('nodejs' 'neo4j-community' 'jre17-openjdk-headless')
 makedepends=('git' 'nodejs-electron-packager' 'npm' 'unzip')
 optdepends=('python: for some scripts' 'powershell: for PowerShell ingestion')
 source=("$pkgname::git+$url.git")

--- a/packages/bloodhound/bloodhound.install
+++ b/packages/bloodhound/bloodhound.install
@@ -1,7 +1,9 @@
 post_install() {
 	set -e
 	echo
-	echo ">>  Don't forget to change the default password for neo4j."
+	echo ">>  Don't forget to run 'systemctl start neo4j'."
+	echo ">>  Once BloodHound is launched, visit http://localhost:7474"
+	echo ">>  Login by neo4j:neo4j to change the default password."
 	echo ">>"
 	echo
 }


### PR DESCRIPTION
Remove `alsa-lib gtk3 libxss nss gconf libxtst` dependencies. No references found in the source code (unless I'm drunk).

Close: https://github.com/BlackArch/blackarch/issues/4543