### PR TITLE
Add LLVM 16 for #4868

### DIFF
--- a/packages/llvm16/PKGBUILD
+++ b/packages/llvm16/PKGBUILD
@@ -48,10 +48,10 @@ build() {
     -DLLVM_LINK_LLVM_DYLIB=ON
     -DLLVM_USE_PERF=ON
     -DCMAKE_CXX_STANDARD=17
-    -DCMAKE_C_COMPILER=clang 
-    -DCMAKE_CXX_COMPILER=clang++ 
-    -DCMAKE_C_FLAGS="-include stdint.h" 
-    -DCMAKE_CXX_FLAGS="-include stdint.h" 
+    -DCMAKE_C_COMPILER=clang
+    -DCMAKE_CXX_COMPILER=clang++
+    -DCMAKE_C_FLAGS="-include stdint.h"
+    -DCMAKE_CXX_FLAGS="-include stdint.h"
   )
 
   cmake .. "${cmake_args[@]}"
@@ -69,3 +69,4 @@ package() {
 
   DESTDIR="$pkgdir" ninja install
 }
+


### PR DESCRIPTION
I realized, while testing PR #4868 that klee relied on LLVM 16. Threrefore, I packaged LLVM 16 and clang 16 to build klee.This PR will allow me to complete the update of klee itself.