### PR TITLE
Update opendoor  4.0.2-rc -> 5.13.2

### DIFF
--- a/packages/opendoor/PKGBUILD
+++ b/packages/opendoor/PKGBUILD
@@ -2,33 +2,28 @@
 # See COPYING for license details.
 
 pkgname=opendoor
-pkgver=v.4.2.0.r4.g5f8a253
+pkgver=5.13.2
 pkgrel=1
 epoch=1
 pkgdesc='OWASP WEB Directory Scanner.'
-groups=('blackarch' 'blackarch-webapp' 'blackarch-scanner')
+groups=('blackarch' 'blackarch-webapp' 'blackarch-scanner' 'blackarch-recon')
 arch=('any')
 url='https://github.com/stanislav-web/OpenDoor'
 license=('GPL-3.0-or-later')
-depends=('python' 'python-urllib3' 'python-json2html' 'python-tabulate'
-         'python-ddt' 'python-mock')
+depends=(
+  'python'
+  'python-packaging'
+  'python-pysocks'
+  'python-six'
+  'python-tabulate'
+  'python-urllib3'
+)
 makedepends=('git' 'python-setuptools')
-source=("$pkgname::git+https://github.com/stanislav-web/OpenDoor.git")
+source=("$pkgname::git+https://github.com/stanislav-web/OpenDoor.git#tag=v$pkgver")
 sha512sums=('SKIP')
 
-pkgver() {
-  cd $pkgname
-
-  ( set -o pipefail
-    git describe --long --tags --abbrev=7 2>/dev/null |
-      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
-    printf "%s.%s" "$(git rev-list --count HEAD)" \
-      "$(git rev-parse --short=7 HEAD)"
-  )
-}
-
 package() {
-  cd $pkgname
+  cd "$pkgname"
 
   install -dm 755 "$pkgdir/usr/bin"
   install -dm 755 "$pkgdir/usr/share/$pkgname"
@@ -36,16 +31,13 @@ package() {
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md CHANGELOG.md
   install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
-  rm *.md LICENSE
-
-  cp -a * "$pkgdir/usr/share/$pkgname/"
+  cp -a data src opendoor.py opendoor.conf VERSION "$pkgdir/usr/share/$pkgname/"
 
   cat > "$pkgdir/usr/bin/$pkgname" << EOF
 #!/bin/sh
 cd /usr/share/$pkgname
-exec python3 $pkgname.py "\$@"
+exec python3 opendoor.py "\$@"
 EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"
 }
-


### PR DESCRIPTION
## Package update

Updates the existing `opendoor` package from the old v4.2.x snapshot to v5.13.2.

### Changes

- Update `pkgver` to `5.13.2`
- Pin source to the upstream `v5.13.2` tag
- Remove `python-json2html` dependency because OpenDoor now has a built-in HTML report renderer
- Remove test-only runtime dependencies:
  - `python-ddt`
  - `python-mock`
- Add current runtime dependencies:
  - `python-packaging`
  - `python-pysocks`
  - `python-six`
  - `python-tabulate`
  - `python-urllib3`
- Keep the existing `/usr/share/opendoor` launcher layout
- Add `blackarch-recon` group because OpenDoor now includes broader web reconnaissance workflows

### Upstream verification

- GitHub release exists for `v5.13.2`
- PyPI publish workflow passed for `v5.13.2`
- Full upstream unittest suite passes
- Coverage gate passes at `99%`

### Package verification

- `PKGBUILD` updated via sparse checkout on macOS
- Package verification completed in an Arch Linux container on macOS/Apple Silicon via `--platform linux/amd64`.

### Notes

This is not a new tool submission. `opendoor` is already available in BlackArch; this PR updates the existing package and refreshes its dependencies.
