### PR TITLE
alterx: initial commit.

### DIFF
--- a/packages/alterx/PKGBUILD
+++ b/packages/alterx/PKGBUILD
@@ -1,0 +1,54 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=alterx
+pkgver=v0.1.0.r2.gbae701c
+pkgrel=1
+pkgdesc='Fast and customizable subdomain wordlist generator using DSL.'
+arch=('x86_64' 'aarch64')
+groups=('blackarch' 'blackarch-misc' 'blackarch-networking')
+url='https://github.com/projectdiscovery/alterx'
+license=('MIT')
+depends=('glibc')
+makedepends=('git' 'go')
+source=("git+https://github.com/projectdiscovery/$pkgname.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null |
+      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" \
+      "$(git rev-parse --short=7 HEAD)"
+  )
+}
+
+build() {
+  cd $pkgname
+
+  GOPATH="$srcdir" go mod download
+  GOPATH="$srcdir" go build \
+    -trimpath \
+    -buildmode=pie \
+    -mod=readonly \
+    -modcacherw \
+    -ldflags "-s -w" \
+    -o $pkgname ./cmd/$pkgname
+
+}
+
+package() {
+  cd $pkgname
+
+  install -dm 755 "$pkgdir/usr/share/$pkgname"
+
+  install -Dm 755 $pkgname "$pkgdir/usr/bin/$pkgname"
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+
+  cp -a static/* permutations.yaml "$pkgdir/usr/share/$pkgname/"
+  
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+


### PR DESCRIPTION
- [x] 📦 New tool/library submission

# 📦 New tool/library submission

### Package name
alterx

### Description
 Fast and customizable subdomain wordlist generator using DSL by projectdiscovery

### Source URL
https://github.com/projectdiscovery/alterx

### License
MIT

### Tool category
misc, networking

### Checklist

- [x] I assert that this tool is not already available in BlackArch or the official [Arch Linux repositories](https://archlinux.org/packages/).
- [x] I assert that this is not a duplicate of an [existing open PR](https://github.com/BlackArch/blackarch/pulls?q=is%3Aopen).
- [x] I assert that I have successfully tested, built and installed the package locally.
- [x] I assert that the PKGBUILD follows the official [BlackArch PKGBUILD templates](https://github.com/BlackArch/blackarch-pkgbuilds).
- [x] I assert that the tool is actively maintained upstream and does not depend on deprecated languages or libraries.
- [x] I assert that I have read the [Arch Linux Code of Conduct](https://terms.archlinux.org/docs/code-of-conduct/) and agree to abide by it.