### PR TITLE
to-remove: pyside2 and binaryninja-python due to deprecation

### DIFF
--- a/lists/to-remove
+++ b/lists/to-remove
@@ -1,0 +1,2 @@
+pyside2
+binaryninja-python


### PR DESCRIPTION
`pyside2` should be removed because super-deprecated. In BA repo it's used only by `binaryninja-python` but this one is archived since 2020, Python2-based and deprecated as well, and it was a "prototype" of the original `binaryninja`.