### PR TITLE
wpprobe: initial commit

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+wpprobe

--- a/packages/wpprobe/PKGBUILD
+++ b/packages/wpprobe/PKGBUILD
@@ -1,0 +1,47 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=wpprobe
+pkgver=v0.11.8.r0.g41b4479
+pkgrel=1
+pkgdesc='A fast WordPress plugin enumeration tool.'
+arch=('x86_64' 'aarch64')
+groups=('blackarch' 'blackarch-scanner' 'blackarch-webapp')
+url='https://github.com/Chocapikk/wpprobe'
+license=('MIT')
+depends=()
+makedepends=('git' 'go')
+source=("git+https://github.com/Chocapikk/wpprobe.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null |
+      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" \
+      "$(git rev-parse --short=7 HEAD)"
+  )
+}
+
+build() {
+  cd $pkgname
+
+  GOPATH="$srcdir" go mod download
+  GOPATH="$srcdir" go build \
+    -trimpath \
+    -buildmode=pie \
+    -mod=readonly \
+    -modcacherw \
+    -ldflags "-s -w" \
+    -o $pkgname .
+}
+
+package() {
+  cd $pkgname
+
+  install -Dm 755 $pkgname "$pkgdir/usr/bin/$pkgname"
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+  install -Dm 644 LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packages/wpprobe/PKGBUILD
+++ b/packages/wpprobe/PKGBUILD
@@ -19,7 +19,7 @@ pkgver() {
 
   ( set -o pipefail
     git describe --long --tags --abbrev=7 2>/dev/null |
-      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+      sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g' ||
     printf "%s.%s" "$(git rev-list --count HEAD)" \
       "$(git rev-parse --short=7 HEAD)"
   )


### PR DESCRIPTION
## Type of PR

- [x] 📦 New tool/library submission

---

# 📦 New tool/library submission

### Package name
wpprobe

### Description
A fast WordPress plugin enumeration tool. It fingerprints installed WordPress plugins (and their versions) to map a target's attack surface during web assessments and bug-bounty recon.

### Source URL
https://github.com/Chocapikk/wpprobe

### License
MIT

### Tool category
scanner, webapp

### Additional context
- Go tool. PKGBUILD follows the official `PKGBUILD-go` template (git source + VCS `pkgver()`, `GOPATH="$srcdir" go mod download`, PIE / `-s -w` build). Static binary, no runtime dependencies.
- Built and tested with `makepkg` in a clean `archlinux:base-devel` container (produced `wpprobe-v0.11.8.r0.g41b4479-1-x86_64.pkg.tar.zst`).
- Added to `lists/to-release`.

### Checklist
- [x] I assert that this tool is not already available in BlackArch or the official [Arch Linux repositories](https://archlinux.org/packages/).
- [x] I assert that this is not a duplicate of an [existing open PR](https://github.com/BlackArch/blackarch/pulls?q=is%3Aopen).
- [x] I assert that I have successfully tested, built and installed the package locally.
- [x] I assert that the PKGBUILD follows the official [BlackArch PKGBUILD templates](https://github.com/BlackArch/blackarch-pkgbuilds).
- [x] I assert that the tool is actively maintained upstream and does not depend on deprecated languages or libraries.
- [x] I assert that I have read the [Arch Linux Code of Conduct](https://terms.archlinux.org/docs/code-of-conduct/) and agree to abide by it.
