### PR TITLE
Update pyinstaller-hooks-contrib, python-wireless and python-pysqlite3

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,3 @@
+pyinstaller-hooks-contrib
+python-wireless
+python-pysqlite3

--- a/packages/pyinstaller-hooks-contrib/PKGBUILD
+++ b/packages/pyinstaller-hooks-contrib/PKGBUILD
@@ -3,8 +3,8 @@
 
 pkgname=pyinstaller-hooks-contrib
 _pkgname=pyinstaller_hooks_contrib
-pkgver=2025.11
-pkgrel=3
+pkgver=2026.0
+pkgrel=1
 pkgdesc='PyInstaller community hooks.'
 arch=('any')
 groups=('blackarch' 'blackarch-misc')
@@ -13,7 +13,7 @@ license=('custom:mixed')
 depends=('python')
 makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('a24859b85616b10ab48a06aca96424f329c9ab90983d9cd4d0ac9e08aabe13921530a2a571afc31c8d2ec76571d9c81bf461a7122e4694019721ab239aeb3dae')
+sha512sums=('c14a1f077e7ffca059a19aee86193d0854245773a5fae39f27b07e19a8775ce2b86a75e0bc9ab16f7d7210532fd9ea21b7a617c902915f41457764c287fe2e8d')
 
 build() {
   cd "$_pkgname-$pkgver"

--- a/packages/python-pysqlite3/PKGBUILD
+++ b/packages/python-pysqlite3/PKGBUILD
@@ -4,36 +4,25 @@
 pkgname=python-pysqlite3
 _pkgname=pysqlite3
 pkgver=0.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc='DB-API 2.0 interface for Sqlite 3.x.'
 arch=('x86_64' 'aarch64')
 url='https://pypi.org/project/pysqlite3/#files'
 license=('zlib/libpng')
 depends=('python' 'sqlite')
-makedepends=('python-pip' 'python-build')
+makedepends=('python-installer' 'python-setuptools' 'python-build' 'python-wheel')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
 sha512sums=('657bef4ac182a35b2114058a519461602975fc64781802871a15832a6df809896fffd64eadc7f20d69dd24ea548472fae5a3cd5e213cf95dbb05a3827ed582cb')
 
 build() {
   cd "$_pkgname-$pkgver"
 
-  python -m build --wheel --outdir="$startdir/dist"
+  python -m build --wheel --no-isolation
 }
 
 package() {
   cd "$_pkgname-$pkgver"
 
-  pip install \
-    --verbose \
-    --disable-pip-version-check \
-    --no-warn-script-location \
-    --ignore-installed \
-    --no-compile \
-    --no-deps \
-    --root="$pkgdir" \
-    --prefix=/usr \
-    --no-index \
-    --find-links="file://$startdir/dist" \
-    $_pkgname
+  python -m installer --destdir="pkgdir" dist/*.whl
 }
 

--- a/packages/python-wireless/PKGBUILD
+++ b/packages/python-wireless/PKGBUILD
@@ -4,36 +4,25 @@
 pkgname=python-wireless
 _pkgname=wireless
 pkgver=0.3.3
-pkgrel=9
+pkgrel=10
 pkgdesc='A dead simple, cross-platform Python library to connect to wireless networks.'
 url='https://pypi.org/project/wireless/#files'
 arch=('any')
 license=('Apache')
 depends=('python')
-makedepends=('python-pip' 'python-build' 'python-wheel')
+makedepends=('python-installer' 'python-build' 'python-wheel' 'python-setuptools')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/wireless-0.3.3.tar.gz")
 sha512sums=('e5f89052dd7f649e92fd2a3ec2657bfc8f891310570572b23eb9fb8e83358f9ea48fdc249e5dc1031393dbb3c37689fa71b186e5097da558525e2526437f742a')
 
 build() {
   cd "$_pkgname-$pkgver"
 
-  python -m build --wheel --outdir="$startdir/dist"
+  python -m build --wheel --no-isolation
 }
 
 package() {
   cd "$_pkgname-$pkgver"
 
-  pip install \
-    --verbose \
-    --disable-pip-version-check \
-    --no-warn-script-location \
-    --ignore-installed \
-    --no-compile \
-    --no-deps \
-    --root="$pkgdir" \
-    --prefix=/usr \
-    --no-index \
-    --find-links="file://$startdir/dist" \
-    $_pkgname
+  python -m installer --destdir="$pkgdir" dist/*.whl
 }
 


### PR DESCRIPTION
pyinstaller-hooks-contrib: update version to 2026.0; https://github.com/pyinstaller/pyinstaller-hooks-contrib/releases/tag/v2026.0

python-wireless and python-pysqlite3: Migrating from python-pip to python-installer; #4800 