### PR TITLE
Add evil-winrm-py

### DIFF
--- a/packages/evil-winrm-py/PKGBUILD
+++ b/packages/evil-winrm-py/PKGBUILD
@@ -28,3 +28,4 @@ package() {
     install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
   fi
 }
+


### PR DESCRIPTION
This PR adds **evil-winrm-py**, a Python implementation of a WinRM shell for Windows and Active Directory pentesting.

- Upstream: https://github.com/adityatelange/evil-winrm-py
- Installs the following binaries:
  - evil-winrm-py
  - ewp
- Grouped under `blackarch` and `blackarch-windows`
- Built and tested locally with `makepkg`

Let me know if any adjustments are needed.
