### PR TITLE
passcracking: to remove

### DIFF
--- a/lists/to-remove
+++ b/lists/to-remove
@@ -1,1 +1,2 @@
 goofile
+passcracking


### PR DESCRIPTION
Source files not available anymore anywhere. archive.org shows the main GitHub repository but didn't archive the source files so it cannot be retrieved anymore.