### PR TITLE
update bluez-hciconfig

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+bluez-hciconfig

--- a/packages/bluez-hciconfig/PKGBUILD
+++ b/packages/bluez-hciconfig/PKGBUILD
@@ -5,15 +5,16 @@
 
 pkgname=bluez-hciconfig
 _pkgname=bluez
-pkgver=5.65
+pkgver=5.86
 pkgrel=1
 pkgdesc='Deprecated hciconfig tool from bluez.'
 url='http://www.bluez.org/'
 arch=('x86_64' 'aarch64')
 license=('GPL2')
 depends=('bluez' 'bluez-utils' 'bluez-libs' 'bluez-tools')
+conflicts=('bluez-deprecated-tools')
 source=("https://www.kernel.org/pub/linux/bluetooth/bluez-$pkgver.tar.xz")
-sha512sums=('c20c09a1a75053c77d73b3ce15ac7fd321eb6df5ca1646d57c6848b87c0c9957908bc17dd928da4ef2aacfc8667877cbc7511c1ba43db839bfa9bf1fb8269907')
+sha512sums=('d3268be43ad869dabd9d9eabc7a0da699837bb5432ecf61e1756e03f9b867a1d989299db1493bd349d73b495d736f55d7518fbb9ee664de49e5d1cf7c2156df7')
 
 build() {
   cd "$_pkgname-$pkgver/tools"
@@ -26,9 +27,9 @@ build() {
 }
 
 package() {
-  cd "$_pkgname-$pkgver/tools"
+  cd "$_pkgname-$pkgver"
 
-  install -Dm 755 hciconfig "$pkgdir/usr/bin/hciconfig"
-  install -Dm 755 hciconfig.1 "$pkgdir/usr/share/man/man1/hciconfig.1"
+  install -Dm 755 tools/hciconfig "$pkgdir/usr/bin/hciconfig"
+  install -Dm 755 doc/hciconfig.1 "$pkgdir/usr/share/man/man1/hciconfig.1"
 }
 


### PR DESCRIPTION
Adding conflicts that solves this:
```
$ sudo pacman -S bluez-hciconfig
resolving dependencies...
looking for conflicting packages...

Package (1)                New Version  Net Change

blackarch/bluez-hciconfig  5.65-1         0.10 MiB

Total Installed Size:  0.10 MiB

:: Proceed with installation? [Y/n] y
(1/1) checking keys in keyring                                                             [####################################################] 100%
(1/1) checking package integrity                                                           [####################################################] 100%
(1/1) loading package files                                                                [####################################################] 100%
(1/1) checking for file conflicts                                                          [####################################################] 100%
error: failed to commit transaction (conflicting files)
bluez-hciconfig: /usr/bin/hciconfig exists in filesystem (owned by bluez-deprecated-tools)
bluez-hciconfig: /usr/share/man/man1/hciconfig.1.gz exists in filesystem (owned by bluez-deprecated-tools)
Errors occurred, no packages were upgraded.
$ 
```

And updating the version even though it is deprecated...