### PR TITLE
add promptfoo (LLM security testing and AI red teaming tool)

### DIFF
--- a/packages/promptfoo/PKGBUILD
+++ b/packages/promptfoo/PKGBUILD
@@ -5,45 +5,46 @@
 pkgname=promptfoo
 pkgver=0.120.20
 pkgrel=1
-pkgdesc="Test and evaluate LLM outputs - AI red teaming, pentesting, and vulnerability scanning"
+pkgdesc='Test and evaluate LLM outputs - AI red teaming, pentesting, and vulnerability scanning'
 arch=('x86_64' 'aarch64')
 groups=('blackarch' 'blackarch-ai')
-url="https://github.com/promptfoo/promptfoo"
+url='https://github.com/promptfoo/promptfoo'
 license=('MIT')
 depends=('nodejs' 'sqlite')
 options=('!strip')
 makedepends=('npm' 'jq' 'python' 'make' 'gcc')
 optdepends=(
-    'python: for Python providers'
-    'ollama: for local Ollama models'
+  'python: for Python providers'
+  'ollama: for local Ollama models'
 )
 source=("https://registry.npmjs.org/${pkgname}/-/${pkgname}-${pkgver}.tgz")
 noextract=("${pkgname}-${pkgver}.tgz")
 sha256sums=('d89a9d28c6d1bd0a90736ba71611a0650f8066ea84ad3c1352a4b82ce2524dd7')
 
 package() {
-    npm install -g --cache "${srcdir}/npm-cache" --prefix "${pkgdir}/usr" \
-        "${srcdir}/${pkgname}-${pkgver}.tgz"
+  npm install -g --cache "${srcdir}/npm-cache" --prefix "${pkgdir}/usr" \
+    "${srcdir}/${pkgname}-${pkgver}.tgz"
 
-    # Non-deterministic race in npm gives 777 permissions to random directories.
-    # See https://github.com/npm/cli/issues/1103 for details.
-    find "${pkgdir}/usr" -type d -exec chmod 755 {} +
+  # Non-deterministic race in npm gives 777 permissions to random directories.
+  # See https://github.com/npm/cli/issues/1103 for details.
+  find "${pkgdir}/usr" -type d -exec chmod 755 {} +
 
-    # npm gives ownership of ALL FILES to build user
-    # https://bugs.archlinux.org/task/63396
-    chown -R root:root "${pkgdir}"
+  # npm gives ownership of ALL FILES to build user
+  # https://bugs.archlinux.org/task/63396
+  chown -R root:root "${pkgdir}"
 
-    # Remove references to pkgdir
-    find "$pkgdir" -name package.json -print0 | xargs -r -0 sed -i '/_where/d'
+  # Remove references to pkgdir
+  find "$pkgdir" -name package.json -print0 | xargs -r -0 sed -i '/_where/d'
 
-    # Remove references to srcdir
-    local tmppackage="$(mktemp)"
-    local pkgjson="$pkgdir/usr/lib/node_modules/$pkgname/package.json"
-    jq '.|=with_entries(select(.key|test("_.+")|not))' "$pkgjson" > "$tmppackage"
-    mv "$tmppackage" "$pkgjson"
-    chmod 644 "$pkgjson"
+  # Remove references to srcdir
+  local tmppackage="$(mktemp)"
+  local pkgjson="$pkgdir/usr/lib/node_modules/$pkgname/package.json"
+  jq '.|=with_entries(select(.key|test("_.+")|not))' "$pkgjson" > "$tmppackage"
+  mv "$tmppackage" "$pkgjson"
+  chmod 644 "$pkgjson"
 
-    # Install license
-    install -Dm644 "${pkgdir}/usr/lib/node_modules/${pkgname}/LICENSE" \
-        "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  # Install license
+  install -Dm644 "${pkgdir}/usr/lib/node_modules/${pkgname}/LICENSE" \
+    "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }
+


### PR DESCRIPTION
This PR adds `promptfoo`, an open-source framework for testing and evaluating
Large Language Model (LLM) outputs.

Key points:
- License: MIT
- Built from upstream source (npm registry)
- Native dependency `better-sqlite3` is compiled during build (required for functionality)
- Tested on BlackArch Linux (x86_64)
- No prebuilt binaries are used

Use cases:
- Prompt injection and jailbreak testing
- LLM output evaluation
- AI red teaming and model security assessment

Notes:
- The `--ignore-scripts` flag is intentionally not used, as it breaks required
  native bindings.
- The package is currently placed in the generic `blackarch` ,  `blackarch-ai` groups.


<img width="1614" height="882" alt="image" src="https://github.com/user-attachments/assets/a9bed3aa-6959-4731-a968-03164046ac47" />
