### PR TITLE
to-release; pyinstaller and pyinstaller-hooks-contrib: Update PKGBUILDs

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,2 @@
+pyinstaller
+pyinstaller-hooks-contrib

--- a/packages/pyinstaller-hooks-contrib/PKGBUILD
+++ b/packages/pyinstaller-hooks-contrib/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=pyinstaller-hooks-contrib
 _pkgname=pyinstaller_hooks_contrib
-pkgver=2025.9
+pkgver=2025.10
 pkgrel=1
 pkgdesc='PyInstaller community hooks.'
 arch=('any')
@@ -13,7 +13,7 @@ license=('custom:mixed')
 depends=('python')
 makedepends=('python-build' 'python-pip')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('ff9f9b5599b5cc1b82795553f95df470b3539ca4160618cf493fba87c2e3fc3c582e0cd6e3465ed85dc18be5be8b7e113cc9ea8636b9cb9792a288c0bf8d9bda')
+sha512sums=('7c1a329246887ec27109f70e270a74853361b5b0f4fcf273e33a28668cdf9cec0a077d9684d60bbb0bc0d9f2fb885e756ed6826d36072e3004576d44cea1f9de')
 
 build() {
   cd "$_pkgname-$pkgver"

--- a/packages/pyinstaller/PKGBUILD
+++ b/packages/pyinstaller/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=pyinstaller
-pkgver=6.16.0
+pkgver=6.17.0
 pkgrel=1
 epoch=2
 groups=('blackarch' 'blackarch-misc')
@@ -20,7 +20,7 @@ makedepends=(
 )
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz"
         'fortify-source-fix.patch')
-sha512sums=('2f75b1e2b729941fd07a35b0dbcd2445196cd09987e6b545b2a70358bb8f72aeca905bf9c50b5900b489509beb53541f954eeb4e25db20d5478063dde555040a'
+sha512sums=('e186827ebf261c02dddd590d073b8eca310fb62069dc3e5bdde7618b8247114fded3e88831a577a964c482d9122d13f1097c4147978b9c05c388b77920b67a2f'
             '765a2f0c984d966c27309194e73a50b325309c5e65253c92a7140d8b179f94394dd0e01aa1b46b3777a1a06da33ce92919070dd70fde87bf5d81eb750d73f5ed')
 options=('!strip' '!emptydirs')
 


### PR DESCRIPTION
Update
- pyinstaller: 6.16 -> 6.17
- pyinstaller-hooks-contrib: 2025.9 -> 2025.10
- sha512sums
- to-release