### PR TITLE
update aespipe 2.4f -> 2.4i

### DIFF
--- a/packages/aespipe/PKGBUILD
+++ b/packages/aespipe/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=aespipe
-pkgver=2.4f
+pkgver=2.4i
 pkgrel=1
 groups=('blackarch' 'blackarch-crypto')
 pkgdesc='Reads data from stdin and outputs encrypted or decrypted results to stdout.'
@@ -10,7 +10,7 @@ arch=('x86_64' 'aarch64')
 url='http://loop-aes.sourceforge.net/aespipe/'
 license=('GPL')
 source=("http://loop-aes.sourceforge.net/$pkgname/$pkgname-v$pkgver.tar.bz2")
-sha512sums=('75b6b2069a0e013dbded29b07b990fc783cc04ce05fc37e6591dae7e8190485960735ec1a1af18d065be57d0b7ec23dbe520e920f92e9c01170b7a23eb32eb3f')
+sha512sums=('fd65339141d498d4eea4b948cb2aa2e6f39091b4599883c219ead00383b24178483ab9b2c22361a8961aa2d505c2c8bf8dddeb714ea7b9ccfa621a0ac8e28bbb')
 
 build() {
   cd "$pkgname-v$pkgver"


### PR DESCRIPTION
### Package name
aespipe

### Description
encrypt data from stdin to stdout

### Source URL
http://loop-aes.sourceforge.net/aespipe/aespipe-v2.4i.tar.bz2

### License
GPL

### Tool category
crypto

### Additional context
i just bumped the release.

### Checklist

- [x] I assert that this tool is not already available in BlackArch or the official [Arch Linux repositories](https://archlinux.org/packages/).
- [x] I assert that this is not a duplicate of an [existing open PR](https://github.com/BlackArch/blackarch/pulls?q=is%3Aopen).
- [x] I assert that I have successfully tested, built and installed the package locally.
- [x] I assert that the PKGBUILD follows the official [BlackArch PKGBUILD templates](https://github.com/BlackArch/blackarch-pkgbuilds).
- [x] I assert that the tool is actively maintained upstream and does not depend on deprecated languages or libraries.
- [x] I assert that I have read the [Arch Linux Code of Conduct](https://terms.archlinux.org/docs/code-of-conduct/) and agree to abide by it.
