### PR TITLE
travis: update builder image

### DIFF
--- a/travis/Dockerfile
+++ b/travis/Dockerfile
@@ -1,13 +1,7 @@
-FROM archlinux
+FROM blackarchlinux/blackarch:base-devel
 
-# Setup mirrors
-RUN printf "[multilib]\nInclude = /etc/pacman.d/mirrorlist\n" \
-        >> "$path/etc/pacman.conf" && \
-    sed -i 's/^#Server/Server/' /etc/pacman.d/mirrorlist && \
-    curl -s https://blackarch.org/strap.sh | bash -
-
-# Setup build dependencies
-RUN pacman --noconfirm --noprogressbar --needed -Syyu base-devel
+# Update Systen
+RUN pacman --noconfirm --noprogressbar --needed -Syyu
 
 # Add builder User
 RUN useradd -m -d /src -G wheel -g users builder -s /bin/bash && \


### PR DESCRIPTION
Change the Base image to blackarch:base-devel. This should reduce the build time for containers during tests significantly, as neither blackarch repos, nor base-devel needs to be installed anymore.