### PR TITLE
nerva: initial commit.

### DIFF
--- a/packages/nerva/PKGBUILD
+++ b/packages/nerva/PKGBUILD
@@ -44,6 +44,5 @@ package() {
 
   install -Dm 755 $pkgname "$pkgdir/usr/bin/$pkgname"
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
-
 }
 

--- a/packages/nerva/PKGBUILD
+++ b/packages/nerva/PKGBUILD
@@ -1,0 +1,50 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=nerva
+pkgver=v1.3.0.r95.ga0835aa
+pkgrel=1
+pkgdesc='Fast service fingerprinting CLI for 170+ protocols (TCP/UDP/SCTP).'
+arch=('x86_64' 'aarch64')
+groups=('blackarch' 'blackarch-scanner' 'blackarch-fingerprint'
+        'blackarch-recon')
+url='https://github.com/praetorian-inc/nerva'
+license=('Apache-2.0')
+depends=('glibc')
+makedepends=('git' 'go')
+source=("git+https://github.com/praetorian-inc/$pkgname.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null |
+      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" \
+      "$(git rev-parse --short=7 HEAD)"
+  )
+}
+
+build() {
+  cd $pkgname
+
+  GOPATH="$srcdir" go mod download
+  GOPATH="$srcdir" go build \
+    -trimpath \
+    -buildmode=pie \
+    -mod=readonly \
+    -modcacherw \
+    -ldflags "-s -w" \
+    -o $pkgname ./cmd/$pkgname
+}
+
+package() {
+  cd $pkgname
+
+  install -Dm 755 $pkgname "$pkgdir/usr/bin/$pkgname"
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+

--- a/packages/nerva/PKGBUILD
+++ b/packages/nerva/PKGBUILD
@@ -45,6 +45,5 @@ package() {
   install -Dm 755 $pkgname "$pkgdir/usr/bin/$pkgname"
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
 
-  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }
 


### PR DESCRIPTION
## Before submitting, please select the type of PR you are opening

- [x] 📦 New tool/library submission

# 📦 New tool/library submission

## Before submitting, please read the requirements

> **🚫 Illegal or unethical software:**
> Examples include brute-forcing social media accounts or DoS attack scripts.

> **🚫 Abandoned or extremely outdated software:**
> Especially if it no longer builds, creates dependency conflicts, or has no active upstream maintenance.

> **🚫 Deprecated languages or libraries dependency:**
> For example, Python 2 or other retired technologies that introduce security or compatibility issues.

> **🚫 Wrapper scripts with no unique functionality:**
> Scripts that simply call another tool with preset arguments (e.g., a front-end that just runs `nmap -sV ...`).

> **🚫 Non-portable or broken build systems:**
> Tools tied to a specific non-Arch distribution or that cannot be cleanly built on Arch/BlackArch.

> **🚫 Duplicate functionality:**
> Tools already covered by better-maintained or more widely-used alternatives in the repository.

> **🚫 Unnecessary anonymization helpers:**
> Scripts such as "free VPN launcher" tools. BlackArch already includes **torctl** for legitimate anonymization.

> **🚫 PKGBUILD does not follow official templates:**
> Submissions must follow the official PKGBUILD templates available in the [BlackArch PKGBUILDs repository](https://github.com/BlackArch/blackarch-pkgbuilds). PRs that deviate significantly from the templates will be rejected or sent back for revision.

### Package name
nerva


### Description
 Fast service fingerprinting CLI for 170+ protocols (TCP/UDP/SCTP), built by PraetorianInc.


### Source URL
https://github.com/praetorian-inc/nerva


### License
Apache-2.0


### Tool category
fingerprint, recon, scanner


### Additional context
N/A


### Checklist

- [x] I assert that this tool is not already available in BlackArch or the official [Arch Linux repositories](https://archlinux.org/packages/).
- [xI assert that this is not a duplicate of an [existing open PR](https://github.com/BlackArch/blackarch/pulls?q=is%3Aopen).
- [x] I assert that I have successfully tested, built and installed the package locally.
- [x] I assert that the PKGBUILD follows the official [BlackArch PKGBUILD templates](https://github.com/BlackArch/blackarch-pkgbuilds).
- [x] I assert that the tool is actively maintained upstream and does not depend on deprecated languages or libraries.
- [x] I assert that I have read the [Arch Linux Code of Conduct](https://terms.archlinux.org/docs/code-of-conduct/) and agree to abide by it.

--

Closes https://github.com/BlackArch/blackarch/issues/4866 if merged.