### PR TITLE
add aimap: security scanner for AI/ML infrastructure

### DIFF
--- a/packages/aimap/PKGBUILD
+++ b/packages/aimap/PKGBUILD
@@ -1,0 +1,36 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=aimap
+pkgver=1.1.1
+pkgrel=1
+groups=('blackarch' 'blackarch-scanner' 'blackarch-recon' 'blackarch-networking')
+pkgdesc='Security scanner and fingerprinter for AI/ML infrastructure. Identifies 23 service types including LLMs, vector databases, and model servers.'
+arch=('x86_64' 'aarch64')
+url='https://github.com/Nicholas-Kloster/aimap'
+license=('MIT')
+makedepends=('go')
+source=("https://github.com/Nicholas-Kloster/aimap/archive/v$pkgver.tar.gz")
+sha512sums=('919f2e2077aa0fdd880f1540faa1ffa94d836de3a5e52bb0ba2bd9a0afc2c9fafb86ae7279f2a17339bd56a7cb631f157a17bbb08f97d0bb7a0af7b077b3e57c')
+
+build() {
+  cd "$pkgname-$pkgver"
+
+  GOPATH="$srcdir" go mod download
+  GOPATH="$srcdir" go build \
+    -trimpath \
+    -buildmode=pie \
+    -mod=readonly \
+    -modcacherw \
+    -ldflags "-s -w" \
+    -o "$pkgname" .
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  install -Dm 755 "$pkgname" "$pkgdir/usr/bin/$pkgname"
+  install -Dm 644 "aimap.1" "$pkgdir/usr/share/man/man1/aimap.1"
+  install -Dm 644 "LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm 644 "README.md" "$pkgdir/usr/share/doc/$pkgname/README.md"
+}


### PR DESCRIPTION
## Before submitting, please select the type of PR you are opening

- [x] 📦 New tool/library submission
- [ ] 🕸️ New mirror submission

---

# 📦 New tool/library submission

### Package name

`aimap`

### Description

aimap is a purpose-built security scanner for AI and machine learning infrastructure. Where `nmap` and `nuclei` identify that a service is running, aimap identifies *which* AI/ML service is running and whether it is exposing data, PII, credentials, or compute.

It fingerprints 23 AI/ML service types across six categories — vector databases (Weaviate, ChromaDB, Qdrant, Milvus), LLM runtimes (Ollama, vLLM, LocalAI, text-generation-webui), ML platforms (MLflow, TensorFlow Serving, Triton, Ray, Ray Dashboard, Kubeflow), orchestration/UI (LangServe, Flowise, Dify, Open WebUI, LiteLLM, BentoML), observability (Langfuse), and notebooks (Jupyter Notebook, Docker Registry) — and runs service-specific deep enumeration to surface actionable findings:

- Unauthenticated Jupyter kernels (RCE)
- Vector database PII field exposure
- Flowise credentials endpoint accessibility
- Ollama open inference endpoints (LLMjacking vector)
- Dify with unclaimed admin accounts
- Langfuse instances leaking LLM conversation history
- MLflow experiments and model registries accessible
- ChromaDB collections with PII-indicating names

Single statically-linked Go binary, read-only HTTP GETs only (no writes, no auth attempts, no exploits), JSON output for pipeline integration. Intended for defenders auditing their own networks for shadow AI deployments and bug bounty researchers testing AI companies within program scope.

### Source URL

https://github.com/Nicholas-Kloster/aimap

### License

MIT

### Tool category

`scanner` (primary; also fits `recon` and `networking` via groups)

### Additional context

- Locally built and tested with `makepkg -s` on `archlinux:latest` — clean build, source sha512 validated, package installs without conflicts, `aimap` binary runs and reports `Fingerprints: 23 AI/ML services`.
- Upstream is actively maintained — current release v1.1.1 cut today (2026-04-16), prebuilt binaries for linux/darwin amd64+arm64 attached to the GitHub release.
- No similar tool currently in BlackArch or the official Arch repos. Generic scanners (`nmap`, `nuclei`) detect AI services as plain HTTP and don't surface AI-specific risk like PII in vector schemas or unauthenticated inference endpoints.
- This release ships `aimap.1` (groff man page) and an MIT `LICENSE` file in the source tree, both installed by the package.

### Checklist

- [x] I assert that this tool is not already available in BlackArch or the official [Arch Linux repositories](https://archlinux.org/packages/).
- [x] I assert that this is not a duplicate of an [existing open PR](https://github.com/BlackArch/blackarch/pulls?q=is%3Aopen).
- [x] I assert that I have successfully tested, built and installed the package locally.
- [x] I assert that the PKGBUILD follows the official [BlackArch PKGBUILD templates](https://github.com/BlackArch/blackarch-pkgbuilds).
- [x] I assert that the tool is actively maintained upstream and does not depend on deprecated languages or libraries.
- [x] I assert that I have read the [Arch Linux Code of Conduct](https://terms.archlinux.org/docs/code-of-conduct/) and agree to abide by it.