### PR TITLE
fix(cupp): remove cd in wrapper script that prevents writing output to cwd

### DIFF
--- a/packages/cupp/PKGBUILD
+++ b/packages/cupp/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc='Common User Password Profiler'
 url='http://www.remote-exploit.org/?page_id=418'
 groups=('blackarch' 'blackarch-cracker')
 license=('GPL3')
-depends=('python2')
+depends=('python')
 makedepends=('git')
 arch=('any')
 source=("git+https://github.com/Mebus/$pkgname.git")
@@ -35,8 +35,7 @@ package() {
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
-cd /usr/share/$pkgname
-exec python3 $pkgname.py "\$@"
+exec python3 /usr/share/$pkgname/$pkgname.py "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"


### PR DESCRIPTION
## Summary

The cupp wrapper script (`/usr/bin/cupp`) does `cd /usr/share/cupp` before exec, which changes the working directory to a root-owned install path. This causes `PermissionError` when cupp tries to write output files (e.g. `jane.txt`) since it writes relative to CWD.

```
PermissionError: [Errno 13] Permission denied: 'jane.txt'
```

The `cd` is unnecessary — `cupp.py` already resolves its config path absolutely:
```python
read_config(os.path.join(os.path.dirname(os.path.realpath(__file__)), "cupp.cfg"))
```

## Changes

- Remove `cd /usr/share/cupp` from wrapper, use absolute path to `cupp.py` instead
- Update `depends` from `python2` to `python` (cupp uses Python 3 syntax, wrapper already calls `python3`)

## Diff

```diff
-depends=('python2')
+depends=('python')
```

```diff
 cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
-cd /usr/share/$pkgname
-exec python3 $pkgname.py "\$@"
+exec python3 /usr/share/$pkgname/$pkgname.py "\$@"
 EOF
```