### PR TITLE
creepy and python2-osmgpsmap to remove

### DIFF
--- a/lists/to-remove
+++ b/lists/to-remove
@@ -1,2 +1,4 @@
 creepy
 python2-osmgpsmap
+python2-flickrapi
+python2-yapsy


### PR DESCRIPTION
`python2-osmgpsmap` is to remove because the original project marked python bindings as deprecated years ago and it depends on `osm-gps-map` package that does not offer anymore some deprecated functions used by this Python bindings.

This package is a dependency of `creepy` but it is an abandoned (Python2-based) project since 2016. Furthermore, creepy does not work anymore because it uses online resources deprecated APIs that are not exposed anymore, for example the Instagram API used by creepy have been dismissed by Meta on 2020, so the tool cannot work anymore.

Removed also Python2 dependencies used only for creepy.