### PR TITLE
Add Screamer: Fast Subnet Discovery

### DIFF
--- a/packages/screamer/PKGBUILD
+++ b/packages/screamer/PKGBUILD
@@ -1,0 +1,28 @@
+# Maintainer: Ifrit <contact@ifritnoises.org>
+
+pkgname=screamer
+pkgver=0.1.1
+pkgrel=1
+pkgdesc='Fast Subnet Discovery'
+arch=('any')
+groups=('blackarch' 'blackarch-recon')
+url='https://github.com/ifritnoises/screamer'
+license=('MIT')
+depends=('python' 'python-scapy' 'python-colorama')
+makedepends=('python-build' 'python-installer' 'python-setuptools' 'python-wheel')
+source=("https://github.com/ifritnoises/screamer/archive/refs/tags/v$pkgver.tar.gz")
+sha512sums=('9138c2bb3f65c2fcd47ff399df54ad50613f2ff481d5c8186c844c527a58ae2f35fbc306c98942e69d656350aed0ac7d7f0bf192258508fd94077ed1f5d27364')
+
+build() {
+  cd "$pkgname-$pkgver"
+
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  python -m installer --destdir="$pkgdir" dist/*.whl
+
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packages/screamer/PKGBUILD
+++ b/packages/screamer/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Ifrit <contact@ifritnoises.org>
 
 pkgname=screamer
-pkgver=0.1.1
+pkgver=0.2.0
 pkgrel=1
 pkgdesc='Fast Subnet Discovery'
 arch=('any')
@@ -11,7 +11,7 @@ license=('MIT')
 depends=('python' 'python-scapy' 'python-colorama')
 makedepends=('python-build' 'python-installer' 'python-setuptools' 'python-wheel')
 source=("https://github.com/ifritnoises/screamer/archive/refs/tags/v$pkgver.tar.gz")
-sha512sums=('9138c2bb3f65c2fcd47ff399df54ad50613f2ff481d5c8186c844c527a58ae2f35fbc306c98942e69d656350aed0ac7d7f0bf192258508fd94077ed1f5d27364')
+sha512sums=('39d0c4603f4692446f37d7ef306e867010d782dec3aa4d89fbdb6b6680775933fd47c68f47f4f72e156e19de7fe433d53bbacc4764021e843e715bff3417b01a')
 
 build() {
   cd "$pkgname-$pkgver"


### PR DESCRIPTION
- [x] 📦 New tool/library submission

# 📦 New tool/library submission

### Package name
screamer

### Description
Screamer is a network reconnaissance tool designed for fast subnet discovery under conditions with unknown network addressing. Instead of scanning all hosts, it heuristically probes likely gateway addresses in each subnet and listens to traffic, gathering information about nearby hosts.

### Source URL
https://github.com/ifritnoises/screamer

### License
MIT

### Tool category
recon

### Additional context
Python package (setuptools backend). Runtime dependencies: `python-scapy`,
`python-colorama`. Requires root privileges for raw packet operations. Active
upstream, Python 3 only.

### Checklist

- [x] I assert that this tool is not already available in BlackArch or the official Arch Linux repositories.
- [x] I assert that this is not a duplicate of an existing open PR.
- [x] I assert that I have successfully tested, built and installed the package locally.
- [x] I assert that the PKGBUILD follows the official BlackArch PKGBUILD templates.
- [x] I assert that the tool is actively maintained upstream and does not depend on deprecated languages or libraries.
- [x] I assert that I have read the Arch Linux Code of Conduct and agree to abide by it.