### PR TITLE
haskell-openafp related packages to remove

### DIFF
--- a/lists/to-remove
+++ b/lists/to-remove
@@ -1,0 +1,3 @@
+haskell-line2pdf
+haskell-openafp
+haskell-openafp-utils


### PR DESCRIPTION
I propose to remove

haskell-line2pdf
haskell-openafp
haskell-openafp-utils

because they are old (2008-2010), abandoned and, mostly, not strictly related to pentesting.

They are not dependencies of current pentesting tools in BlackArch repo.