### PR TITLE
goofile: to remove due to Google CAPTCHA

### DIFF
--- a/lists/to-remove
+++ b/lists/to-remove
@@ -1,0 +1,1 @@
+goofile


### PR DESCRIPTION
goofile cannot work anymore since Google now uses CAPTCHA control on this kind of requests. I would suggest to drop the package since unusable. An alternative could be to use Google APIs but it is out of scope of the purpose of this old tool. Btw the purpose of this tool can be reached by crawling and fuzzing a website target.