### PR TITLE
Update nox-framework to v1.0.4

### DIFF
--- a/packages/nox-framework/PKGBUILD
+++ b/packages/nox-framework/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=nox-framework
-pkgver=1.0.1
+pkgver=1.0.4
 pkgrel=1
 pkgdesc='OSINT & CTI Framework with 120+ sources, async performance, identity pivoting, and automated risk analysis.'
 arch=('any')
@@ -17,7 +17,7 @@ depends=('python' 'python-aiohttp' 'python-aiohttp-socks' 'python-aiosqlite'
 makedepends=('python-build' 'python-installer' 'python-setuptools'
              'python-wheel')
 source=("$url/archive/refs/tags/v$pkgver.tar.gz")
-sha512sums=('e8e22dd8f82cbe9347313d50f50f8adc63c339dba62b2b69d6761ac1781563ac4e6f9d58586e9b93da5fcbaa86be1a580a1f2990cf4abd4e558dd4d08b34852b')
+sha512sums=('a10a4b99843dd2fb662e9f64b183140862b910dd1fe97ddb4552528dbeb2ff269e1d723c4d095f0e89339a2a06fe39e709906274b432e4f24a5fb4271e8b23bd')
 
 build() {
   cd "$pkgname-$pkgver"


### PR DESCRIPTION
Hi everyone!
Updating nox-framework to 1.0.4.

This release addresses some stability and logic issues identified post-launch:

- SSL/TLS: Fixed _build_ssl_context (loading CA certs).
- Reporting: Fixed regex anchoring (prevented false positive noise filtering).
- Performance: Fixed memory leak in AvalancheScanner and switched ProxyManager to lazy loading.
- Auth: Fixed IntelX API key retrieval.

Thanks :)