### PR TITLE
onionsearch: fix package.

### DIFF
--- a/packages/onionsearch/PKGBUILD
+++ b/packages/onionsearch/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=onionsearch
 pkgver=44.fc9d62c
-pkgrel=1
+pkgrel=5
 pkgdesc='Script that scrapes urls on different .onion search engines.'
 groups=('blackarch' 'blackarch-webapp' 'blackarch-scanner')
 arch=('any')


### PR DESCRIPTION
Fixed the onionsearch package that wasn't working and was missing deps.

I used a mix of the PKGBUILD-python-standalone and the PKGBUILD-python-PEP517-setuptools templates:

- It fetches the version from the git
- Installs the README at the proper location
- Uses the python libs from the repo so it's not cluttering with a venv

Cheers!

EDIT: typo