### PR TITLE
Update angr to 9.2.182

### DIFF
--- a/packages/angr/PKGBUILD
+++ b/packages/angr/PKGBUILD
@@ -19,8 +19,8 @@ depends=('python' 'python-capstone' 'python-networkx' 'python-rpyc'
          'python-bintrees' 'python-dpkt' 'python-z3-solver' 'python-gitpython'
          'python-sortedcontainers' 'python-pycparser' 'python-ailment'
          'python-protobuf' 'python-itanium-demangler' 'python-cppheaderparser'
-         'python-sympy' 'python-nampa' 'rust')
-makedepends=('git' 'python-setuptools' 'python-pip' 'python-wheel')
+         'python-sympy' 'python-nampa')
+makedepends=('git' 'python-setuptools' 'python-setuptools-rust' 'rust' 'python-pip' 'python-wheel')
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz")
 sha512sums=('f86a28e3066860f4bbf4c33d42ff35abe66d7a1d6cb7b744282594a2f44afd2d5839e3162bff23f83a8e47065102a31138db260857f4eb4c783b2b8c888084d7')
 


### PR DESCRIPTION
Currently, the latest available angr version is 9.1.171, and it installs itself to python 3.12 site-packages, which is inaccessible from arch linux's python 3.13 version. This upgrade fixes the problem and updates the
package.