### PR TITLE
add nox-framework and python-fpdf2 packages

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,2 @@
+python-fpdf2
+nox-framework

--- a/packages/nox-framework/PKGBUILD
+++ b/packages/nox-framework/PKGBUILD
@@ -1,0 +1,33 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=nox-framework
+pkgver=1.0.0
+pkgrel=1
+pkgdesc='The ultimate OSINT & CTI Framework. 120+ sources, async performance, identity pivoting, and automated risk analysis. Built for Red Teams and Forensics.'
+arch=('any')
+groups=('blackarch' 'blackarch-scanner' 'blackarch-recon' 'blackarch-forensic')
+url='https://github.com/nox-project/nox-framework'
+license=('Apache-2.0')
+depends=('python' 'python-aiohttp' 'python-aiohttp-socks' 'python-aiosqlite'
+         'python-httpx' 'python-requests' 'python-certifi' 'python-cloudscraper'
+         'python-beautifulsoup4' 'python-lxml' 'python-dnspython' 'python-phonenumbers'
+         'python-pydantic' 'python-pydantic-core' 'python-colorama' 'python-rich'
+         'python-stem' 'python-fpdf2')
+makedepends=('python-build' 'python-installer' 'python-setuptools'
+             'python-wheel')
+source=("$url/archive/refs/tags/v$pkgver.tar.gz")
+sha512sums=('3154da1139eba6c1f320378fce0fac43a2a2833476167be541ecaafcfcf45115f53ed51216bbe754165631d9dcbf1b94618539045ca52de09c5df07180366656')
+
+build() {
+  cd "$pkgname-$pkgver"
+
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  python -m installer --destdir="$pkgdir" dist/*.whl
+}
+

--- a/packages/nox-framework/PKGBUILD
+++ b/packages/nox-framework/PKGBUILD
@@ -23,11 +23,14 @@ build() {
   cd "$pkgname-$pkgver"
 
   python -m build --wheel --no-isolation
+  python build_sources.py
 }
 
 package() {
   cd "$pkgname-$pkgver"
 
   python -m installer --destdir="$pkgdir" dist/*.whl
+  install -dm755 "$pkgdir/usr/share/$pkgname/sources"
+  install -m644 sources/*.json "$pkgdir/usr/share/$pkgname/sources/"
 }
 

--- a/packages/python-fpdf2/PKGBUILD
+++ b/packages/python-fpdf2/PKGBUILD
@@ -1,0 +1,30 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-fpdf2
+_pkgname=fpdf2
+pkgver=2.8.7
+pkgrel=1
+pkgdesc='Simple PDF generation for Python '
+arch=('any')
+groups=('blackarch')
+url='https://github.com/py-pdf/fpdf2'
+license=('LGPL-3.0-only')
+depends=('python' 'python-defusedxml' 'python-pillow' 'python-fonttools')
+makedepends=('python-build' 'python-installer' 'python-setuptools'
+             'python-wheel')
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('fb1b5a1c0322eab9b70d5a4f4e38b40543bb515119c55aa4b1b7796571c6e020f21b0db75f46db9753e95d949a157e67ca1afb9f1ebe18d5872567dc7c42c60b')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  python -m installer --destdir="$pkgdir" dist/*.whl
+}
+


### PR DESCRIPTION
## Before submitting, please select the type of PR you are opening

- [x] 📦 New tool/library submission

Solves #4904 

---
<!-- Fill in ONLY the section that matches your PR type above. Delete the other sections. -->

# 📦 New tool/library submission

### Package name
<!-- Indicate the name of the package as it will appear in the BlackArch repository -->
nox-framework and python-fpdf2

### Description
<!-- Clear and concise description of what the tool does and what security use case it addresses -->
The ultimate OSINT & CTI Framework. 120+ sources, async performance, identity pivoting, and automated risk analysis. Built for Red Teams and Forensics.

### Source URL
<!-- Link to the tool's upstream source code repository -->
https://github.com/nox-project/nox-framework

### License
<!-- Indicate the tool's license, e.g. MIT, GPL-3.0. If there is no license or source is not public, indicate "custom" -->
nox-framework: Apache-2.0
python-fpdf: LGPL-3.0-only

### Tool category
<!-- Indicate the most appropriate category for this tool. Available categories:
anti-forensic, automation, automobile, backdoor, binary, bluetooth, code-audit, cracker,
crypto, database, debugger, decompiler, defensive, disassembler, dos, drone, exploitation,
fingerprint, firmware, forensic, fuzzer, hardware, honeypot, ids, keylogger, malware, misc,
mobile, networking, nfc, packer, proxy, radio, recon, reversing, scanner, sniffer, social,
spoof, stego, tunnel, voip, webapp, windows, wireless -->
nox-framework: recon, scanner, forensic

### Checklist

- [x] I assert that this tool is not already available in BlackArch or the official [Arch Linux repositories](https://archlinux.org/packages/).
- [x] I assert that this is not a duplicate of an [existing open PR](https://github.com/BlackArch/blackarch/pulls?q=is%3Aopen).
- [x] I assert that I have successfully tested, built and installed the package locally.
- [x] I assert that the PKGBUILD follows the official [BlackArch PKGBUILD templates](https://github.com/BlackArch/blackarch-pkgbuilds).
- [x] I assert that the tool is actively maintained upstream and does not depend on deprecated languages or libraries.
- [x] I assert that I have read the [Arch Linux Code of Conduct](https://terms.archlinux.org/docs/code-of-conduct/) and agree to abide by it.