### PR TITLE
airgeddon: add sox as optdep

### DIFF
--- a/packages/airgeddon/PKGBUILD
+++ b/packages/airgeddon/PKGBUILD
@@ -17,7 +17,7 @@ optdepends=('hashcat' 'crunch' 'mdk4' 'reaver' 'beef' 'hostapd' 'lighttpd'
             'pixiewps' 'dhcp' 'curl' 'ethtool' 'rfkill' 'wget' 'usbutils'
             'xorg-xdpyinfo' 'ccze' 'xorg-xset' 'asleap' 'john' 'hostapd-wpe'
             'nftables' 'openssl' 'mdk3' 'hcxtools' 'hcxdumptool' 'wireshark-cli'
-            'systemd' 'tcpdump' 'arping' 'hostapd-mana')
+            'systemd' 'tcpdump' 'arping' 'hostapd-mana' 'sox')
 makedepends=('git' 'coreutils')
 source=("git+https://github.com/v1s1t0r1sh3r3/$pkgname.git")
 sha512sums=('SKIP')


### PR DESCRIPTION
Sox dependency was added in v11.61 (https://github.com/v1s1t0r1sh3r3/airgeddon/releases/tag/v11.61) to add beep sounds to Evil Twin attacks to alert about different events. It is required for the "play" command.

Refs.
https://github.com/v1s1t0r1sh3r3/airgeddon/blob/d7e24237acd32b8d38e28e0d9e93001dfee44131/Dockerfile#L60 https://github.com/v1s1t0r1sh3r3/airgeddon/blob/d7e24237acd32b8d38e28e0d9e93001dfee44131/plugins/missing_dependencies.sh#L79