### PR TITLE
Angr fix

### DIFF
--- a/packages/angr/PKGBUILD
+++ b/packages/angr/PKGBUILD
@@ -13,7 +13,7 @@ url='https://pypi.org/project/angr/#files'
 license=('BSD-2-Clause')
 depends=('python' 'python-capstone' 'python-networkx' 'python-rpyc'
          'python-progressbar' 'python-mulpyplexer' 'python-unicorn'
-         'python-cooldict' 'python-archinfo' 'python-pyvex' 'python-ana' 
+         'python-cooldict' 'python-archinfo' 'python-pyvex' 'python-ana'
          'python-claripy' 'python-simuvex' 'python-cle' 'libffi' 'python-colorama'
          'python-cachetools' 'python-pyelftools' 'python-cffi' 'python-psutil'
          'python-bintrees' 'python-dpkt' 'python-z3-solver' 'python-gitpython'

--- a/packages/python-lmdb/PKGBUILD
+++ b/packages/python-lmdb/PKGBUILD
@@ -10,8 +10,8 @@ arch=('any')
 url='https://github.com/jnwatson/py-lmdb/'
 license=('OLDAP-2.8')
 depends=('python')
-makedepends=('python-setuptools' 'python-wheel' 'python-cffi' 'python-patch-ng')
-source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz") 
+makedepends=('python-setuptools' 'python-wheel' 'python-cffi')
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
 sha512sums=('2813f556a9499bb7555f0119ddaf139d033c5f58f427a983d61cb3d3b1a8f2978cfcc9e8424e81af5476aac00e1e498ff33aabdcaecd5a6d1dafebd604c56bc3')
 
 build() {

--- a/packages/python-pyformlang/PKGBUILD
+++ b/packages/python-pyformlang/PKGBUILD
@@ -13,18 +13,19 @@ source=(https://files.pythonhosted.org/packages/source/${_pyname::1}/$_pyname/$_
 b2sums=('1d45e1c700a46be39c95043c8a21fc6808d27d230cee83a35079acd39c13f12fd3290bab6d9f2244aab9ac856a906f0b523c992416d8bb94872e5c04134c2fdd')
 
 check() {
-    cd $srcdir/$_pyname-$pkgver
+    cd "$srcdir/$_pyname-$pkgver"
     PYTHONPATH=./build/lib/ pytest
 }
 
 build() {
-    cd $srcdir/$_pyname-$pkgver
+    cd "$srcdir/$_pyname-$pkgver"
     python -m build --wheel --no-isolation
 }
 
 package() {
-    cd $srcdir/$_pyname-$pkgver
+    cd "$srcdir/$_pyname-$pkgver"
     python -m installer --destdir="$pkgdir" dist/*.whl
 
     install -Dm644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}"
-}    
+}
+


### PR DESCRIPTION
After the update to angr, it turns out that newer versions of angr have new  runtime dependencies. This PR adds the newly needed dependencies.