### PR TITLE
New package: pypy3-flit-core

### DIFF
--- a/packages/pypy3-flit-core/PKGBUILD
+++ b/packages/pypy3-flit-core/PKGBUILD
@@ -1,0 +1,23 @@
+#  
+_base=flit_core
+pkgname=pypy3-${_base//_/-}
+pkgver=3.12.0
+pkgrel=1
+pkgdesc="A PEP 517 build backend for packages using Flit"
+arch=(any)
+url="https://github.com/pypa/${_base::4}/tree/main/${_base}"
+license=(BSD-3-Clause)
+depends=(pypy3)
+source=(${_base::4}-${pkgver}.tar.gz::https://github.com/pypa/${_base::4}/archive/${pkgver}.tar.gz)
+sha512sums=('ff6df66dfdae6fdf7b277cc3fbb7c9a569103cbe82a3e3ce6f315ec6adec46be8692eba4549a66b3af537d128e6b57ed8f49316b705636466c25674198503643')
+
+build() {
+  cd ${_base::4}-${pkgver}/${_base}
+  pypy3 -m flit_core.wheel
+}
+
+package() {
+  cd ${_base::4}-${pkgver}/${_base}
+  pypy3 bootstrap_install.py --installdir "$pkgdir"/opt/pypy3/lib/pypy3.11/site-packages dist/${_base}-*.whl
+  install -Dm 644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}"
+}


### PR DESCRIPTION
This PR, which should be followed by a series of other PRs, has the goal of adding a pypy-angr package which allows for running angr under pypy. according to the angr docs,using pypy allows for 10x performance improvement (see the [docs](https://docs.angr.io/en/latest/advanced-topics/speed.html) ) .pypy3-flit-core will allow the addition of the pypy build system, which should be followed with angr's dependencies, and finally angr itself