### PR TITLE
updated klee package

### DIFF
--- a/packages/klee/PKGBUILD
+++ b/packages/klee/PKGBUILD
@@ -14,7 +14,7 @@ license=('custom:UIUC')
 groups=('blackarch' 'blackarch-binary' 'blackarch-reversing'
         'blackarch-debugger')
 depends=('gperftools' 'z3' 'libcap' 'python' 'llvm-libs' 'klee-uclibc' 'sqlite')
-makedepends=('llvm' 'clang' 'cmake' 'git' 'gperftools' 'z3')
+makedepends=('llvm>=15' 'clang==16' 'cmake' 'git' 'gperftools' 'z3')
 source=("git+https://github.com/$pkgname/$pkgname.git"
         "https://github.com/google/googletest/archive/refs/tags/v1.16.0.zip")
 sha512sums=(


### PR DESCRIPTION
This update follows the one to klee-uclibc. it brings klee to an up-to-date state