### PR TITLE
multiple: migrating from pip to python-installer; updating versions.

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,4 @@
+python-jpype1
+python-pick
+python-pyghidra
+python-pymssql

--- a/packages/python-jpype1/PKGBUILD
+++ b/packages/python-jpype1/PKGBUILD
@@ -4,13 +4,13 @@
 pkgname=python-jpype1
 _pkgname=${pkgname#python-}
 pkgver=1.6.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Python to Java bridge, an effort to allow Python programs full access to Java class libraries.'
 arch=('x86_64' 'aarch64')
 url='https://github.com/jpype-project/jpype'
 license=('Apache-2.0')
 depends=('python' 'python-packaging' 'java-runtime')
-makedepends=('python-build' 'python-pip')
+makedepends=('python-build' 'python-wheel' 'python-installer' 'python-setuptools')
 options=(!emptydirs)
 conflicts=('jpype' 'python-jpype')
 source=("https://github.com/jpype-project/jpype/archive/refs/tags/v$pkgver.tar.gz")
@@ -19,23 +19,12 @@ sha512sums=('5849509334ab4eb63546b584eb32a0d61a9da2b5b303acc380f0be2742b96b32a2b
 build() {
   cd "jpype-$pkgver"
 
-  python -m build --wheel --outdir="$startdir/dist"
+  python -m build --wheel --no-isolation
 }
 
 package() {
   cd "jpype-$pkgver"
 
-  pip install \
-    --verbose \
-    --disable-pip-version-check \
-    --no-warn-script-location \
-    --ignore-installed \
-    --no-compile \
-    --no-deps \
-    --root="$pkgdir" \
-    --prefix=/usr \
-    --no-index \
-    --find-links="file://$startdir/dist" \
-    $_pkgname
+  python -m installer --destdir="$pkgdir" dist/*.whl
 }
 

--- a/packages/python-pick/PKGBUILD
+++ b/packages/python-pick/PKGBUILD
@@ -4,36 +4,25 @@
 pkgname=python-pick
 _pkgname=pick
 pkgver=2.4.0
-pkgrel=4
+pkgrel=5
 pkgdesc='Create curses based interactive selection list in the terminal.'
 arch=('any')
 url='https://pypi.org/project/pick/#files'
 license=('MIT')
 depends=('python')
-makedepends=('python-build' 'python-pip')
+makedepends=('python-build' 'python-wheel' 'python-installer' 'python-setuptools' 'python-poetry-core')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
 sha512sums=('23524a344bc5a87399082bd18f15c1d0ac53ad5dd283547d36edd25e4870bdfcd8d3ed9ed7199b1883120ba8db5cb11dac6a433592d77d4f36aab9ad12b340b1')
 
 build() {
   cd "$_pkgname-$pkgver"
 
-  python -m build --wheel --outdir="$startdir/dist"
+  python -m build --wheel --no-isolation
 }
 
 package() {
   cd "$_pkgname-$pkgver"
 
-  pip install \
-    --verbose \
-    --disable-pip-version-check \
-    --no-warn-script-location \
-    --ignore-installed \
-    --no-compile \
-    --no-deps \
-    --root="$pkgdir" \
-    --prefix=/usr \
-    --no-index \
-    --find-links="file://$startdir/dist" \
-    $_pkgname
+  python -m installer --destdir="$pkgdir" dist/*.whl
 }
 

--- a/packages/python-pyghidra/PKGBUILD
+++ b/packages/python-pyghidra/PKGBUILD
@@ -3,39 +3,28 @@
 
 pkgname=python-pyghidra
 _pkgname=${pkgname#python-}
-pkgver=3.0.0
-pkgrel=2
+pkgver=3.0.2
+pkgrel=1
 pkgdesc='Python library that provides direct access to the Ghidra API.'
 arch=('any')
 url='https://github.com/NationalSecurityAgency/ghidra'
 license=('Apache-2.0')
 depends=('python-jpype1' 'python-packaging')
-makedepends=('python-build' 'python-pip')
+makedepends=('python-build' 'python-wheel' 'python-installer' 'python-setuptools')
 options=(!emptydirs)
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('0c4a41929f46ccebb962a3b930adad3303ab6f604b3ab2b87d72d99c5e853604d68a672fef0c7fff8071f6a2bef7879569772d17421e86d6daa36481fe511d42')
+sha512sums=('b81fd1fa559443c84426dc3b8644004b521d57e55362e91fd6d8309f1f157da4b2a8d4b5b45bc34c590b88a8f62bf0dd6980cc7c07f4e786557a283bc4bc4c8a')
 
 build() {
   cd "$_pkgname-$pkgver"
 
-  python -m build --wheel --outdir="$startdir/dist"
+  python -m build --wheel --no-isolation
 }
 
 package() {
   cd "$_pkgname-$pkgver"
 
-  pip install \
-    --verbose \
-    --disable-pip-version-check \
-    --no-warn-script-location \
-    --ignore-installed \
-    --no-compile \
-    --no-deps \
-    --root="$pkgdir" \
-    --prefix=/usr \
-    --no-index \
-    --find-links="file://$startdir/dist" \
-    $_pkgname
+  python -m installer --destdir="$pkgdir" dist/*.whl
 
     # No need. It installs an executable to install pyghidra in a venv. It is
     # already provided by ghidra package

--- a/packages/python-pymssql/PKGBUILD
+++ b/packages/python-pymssql/PKGBUILD
@@ -3,37 +3,34 @@
 
 pkgname=python-pymssql
 _pkgname=pymssql
-pkgver=2.3.11
+pkgver=2.3.13
 pkgrel=1
 pkgdesc='DB-API interface to Microsoft SQL Server for Python. (new Cython-based version).'
 arch=('x86_64' 'aarch64')
 url='https://pypi.org/project/pymssql/#files'
 license=('LGPL')
 depends=('python' 'freetds')
-makedepends=('python-pip' 'python-build' 'python-wheel' 'cython')
+makedepends=('python-installer' 'python-setuptools' 'python-build' 'python-wheel' 'cython'
+            'python-packaging' 'python-setuptools-scm' 'python-tomli')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('501a60aba45ed9294c94ff4cc0d05ad495b67e64827f559a361c3826b0dd739f164e548ce04d1d8e2b64438ddc798206b6e2cb095c7ea650887022b65c1c28c1')
+sha512sums=('53bcf3f04c00bfac60935af12331e08a5adc59e1eaab12083304f49799a925e99f944436ce4cff606c562fee842c93e4a824f46c97513f2efc6196be82184023')
+
+
+prepare() {
+  cd "$_pkgname-$pkgver"
+
+  sed -i '/standard-distutils/d' pyproject.toml
+}
 
 build() {
   cd "$_pkgname-$pkgver"
 
-  python -m build --wheel --outdir="$startdir/dist"
+  python -m build --wheel --no-isolation
 }
 
 package() {
   cd "$_pkgname-$pkgver"
 
-  pip install \
-    --verbose \
-    --disable-pip-version-check \
-    --no-warn-script-location \
-    --ignore-installed \
-    --no-compile \
-    --no-deps \
-    --root="$pkgdir" \
-    --prefix=/usr \
-    --no-index \
-    --find-links="file://$startdir/dist" \
-    $_pkgname
+  python -m installer --destdir="$pkgdir" dist/*.whl
 }
 


### PR DESCRIPTION
Updating python-pyghidra and python-pymssql versions

Migrating python-jpype1, python-pick, python-pyghidra, python-pymssql from python-pip to python-installer.

Fix python-pymssql PKGBUILD to remove line from pyproject.toml that caused errors due to non-existent package provided by python-setuptools.

Fix depends and makedepends, and updating to-release.