### PR TITLE
airgeddon: add xorg-xhost as dependency

### DIFF
--- a/packages/airgeddon/PKGBUILD
+++ b/packages/airgeddon/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=airgeddon
 pkgver=v11.61.r0.gd7e2423
-pkgrel=2
+pkgrel=3
 epoch=1
 pkgdesc='Multi-use bash script for Linux systems to audit wireless networks.'
 groups=('blackarch' 'blackarch-wireless' 'blackarch-automation')
@@ -17,7 +17,7 @@ optdepends=('hashcat' 'crunch' 'mdk4' 'reaver' 'beef' 'hostapd' 'lighttpd'
             'pixiewps' 'dhcp' 'curl' 'ethtool' 'rfkill' 'wget' 'usbutils'
             'xorg-xdpyinfo' 'ccze' 'xorg-xset' 'asleap' 'john' 'hostapd-wpe'
             'nftables' 'openssl' 'mdk3' 'hcxtools' 'hcxdumptool' 'wireshark-cli'
-            'systemd' 'tcpdump' 'arping' 'hostapd-mana' 'sox')
+            'systemd' 'tcpdump' 'arping' 'hostapd-mana' 'sox' 'xorg-xhost')
 makedepends=('git' 'coreutils')
 source=("git+https://github.com/v1s1t0r1sh3r3/$pkgname.git")
 sha512sums=('SKIP')


### PR DESCRIPTION
xorg-xhost may be required on wayland to provide the xhost command. See https://github.com/v1s1t0r1sh3r3/airgeddon/wiki/FAQ%20&%20Troubleshooting#when-i-start-airgeddon-i-see-this-message-no-graphics-system-was-detected

can someone test the PKGBUILD? I'm away from my testing machine.