### PR TITLE
jondobrowser and jondoconsole to remove

### DIFF
--- a/lists/to-remove
+++ b/lists/to-remove
@@ -1,0 +1,2 @@
+jondobrowser
+jondoconsole


### PR DESCRIPTION
I propose to remove

jondobrowser
jondoconsole

because old and not maintained anymore and break the 6th rule of [BlackArch packaging rules](https://github.com/BlackArch/blackarch/issues/2842).

They are not dependencies of other tools in BlackArch repository.