### PR TITLE
python-sectools: update to fix ldap import error

### DIFF
--- a/packages/extractbitlockerkeys/PKGBUILD
+++ b/packages/extractbitlockerkeys/PKGBUILD
@@ -3,13 +3,13 @@
 
 pkgname=extractbitlockerkeys
 pkgver=1.2.r18.g4e111d6
-pkgrel=1
+pkgrel=2
 pkgdesc='Script to automatically extract the bitlocker recovery keys from a domain.'
 arch=('any')
 groups=('blackarch' 'blackarch-windows')
 url='https://github.com/p0dalirius/extractbitlockerkeys'
 license=('GPL-2.0-or-later')
-depends=('python' 'python-sectools' 'python-xlsxwriter')
+depends=('python' 'python-sectools>=1.5.0' 'python-xlsxwriter')
 makedepends=('git')
 source=("git+$url.git")
 sha512sums=('SKIP')

--- a/packages/finduncommonshares/PKGBUILD
+++ b/packages/finduncommonshares/PKGBUILD
@@ -3,14 +3,14 @@
 
 pkgname=finduncommonshares
 pkgver=3.2.r9.g8dc90e5
-pkgrel=1
+pkgrel=2
 pkgdesc='Python script allowing to quickly find uncommon shares in vast Windows Domains.'
 arch=('any')
 groups=('blackarch' 'blackarch-windows')
 url='https://github.com/p0dalirius/pyFindUncommonShares'
 license=('GPL-2.0-only')
 depends=('impacket' 'python' 'python-dnspython' 'python-pycryptodome'
-         'python-sectools' 'python-xlsxwriter')
+         'python-sectools>=1.5.1' 'python-xlsxwriter')
 makedepends=('git')
 source=("$pkgname::git+$url.git")
 sha512sums=('SKIP')

--- a/packages/ldapwordlistharvester/PKGBUILD
+++ b/packages/ldapwordlistharvester/PKGBUILD
@@ -3,13 +3,13 @@
 
 pkgname=ldapwordlistharvester
 pkgver=1.2.r17.ge5f1862
-pkgrel=1
+pkgrel=2
 pkgdesc='Tool to generate wordlist from information present in LDAP, in order to crack passwords of domain accounts.'
 arch=('any')
 groups=('blackarch' 'blackarch-wordlist' 'blackarch-wordlist')
 url='https://github.com/p0dalirius/pyLDAPWordlistHarvester'
 license=('GPL-2.0-only')
-depends=('python' 'python-pycryptodome' 'python-sectools' 'python-xlsxwriter')
+depends=('python' 'python-pycryptodome' 'python-sectools>=1.5.0' 'python-xlsxwriter')
 makedepends=('git')
 source=("$pkgname::git+$url.git")
 sha512sums=('SKIP')

--- a/packages/python-sectools/PKGBUILD
+++ b/packages/python-sectools/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=python-sectools
 _pkgname=${pkgname#python-}
-pkgver=1.4.4
+pkgver=1.5.0
 pkgrel=1
 pkgdesc='Offensive security python toolbox.'
 arch=('any')
@@ -13,7 +13,7 @@ depends=('python' 'python-ldap3')
 makedepends=('python-setuptools')
 options=(!emptydirs)
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('81af60152f8eefd55bcd8b779747f3f364f35dd24aaf8ffa060ac99f068a776cb5f2a7a1ce0c0a9bd02d5dcb4810dff274dd302661cd9c5a6f491ea50b0c053f')
+sha512sums=('b7cfafa1ab42fa23180454ac61c5e5e328036024ebaf01c1c3674ed243e0a862b576be2d0de045f5f46dc17fa087d733ec1c04f9d0e20ac0d508208adc27567f')
 
 build() {
   cd "$_pkgname-$pkgver"


### PR DESCRIPTION
updating sectools to 1.5.0 fixes

- extractbitlockerkeys (see https://github.com/p0dalirius/ExtractBitlockerKeys/pull/11)
- ldapwordlistharvester (see https://github.com/p0dalirius/pyLDAPWordlistHarvester/pull/16)

but unfortunatelly, finduncommonshares will requires sectools 1.5.1 (see https://github.com/p0dalirius/pyFindUncommonShares/pull/36 and https://github.com/p0dalirius/sectools/issues/18)