### PR TITLE
packages: add procscope

### DIFF
--- a/packages/procscope/PKGBUILD
+++ b/packages/procscope/PKGBUILD
@@ -1,0 +1,50 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=procscope
+pkgver=1.1.0
+pkgrel=1
+pkgdesc='Process-scoped runtime investigation tool using eBPF.'
+groups=('blackarch' 'blackarch-defensive' 'blackarch-forensic' 'blackarch-debugger')
+arch=('x86_64' 'aarch64')
+url='https://github.com/Mutasem-mk4/procscope'
+license=('MIT')
+depends=()
+makedepends=('go')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Mutasem-mk4/procscope/archive/refs/tags/v$pkgver.tar.gz")
+sha512sums=('f8483681b1f3b6349e65d668aec67ab02bb7a0dced4f86478280561f23cdffbf139d50ba275cbf1ce17062c045b2e944f674c5c108efa38d50e752cc2e5d48bd')
+
+build() {
+  cd "$pkgname-$pkgver"
+
+  export CGO_ENABLED=0
+  export GOFLAGS='-trimpath -mod=readonly -modcacherw'
+
+  go build \
+    -buildmode=pie \
+    -ldflags "-s -w \
+      -X 'github.com/Mutasem-mk4/procscope/internal/version.Version=$pkgver' \
+      -X 'github.com/Mutasem-mk4/procscope/internal/version.Commit=blackarch'" \
+    -o "$pkgname" \
+    ./cmd/procscope
+}
+
+check() {
+  cd "$pkgname-$pkgver"
+  go test -short ./internal/events/... ./internal/output/... ./internal/redact/... ./internal/version/...
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  install -Dm755 "$pkgname" "$pkgdir/usr/bin/$pkgname"
+  install -Dm644 "man/$pkgname.1" "$pkgdir/usr/share/man/man1/$pkgname.1"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 "completions/$pkgname.bash" \
+    "$pkgdir/usr/share/bash-completion/completions/$pkgname"
+  install -Dm644 "completions/$pkgname.zsh" \
+    "$pkgdir/usr/share/zsh/site-functions/_$pkgname"
+  install -Dm644 "completions/$pkgname.fish" \
+    "$pkgdir/usr/share/fish/vendor_completions.d/$pkgname.fish"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+}


### PR DESCRIPTION
## Summary
- add procscope, a process-scoped eBPF runtime investigation tool for Linux malware triage and incident response
- package upstream release v1.1.0 from the GitHub source tarball with a pinned SHA-512 checksum
- install the binary, man page, shell completions, license, and README

## Package Notes
- groups: blackarch-defensive, blackarch-forensic, blackarch-debugger
- build uses upstream's pure-Go flow with CGO_ENABLED=0
- check() runs the upstream unit-test subset that does not require eBPF runtime access

## Validation Notes
- upstream CI currently builds Debian and Arch packages successfully
- Arch/BlackArch host-side makepkg validation is still recommended during review