### PR TITLE
packages: nirsoft: 1.23 -> 1.30, scap-security-guide: 0.1.60 -> 0.1.80

### DIFF
--- a/packages/nirsoft/PKGBUILD
+++ b/packages/nirsoft/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=nirsoft
-pkgver=1.23.30
+pkgver=1.30.23
 pkgrel=1
 pkgdesc='Unique collection of small and useful freeware utilities.'
 groups=('blackarch' 'blackarch-windows' )

--- a/packages/nirsoft/PKGBUILD
+++ b/packages/nirsoft/PKGBUILD
@@ -12,12 +12,12 @@ url='https://www.nirsoft.net'
 urlZip="https://download.nirsoft.net/nirsoft_package_enc_$pkgver.zip"
 
 pkgver() {
-	curl "https://launcher.nirsoft.net/downloads/index.html" 2>/dev/null |
+  curl "https://launcher.nirsoft.net/downloads/index.html" 2>/dev/null |
     grep -P '<a.*_enc_.*\.zip' | sed -r 's/.*_([0-9]+\.[0-9]+\.[0-9]+).*/\1/gi'
 }
 package() {
-	tmpFile='/tmp/nirsoft.zip'
-	targetDir="$pkgdir/usr/share/windows/nirsoft/"
+  tmpFile='/tmp/nirsoft.zip'
+  targetDir="$pkgdir/usr/share/windows/nirsoft/"
 
   install -dm 755 "${targetDir}"
 

--- a/packages/scap-security-guide/PKGBUILD
+++ b/packages/scap-security-guide/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=scap-security-guide
-pkgver=0.1.60
+pkgver=0.1.80
 pkgrel=1
 pkgdesc='Security compliance content in SCAP, Bash, Ansible, and other formats.'
 arch=('any')
@@ -14,7 +14,7 @@ depends=()
 makedepends=('git')
 optdepends=('openscap' 'scap-workbench')
 source=("https://github.com/ComplianceAsCode/content/releases/download/v$pkgver/$pkgname-$pkgver.zip")
-sha512sums=('15ab7480fc329baf192bac8474795ec8c4409be40bd01359b13a3c65f511322275fcded1de6ab79b3b70e37c24fe4629e5188c3fea29ef6e6bf839ea46c10d9d')
+sha512sums=('ddaf6d35cf30ce8431ae401a855855a96cc53b7ae78afa34225f3df060549ea45874e7e9b192695de0863eec77ce4822e9d57fd3c4047759317de9c99cc6df4c')
 
 pkgver() {
   git ls-remote --sort=v:refname -t --refs \


### PR DESCRIPTION
updated nirsoft to the 4/18/26 binaries.
updated scap-security-guide to the March release.