### PR TITLE
garminusb2nmea to remove because generally no more applicable

### DIFF
--- a/lists/to-remove
+++ b/lists/to-remove
@@ -1,0 +1,1 @@
+garminusb2nmea


### PR DESCRIPTION
I propose to remove this package because modern Garmin devices no need anymore a converter. When NMEA is enabled on them, their output is already in NMEA.

This tool was useful on very old Garmin devices that didn't output NMEA by default but only binary data by the old Garmin Proprietary Binary Protocol, so, a converter to NMEA was needed. Nowadays, since modern Garmin devices output directly as NMEA, there is no sense to keep this package.