### PR TITLE
goshs: update to 2.1.0

### DIFF
--- a/packages/goshs/PKGBUILD
+++ b/packages/goshs/PKGBUILD
@@ -2,17 +2,17 @@
 # See COPYING for license details.
 
 pkgname=goshs
-pkgver=2.0.8
+pkgver=2.1.0
 pkgrel=1
 pkgdesc='A single-binary file server for pentesters and sysadmins with HTTP/S, WebDAV, SFTP, SMB, LDAP, NTLM hash capture, DNS/SMTP callbacks and more.'
 arch=('x86_64' 'aarch64')
 groups=('blackarch' 'blackarch-misc')
-url='https://github.com/patrickhener/goshs'
+url='https://github.com/goshs-labs/goshs'
 license=('MIT')
 depends=()
 makedepends=('go')
 source=("$url/archive/refs/tags/v$pkgver.tar.gz")
-sha512sums=('125014f448140b17314feac73893bcd5ed0e05b158912b8a517872f77466162f389d7541930ecc89405af345e61e15f75daa330b50aa48a7533de5420efca2e6')
+sha512sums=('0a6bbe1418e7b25fe47c7976198a26d23dd14dbad9f8bacc186da47467e752108a08a5636aff7db4ce17c5f52260ea834a67c36da18a8fde9c570991ea94fc0f')
 
 build() {
   cd "$pkgname-$pkgver"


### PR DESCRIPTION
Closes #4953

- Version: 2.0.8 → 2.1.0
- URL: patrickhener/goshs → goshs-labs/goshs (upstream repo migration)