### PR TITLE
complemento: to remove because toolset of old superseeded tools

### DIFF
--- a/lists/to-remove
+++ b/lists/to-remove
@@ -1,0 +1,1 @@
+complemento


### PR DESCRIPTION
I propose to remove complemento because:
* latest version very old (2011)
* set of tools (it is against BlackArch 1, 2, 3, 4, 7 [packaging rules](https://github.com/BlackArch/blackarch/issues/2842))
* Python2 like the hell
* ReverseRaider can be replaced by any modern fuzzer like `ffuf` or `wfuzz`
* LetDown is just a simple tcp flooder (breaking BlackArch rule -> no DoS tools)
* Httsquash is an old is an old http server scanner, banner grabber and data retriever tool, with partial features (and never completed) fingerprinting functionalities.