### PR TITLE
Update python packages

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,3 @@
+pyinstaller
+python-dnsimple
+python-pyngrok

--- a/packages/pyinstaller/PKGBUILD
+++ b/packages/pyinstaller/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=pyinstaller
-pkgver=6.19.0
+pkgver=6.20.0
 pkgrel=1
 epoch=2
 groups=('blackarch' 'blackarch-misc')
@@ -20,7 +20,7 @@ makedepends=(
 )
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz"
         'fortify-source-fix.patch')
-sha512sums=('1859e80852e486272bddfb509c1763536dcae28de2de0d6df1b5b215652736cfc144e1a56c350f99ae4aae25f7bf9379ab70c5517c36595b9be94290a913d3b5'
+sha512sums=('dfee9c5a7a126d0eedd7cca82df83a9939f99c5fdfb86e64346fe4850869c89cbc16430665c678c458f3d2d4a1bbe6d1a8fa80bb31e166d06251e7b500dce878'
             '765a2f0c984d966c27309194e73a50b325309c5e65253c92a7140d8b179f94394dd0e01aa1b46b3777a1a06da33ce92919070dd70fde87bf5d81eb750d73f5ed')
 options=('!strip' '!emptydirs')
 
@@ -43,7 +43,6 @@ build() {
   #cd ..
 
   # Build package
-  export CFLAGS="$CFLAGS -Wno-error=discarded-qualifiers" # Temporary fix for 6.19
   python -m build --wheel --no-isolation
 }
 

--- a/packages/python-dnsimple/PKGBUILD
+++ b/packages/python-dnsimple/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=python-dnsimple
 _pkgname=dnsimple
 pkgdesc='DNSimple API service for python.'
-pkgver=7.2.0
+pkgver=7.3.0
 pkgrel=1
 arch=('any')
 url='https://pypi.org/project/dnsimple/'
@@ -13,7 +13,7 @@ depends=('python' 'python-requests' 'python-omitempty')
 makedepends=('python-build' 'python-installer' 'python-wheel'
              'python-setuptools' 'python-poetry-core')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('64a71555683fe5ccd1e308f9e7dc414bc04c7d2adcb6609dde8f62915098d07f9368ffad22148b370ef52d64633dc940d7c07468e7b772d0bc333522394f0246')
+sha512sums=('23da7f6a8f51ad9d49919ab186d59dc69ae4c3d771056f4ecb8a0a7b8b1210f0ecda51c16ce81c5b55d74b1fcf8a22c6a30cdedb69c386101a3b4f30fc26a1b7')
 
 build() {
   cd "$_pkgname-$pkgver"

--- a/packages/python-pyngrok/PKGBUILD
+++ b/packages/python-pyngrok/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=python-pyngrok
 _pkgname=pyngrok
-pkgver=8.0.0
+pkgver=8.1.1
 pkgrel=1
 pkgdesc='A Python wrapper for Ngrok.'
 arch=('any')
@@ -13,7 +13,7 @@ depends=('python' 'ngrok')
 makedepends=('python-build' 'python-installer' 'python-setuptools'
              'python-wheel')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('985ec8d4d1d20c313def654c69485bf27bf585222ffa12ee09751f0e4c8a03ce77f54972c109e82ed692b45b626918dbc262bac157a563f1089890bc1fc46fd1')
+sha512sums=('f19a0ae3e081d4055754caa140a2b40d1bfbd2e143d655f0271defb6a1b9b5e54f23e803fa5942ff4f41bf25b8b85e4af28c779a8786738a79676479b4475f2d')
 
 build() {
   cd "$_pkgname-$pkgver"


### PR DESCRIPTION
Simple updates

Only the "export CFLAGS" line is removed from the pyinstaller PKGBUILD, as it was a fix applied in #4857 and has already been resolved in https://github.com/pyinstaller/pyinstaller/pull/9372