### PR TITLE
unicornscan: update to 0.4.42

### DIFF
--- a/packages/unicornscan/PKGBUILD
+++ b/packages/unicornscan/PKGBUILD
@@ -2,44 +2,50 @@
 # See COPYING for license details.
 
 pkgname=unicornscan
-pkgver=v0.4.10.r5.gf110f0d
-pkgrel=2
+pkgver=0.4.42
+pkgrel=1
 epoch=1
-pkgdesc='Asynchronous, stateless tool for scalable, high-speed network reconnaissance and security auditing.'
+pkgdesc='Asynchronous, stateless TCP/UDP scanner for scalable, high-speed network reconnaissance. Includes Alicorn web UI for result visualization.'
 arch=('x86_64' 'aarch64')
-groups=('blackarch' 'blackarch-scanner')
+groups=('blackarch' 'blackarch-scanner' 'blackarch-recon')
 url='https://github.com/robertelee78/unicornscan'
 license=('GPL-2.0-or-later')
-depends=('libpcap' 'postgresql-libs' 'libdnet' 'libltdl' 'libmaxminddb')
-makedepends=('git' 'flex' 'bison')
-source=("git+https://github.com/robertelee78/$pkgname.git")
+depends=('libpcap' 'postgresql-libs' 'libdnet' 'libltdl' 'libmaxminddb' 'libcap')
+makedepends=('git' 'flex' 'bison' 'autoconf' 'automake' 'libtool' 'postgresql')
+optdepends=('docker: Alicorn web UI container runtime'
+            'docker-compose: Alicorn web UI orchestration'
+            'geoip-database: IP geolocation lookups'
+            'geoip-database-extra: Extended IP geolocation data')
+source=("git+https://github.com/robertelee78/$pkgname.git#tag=v$pkgver")
 sha512sums=('SKIP')
-
-pkgver() {
-  cd $pkgname
-
-  ( set -o pipefail
-    git describe --long --tags --abbrev=7 2>/dev/null |
-      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
-    printf "%s.%s" "$(git rev-list --count HEAD)" \
-      "$(git rev-parse --short=7 HEAD)"
-  )
-}
+install=unicornscan.install
 
 prepare() {
   cd $pkgname
 
-  if [[ "$CARCH" == "i686" || "$CARCH" == "x86_64" ]]; then
-    ./configure CFLAGS="$CFLAGS -D_GNU_SOURCE" --prefix=/usr \
-      --sysconfdir=/etc --localstatedir=/var --with-pgsql
-  else
-    ./configure CFLAGS="$CFLAGS -D_GNU_SOURCE" --prefix=/usr \
-      --sysconfdir=/etc --localstatedir=/var --with-pgsql --build=arm
-  fi
+  # Generate build system from autotools
+  autoreconf -fi
 }
 
 build() {
   cd $pkgname
+
+  # Configure with PostgreSQL support
+  # -Wno-error required for legacy C code with modern GCC
+  if [[ "$CARCH" == "aarch64" ]]; then
+    ./configure CFLAGS="$CFLAGS -D_GNU_SOURCE -Wno-error" \
+      --prefix=/usr \
+      --sysconfdir=/etc \
+      --localstatedir=/var \
+      --with-pgsql \
+      --build=aarch64-unknown-linux-gnu
+  else
+    ./configure CFLAGS="$CFLAGS -D_GNU_SOURCE -Wno-error" \
+      --prefix=/usr \
+      --sysconfdir=/etc \
+      --localstatedir=/var \
+      --with-pgsql
+  fi
 
   make
 }
@@ -48,5 +54,70 @@ package() {
   cd $pkgname
 
   make DESTDIR="$pkgdir" install
-}
 
+  # Create runtime directory
+  install -dm755 "$pkgdir/var/unicornscan"
+
+  # =========================================================================
+  # Install Alicorn Web UI
+  # =========================================================================
+  install -dm755 "$pkgdir/opt/unicornscan-web"
+  install -dm755 "$pkgdir/opt/unicornscan-web/src"
+  install -dm755 "$pkgdir/opt/unicornscan-web/public"
+  install -dm755 "$pkgdir/opt/unicornscan-web/cli"
+  install -dm755 "$pkgdir/opt/unicornscan-web/sql"
+  install -dm755 "$pkgdir/opt/unicornscan-web/geoip-api"
+  install -dm755 "$pkgdir/opt/unicornscan-web/postgrest"
+
+  # Docker configuration
+  install -Dm644 alicorn/docker-compose.standalone.yml "$pkgdir/opt/unicornscan-web/docker-compose.yml"
+  install -Dm644 alicorn/Dockerfile "$pkgdir/opt/unicornscan-web/Dockerfile"
+  install -Dm644 alicorn/nginx.conf "$pkgdir/opt/unicornscan-web/nginx.conf"
+
+  # PostgREST
+  install -Dm644 alicorn/postgrest/Dockerfile "$pkgdir/opt/unicornscan-web/postgrest/Dockerfile"
+
+  # Build configuration
+  install -Dm644 alicorn/package.json "$pkgdir/opt/unicornscan-web/package.json"
+  install -Dm644 alicorn/package-lock.json "$pkgdir/opt/unicornscan-web/package-lock.json"
+  install -Dm644 alicorn/vite.config.ts "$pkgdir/opt/unicornscan-web/vite.config.ts"
+  install -Dm644 alicorn/tsconfig.json "$pkgdir/opt/unicornscan-web/tsconfig.json"
+  install -Dm644 alicorn/tsconfig.app.json "$pkgdir/opt/unicornscan-web/tsconfig.app.json"
+  install -Dm644 alicorn/tsconfig.node.json "$pkgdir/opt/unicornscan-web/tsconfig.node.json"
+  install -Dm644 alicorn/index.html "$pkgdir/opt/unicornscan-web/index.html"
+
+  # Optional config files (may not exist in all versions)
+  [[ -f alicorn/eslint.config.js ]] && install -Dm644 alicorn/eslint.config.js "$pkgdir/opt/unicornscan-web/eslint.config.js"
+  [[ -f alicorn/vitest.config.ts ]] && install -Dm644 alicorn/vitest.config.ts "$pkgdir/opt/unicornscan-web/vitest.config.ts"
+
+  # Source code
+  cp -r alicorn/src/* "$pkgdir/opt/unicornscan-web/src/"
+  cp -r alicorn/public/* "$pkgdir/opt/unicornscan-web/public/"
+
+  # CLI / Setup wizard
+  install -Dm644 alicorn/cli/setup.ts "$pkgdir/opt/unicornscan-web/cli/setup.ts"
+
+  # GeoIP API service
+  install -Dm644 alicorn/geoip-api/Dockerfile "$pkgdir/opt/unicornscan-web/geoip-api/Dockerfile"
+  install -Dm644 alicorn/geoip-api/package.json "$pkgdir/opt/unicornscan-web/geoip-api/package.json"
+  install -Dm644 alicorn/geoip-api/server.js "$pkgdir/opt/unicornscan-web/geoip-api/server.js"
+
+  # SQL schema
+  install -Dm644 src/output_modules/database/sql/pgsql_schema.sql "$pkgdir/opt/unicornscan-web/sql/pgsql_schema.sql"
+
+  # =========================================================================
+  # Install management scripts
+  # =========================================================================
+  install -Dm755 debian/unicornscan-web "$pkgdir/usr/bin/unicornscan-web"
+  install -Dm755 scripts/unicornscan-geoip-update "$pkgdir/usr/bin/unicornscan-geoip-update"
+
+  # =========================================================================
+  # Documentation
+  # =========================================================================
+  install -Dm644 README "$pkgdir/usr/share/doc/$pkgname/README"
+  install -Dm644 docs/MANUAL.txt "$pkgdir/usr/share/doc/$pkgname/MANUAL.txt" 2>/dev/null || true
+  install -Dm644 HISTORY.md "$pkgdir/usr/share/doc/$pkgname/HISTORY.md" 2>/dev/null || true
+
+  # License
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packages/unicornscan/unicornscan.install
+++ b/packages/unicornscan/unicornscan.install
@@ -1,0 +1,75 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# Post-install script for unicornscan
+
+post_install() {
+  # Create unicornscan group for shared config access
+  if ! getent group unicornscan >/dev/null 2>&1; then
+    groupadd -r unicornscan 2>/dev/null || true
+  fi
+
+  # Set modules.conf ownership for group access
+  if [[ -f /etc/unicornscan/modules.conf ]]; then
+    chown root:unicornscan /etc/unicornscan/modules.conf 2>/dev/null || true
+    chmod 660 /etc/unicornscan/modules.conf 2>/dev/null || true
+  fi
+
+  # Set Linux capabilities to allow running without root
+  # Fails gracefully if not supported (containers, SELinux, etc.)
+  setcap 'cap_net_raw,cap_net_admin,cap_sys_chroot,cap_setuid,cap_setgid+ep' \
+    /usr/bin/unicornscan 2>/dev/null || true
+  setcap 'cap_net_raw,cap_net_admin,cap_sys_chroot,cap_setuid,cap_setgid+ep' \
+    /usr/bin/fantaip 2>/dev/null || true
+  setcap 'cap_net_raw,cap_net_admin,cap_sys_chroot,cap_setuid,cap_setgid+ep' \
+    /usr/libexec/unicornscan/unilisten 2>/dev/null || true
+  setcap 'cap_net_raw,cap_net_admin,cap_sys_chroot,cap_setuid,cap_setgid+ep' \
+    /usr/libexec/unicornscan/unisend 2>/dev/null || true
+
+  cat <<EOF
+
+╔════════════════════════════════════════════════════════════════╗
+║              Unicornscan installed successfully!               ║
+╠════════════════════════════════════════════════════════════════╣
+║                                                                ║
+║  QUICK START:                                                  ║
+║    unicornscan -mT 192.168.1.0/24:1-1000    # TCP SYN scan     ║
+║    unicornscan -mU 192.168.1.1:53,161       # UDP scan         ║
+║    unicornscan -mA 192.168.1.0/24           # ARP discovery    ║
+║                                                                ║
+║  ALICORN WEB UI (requires Docker):                             ║
+║    unicornscan-web start                    # Start services   ║
+║    http://localhost:31337                   # Open browser     ║
+║                                                                ║
+║  GEOIP (recommended):                                          ║
+║    sudo unicornscan-geoip-update            # Download DBs     ║
+║                                                                ║
+║  Add yourself to unicornscan group for config access:          ║
+║    sudo usermod -aG unicornscan \$USER && newgrp unicornscan    ║
+║                                                                ║
+╚════════════════════════════════════════════════════════════════╝
+
+EOF
+}
+
+post_upgrade() {
+  post_install
+}
+
+pre_remove() {
+  # Stop web UI if running
+  if command -v unicornscan-web >/dev/null 2>&1; then
+    unicornscan-web stop 2>/dev/null || true
+  fi
+}
+
+post_remove() {
+  # Remove capabilities (not strictly necessary but clean)
+  if command -v setcap >/dev/null 2>&1; then
+    setcap -r /usr/bin/unicornscan 2>/dev/null || true
+    setcap -r /usr/bin/fantaip 2>/dev/null || true
+    setcap -r /usr/libexec/unicornscan/unilisten 2>/dev/null || true
+    setcap -r /usr/libexec/unicornscan/unisend 2>/dev/null || true
+  fi
+
+  echo "Unicornscan removed. Config files in /etc/unicornscan/ preserved."
+  echo "To remove completely: rm -rf /etc/unicornscan /opt/unicornscan-web"
+}


### PR DESCRIPTION
## Summary

Major update to unicornscan from v0.4.10 to v0.4.42 (32 version jump).

## Changes

### New Features in 0.4.42
- **Alicorn Web UI** - React-based interface for visualizing scan results
- **Compound scan modes** (-mA+T, -mA+U) for ARP-filtered scanning
- **MAC address capture** for local network targets
- **ASN/CIDR grouping** in topology view
- **Multi-scan comparison** with diff exports
- **GeoIP API service** for live IP lookups
- **PostgreSQL cloud support** via PostgREST

### PKGBUILD Improvements
- Added `autoreconf -fi` in prepare() - fixes build from git source
- Added Alicorn Web UI installation to /opt/unicornscan-web/
- Added management scripts: `unicornscan-web`, `unicornscan-geoip-update`
- Added install script with setcap for non-root operation
- Added aarch64 architecture support
- Added makedepends: autoconf, automake, libtool, postgresql
- Added optdepends: docker, docker-compose, geoip-database
- Added blackarch-recon group

### Files Changed
- `packages/unicornscan/PKGBUILD` - Complete rewrite
- `packages/unicornscan/unicornscan.install` - New file

## Testing

- [x] Builds successfully with makepkg -s
- [x] Passes namcap validation
- [x] Installs correctly
- [x] Capabilities set properly (non-root scanning works)
- [x] unicornscan-web starts Docker containers
- [x] Scans work: TCP SYN, UDP, ARP modes

## Upstream

- Repository: https://github.com/robertelee78/unicornscan
- Release: https://github.com/robertelee78/unicornscan/releases/tag/v0.4.42

## Checklist

- [x] pkgcheck passed
- [x] Follows BlackArch PKGBUILD style
- [x] Two-space indentation
- [x] Proper groups assigned
- [x] License file installed