### PR TITLE
nuclei: remove forced -config flag.

### DIFF
--- a/packages/nuclei/PKGBUILD
+++ b/packages/nuclei/PKGBUILD
@@ -53,7 +53,7 @@ package() {
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
-exec /usr/share/$pkgname/$pkgname -config /usr/share/$pkgname/config.yaml "\$@"
+exec /usr/share/$pkgname/$pkgname "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"


### PR DESCRIPTION
A small fix to prevent nuclei using the default config file in /usr/share/nuclei/config.yaml.
Cheers!