### PR TITLE
android-sdk-build-tools: Fix PKGBUILD

### DIFF
--- a/packages/android-sdk-build-tools/PKGBUILD
+++ b/packages/android-sdk-build-tools/PKGBUILD
@@ -19,10 +19,10 @@ sha512sums=('effdb12758877bbceaa9efb638798cc7c018f3d9e48632a509445bbf5f684d28798
 options=('!strip')
 
 package() {
-  cd $pkgdir
+  cd "$pkgdir"
 
-  ver=$(cat "$srcdir/$_android/source.properties" |
-  grep ^Pkg.Revision=|sed 's/Pkg.Revision=\([0-9.]*\).*/\1/')
+  ver="$(cat "$srcdir/$_android/source.properties" |
+  grep ^Pkg.Revision=|sed 's/Pkg.Revision=\([0-9.]*\).*/\1/')"
 
   install -dm 755 "opt/$_sdk/build-tools/$ver"
   install -dm 755 "usr/bin"
@@ -34,8 +34,7 @@ package() {
   binaries=("aapt" "aapt2" "aidl" "apksigner" "bcc_compat" "d8" "dexdump" "dx" \
     "llvm-rs-cc" "mainDexClasses" "split-select" "zipalign")
 
-  for f in "${binaries[@]}"
-  do
+  for f in "${binaries[@]}"; do
     ln -s "/opt/$_sdk/build-tools/$ver/$f" "usr/bin/$f"
   done
 }


### PR DESCRIPTION
- Fix android version to avoid errors in package(): 11 -> 12:
Error with 11:
==> Entering fakeroot environment...
==> Starting package()...
cat: /src/src/android-11/source.properties: No such file or directory
install: cannot stat '/src/src/android-11/NOTICE.txt': No such file or directory
==> ERROR: A failure occurred in package().
    Aborting...

- Adding conflict with dioxus-cli:
Steps to reproduce:

$ sudo pacman -S android-sdk-build-tools
and
$ sudo pacman -S dioxus-cli

output:
Packages (1) dioxus-cli-0.7.1-1

Total Installed Size: 76.50 MiB

:: Proceed with installation? [Y/n] y
(1/1) checking keys in keyring [#############] 100%
(1/1) checking package integrity [#############] 100%
(1/1) loading package files [#############] 100%
(1/1) checking for file conflicts [#############] 100%
error: failed to commit transaction (conflicting files)
dioxus-cli: /usr/bin/dx exists in filesystem (owned by android-sdk-build-tools)
Errors occurred, no packages were upgraded.