### PR TITLE
pyinstaller: update to 6.16.0 and update pyinstaller-hooks-contrib

### DIFF
--- a/packages/pyinstaller-hooks-contrib/PKGBUILD
+++ b/packages/pyinstaller-hooks-contrib/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=pyinstaller-hooks-contrib
 _pkgname=pyinstaller_hooks_contrib
-pkgver=2024.11
+pkgver=2025.9
 pkgrel=1
 pkgdesc='PyInstaller community hooks.'
 arch=('any')
@@ -13,7 +13,7 @@ license=('custom:mixed')
 depends=('python')
 makedepends=('python-build' 'python-pip')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('f0f6c5cfe92c17cb66b9eee0e7cd7b25749b9b555967b9cacfca90e99beb13e53a2c52cf8619271c5f15e587f993fd2d11765dce1c940f4cdefa1a23de20d72d')
+sha512sums=('ff9f9b5599b5cc1b82795553f95df470b3539ca4160618cf493fba87c2e3fc3c582e0cd6e3465ed85dc18be5be8b7e113cc9ea8636b9cb9792a288c0bf8d9bda')
 
 build() {
   cd "$_pkgname-$pkgver"

--- a/packages/pyinstaller/PKGBUILD
+++ b/packages/pyinstaller/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=pyinstaller
-pkgver=6.12.0
+pkgver=6.16.0
 pkgrel=1
 epoch=2
 groups=('blackarch' 'blackarch-misc')
@@ -11,7 +11,7 @@ arch=('x86_64' 'aarch64')
 url='https://pyinstaller.org'
 license=('Apache-2.0' 'GPL-2.0-or-later' 'MIT')
 depends=(
-  'python' 'python-setuptools' 'python-altgraph' # project python dependencies
+  'python' 'python-setuptools' 'python-altgraph' 'pyinstaller-hooks-contrib' # project python dependencies
   'glibc' 'binutils' 'gcc' 'base-devel' # project system dependencies
 )
 makedepends=(
@@ -20,7 +20,7 @@ makedepends=(
 )
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz"
         'fortify-source-fix.patch')
-sha512sums=('ce929c8f573a12866a6a632bf9d3a3bee1992a3ed70dfd3b91f634d7751b72386e05fd32c366c35de2ac5a96ed0350f4b6ac1bc671675af27e703116fe24f19f'
+sha512sums=('2f75b1e2b729941fd07a35b0dbcd2445196cd09987e6b545b2a70358bb8f72aeca905bf9c50b5900b489509beb53541f954eeb4e25db20d5478063dde555040a'
             '765a2f0c984d966c27309194e73a50b325309c5e65253c92a7140d8b179f94394dd0e01aa1b46b3777a1a06da33ce92919070dd70fde87bf5d81eb750d73f5ed')
 options=('!strip' '!emptydirs')
 


### PR DESCRIPTION
Update:
- Versions:
pyinstaller 6.12.0 -> 6.16.0
pyinstaller-hooks-contrib 2024.11 -> 2025.9
- sha512sums
- PyInstaller Depends