### PR TITLE
libdnet-ipv6 to remove because upstream supports ipv6

### DIFF
--- a/lists/to-remove
+++ b/lists/to-remove
@@ -1,0 +1,1 @@
+libdnet-ipv6


### PR DESCRIPTION
libnet official package seems to already support IPv6 since v1.16 -> https://github.com/ofalk/libdnet/releases/tag/libdnet-1.16

so, this package has no more sense to be in BlackArch repository. It is not a dependency of other BlackArch packages.