### PR TITLE
pyinstaller-hooks-contrib: update PKGBUILD and to-release

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+pyinstaller-hooks-contrib

--- a/packages/pyinstaller-hooks-contrib/PKGBUILD
+++ b/packages/pyinstaller-hooks-contrib/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=pyinstaller-hooks-contrib
 _pkgname=pyinstaller_hooks_contrib
-pkgver=2025.10
+pkgver=2025.11
 pkgrel=1
 pkgdesc='PyInstaller community hooks.'
 arch=('any')
@@ -13,7 +13,7 @@ license=('custom:mixed')
 depends=('python')
 makedepends=('python-build' 'python-pip')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('7c1a329246887ec27109f70e270a74853361b5b0f4fcf273e33a28668cdf9cec0a077d9684d60bbb0bc0d9f2fb885e756ed6826d36072e3004576d44cea1f9de')
+sha512sums=('a24859b85616b10ab48a06aca96424f329c9ab90983d9cd4d0ac9e08aabe13921530a2a571afc31c8d2ec76571d9c81bf461a7122e4694019721ab239aeb3dae')
 
 build() {
   cd "$_pkgname-$pkgver"


### PR DESCRIPTION
https://github.com/pyinstaller/pyinstaller-hooks-contrib/releases/tag/v2025.11

Update: pkgver and sha512sums