### PR TITLE
fix full repository installation conflicts

### DIFF
--- a/packages/bagbak/PKGBUILD
+++ b/packages/bagbak/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=bagbak
 pkgver=342.71fbd4d
-pkgrel=1
+pkgrel=2
 pkgdesc='Yet another frida based App decryptor.'
 arch=('any')
 groups=('blackarch' 'blackarch-mobile' 'blackarch-reversing' 'blackarch-binary')
@@ -29,7 +29,7 @@ package() {
 
   cd "$_npmdir"
 
-  npm install --user root -g --prefix "$pkgdir/usr" "$pkgname@"
+  npm install -g --prefix "$pkgdir/usr" "$pkgname@"
 
   cd "$srcdir/$pkgname"
 

--- a/packages/brosec/PKGBUILD
+++ b/packages/brosec/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=brosec
 pkgver=278.c51164f
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-exploitation')
 pkgdesc='An interactive reference tool to help security professionals utilize useful payloads and commands.'
 url='https://github.com/gabemarshall/Brosec'
@@ -30,7 +30,7 @@ package(){
 
   cd "$_npmdir"
 
-  npm install --user root -g --prefix "$pkgdir/usr" Brosec@
+  npm install -g --prefix "$pkgdir/usr" Brosec@
 
   cd "$srcdir/$pkgname"
 

--- a/packages/express/PKGBUILD
+++ b/packages/express/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=express
 pkgver=4.17.3
-pkgrel=1
+pkgrel=2
 epoch=1
 pkgdesc='High performance, high class web development for node.js.'
 arch=('any')
@@ -23,7 +23,7 @@ package() {
 
   cd $_npmdir
 
-  npm install --user root -g --prefix "$pkgdir/usr" "express@$pkgver"
+  npm install -g --prefix "$pkgdir/usr" "express@$pkgver"
   rm -rf "$_npmdir/root"
 }
 

--- a/packages/git-dump/PKGBUILD
+++ b/packages/git-dump/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=git-dump
 _pkgname=node-git-dump
 pkgver=7.4c9a2a9
-pkgrel=1
+pkgrel=2
 pkgdesc='Dump the contents of a remote git repository without directory listing enabled.'
 arch=('any')
 groups=('blackarch' 'blackarch-scanner' 'blackarch-code-audit')
@@ -30,7 +30,7 @@ package() {
 
   cd "$_npmdir"
 
-  npm install --user root -g --prefix "$pkgdir/usr" "$pkgname@"
+  npm install -g --prefix "$pkgdir/usr" "$pkgname@"
 
   cd "$srcdir/$_pkgname"
 

--- a/packages/jstillery/PKGBUILD
+++ b/packages/jstillery/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=jstillery
 pkgver=65.512e9af
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-webapp')
 pkgdesc='Advanced JavaScript Deobfuscation via Partial Evaluation.'
 url='https://github.com/mindedsecurity/JStillery'
@@ -26,7 +26,7 @@ package() {
   install -dm 755 "$pkgdir/usr/bin"
   install -dm 755 "$pkgdir/usr/share/$pkgname"
 
-  npm install --user root -g --prefix "$pkgdir/usr"
+  npm install -g --prefix "$pkgdir/usr"
 
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
   install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"

--- a/packages/novahot/PKGBUILD
+++ b/packages/novahot/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=novahot
 pkgver=23.69857bb
-pkgrel=1
+pkgrel=2
 pkgdesc='A webshell framework for penetration testers.'
 groups=('blackarch' 'blackarch-webapp')
 arch=('any')
@@ -29,7 +29,7 @@ package() {
 
   cd $_npmdir
 
-  npm install --user root -g --prefix "$pkgdir/usr" novahot@
+  npm install -g --prefix "$pkgdir/usr" novahot@
 
   cd "$srcdir/$pkgname"
 

--- a/packages/padding-oracle-attacker/PKGBUILD
+++ b/packages/padding-oracle-attacker/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=padding-oracle-attacker
 pkgver=57.59dd18c
-pkgrel=1
+pkgrel=2
 pkgdesc='CLI tool to execute padding oracle attacks with support for concurrent network requests.'
 arch=('any')
 groups=('blackarch' 'blackarch-crypto')
@@ -29,7 +29,7 @@ package() {
 
   cd "$_npmdir"
 
-  npm install --user root -g --prefix "$pkgdir/usr" "$pkgname@"
+  npm install -g --prefix "$pkgdir/usr" "$pkgname@"
 
   cd "$srcdir/$pkgname"
 

--- a/packages/padoracle/PKGBUILD
+++ b/packages/padoracle/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=padoracle
 pkgver=v0.1.1.r30.g535ae89
-pkgrel=1
+pkgrel=2
 pkgdesc='Padding Oracle Attack with Node.js.'
 arch=('any')
 groups=('blackarch' 'blackarch-crypto')
@@ -29,7 +29,7 @@ package() {
 
   cd "$_npmdir"
 
-  npm install --user root -g --prefix "$pkgdir/usr" "$pkgname@"
+  npm install -g --prefix "$pkgdir/usr" "$pkgname@"
 
   cd "$srcdir/$pkgname"
 

--- a/packages/pown/PKGBUILD
+++ b/packages/pown/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=pown
 pkgver=332.0e32edf
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-webapp' 'blackarch-recon' 'blackarch-scanner'
         'blackarch-social' 'blackarch-proxy')
 pkgdesc='Security testing and exploitation toolkit built on top of Node.js and NPM.'
@@ -30,7 +30,7 @@ package() {
 
   cd $_npmdir
 
-  npm install --user root -g --prefix "$pkgdir/usr" $pkgname@
+  npm install -g --prefix "$pkgdir/usr" $pkgname@
   rm -rf "$_npmdir/root"
 }
 

--- a/packages/pwned/PKGBUILD
+++ b/packages/pwned/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=pwned
 pkgver=3074.68e1027
-pkgrel=1
+pkgrel=2
 pkgdesc="A command-line tool for querying the 'Have I been pwned?' service."
 groups=('blackarch' 'blackarch-recon')
 arch=('any')
@@ -29,7 +29,7 @@ package() {
 
   cd $_npmdir
 
-  npm install --user root -g --prefix "$pkgdir/usr" pwned@
+  npm install -g --prefix "$pkgdir/usr" pwned@
   rm -rf "$_npmdir/root"
 
   cd "$srcdir/pwned"

--- a/packages/retire/PKGBUILD
+++ b/packages/retire/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=retire
 _pkgname=retire.js
 pkgver=5.4.3.r23.g24fe8f4
-pkgrel=1
+pkgrel=2
 pkgdesc='Scanner detecting the use of JavaScript libraries with known vulnerabilities.'
 arch=('any')
 groups=('blackarch' 'blackarch-scanner' 'blackarch-code-audit')
@@ -35,7 +35,7 @@ package() {
 
   cd "$_npmdir"
 
-  npm install --user root -g --prefix "$pkgdir/usr" "$pkgname@"
+  npm install -g --prefix "$pkgdir/usr" "$pkgname@"
   rm -rf "$_npmdir/root"
 
   cd "$srcdir/$_pkgname"

--- a/packages/shuji/PKGBUILD
+++ b/packages/shuji/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=shuji
 pkgver=v0.8.0.r118.g498fe89
-pkgrel=1
+pkgrel=2
 pkgdesc='Reverse engineering JavaScript and CSS sources from sourcemaps.'
 arch=('any')
 groups=('blackarch' 'blackarch-decompiler')
@@ -35,7 +35,7 @@ package() {
 
   cd "$_npmdir"
 
-  npm install --user root -g --prefix "$pkgdir/usr" "$pkgname@"
+  npm install -g --prefix "$pkgdir/usr" "$pkgname@"
 
   cd "$srcdir/$pkgname"
 

--- a/packages/viproy-voipkit/PKGBUILD
+++ b/packages/viproy-voipkit/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=viproy-voipkit
 pkgver=82.52b27db
-pkgrel=5
+pkgrel=6
 epoch=1
 pkgdesc='VoIP Pen-Test Kit for Metasploit Framework.'
 groups=('blackarch' 'blackarch-exploitation' 'blackarch-fuzzer'
@@ -31,11 +31,6 @@ package() {
   install -dm 755 "$pkgdir/usr/share/$pkgname/modules/auxiliary/spoof/cisco"
   install -dm 755 "$pkgdir/usr/share/$pkgname/lib/msf/core/auxiliary"
   install -dm 755 "$pkgdir/usr/share/$pkgname/modules/auxiliary/voip"
-
-  install -dm 755 "$pkgdir/usr/share/metasploit/lib/rex/proto/sip"
-  install -dm 755 "$pkgdir/usr/share/metasploit/lib/msf/core/auxiliary"
-  install -dm 755 "$pkgdir/usr/share/metasploit/modules/auxiliary/scanner/sip"
-  install -dm 755 "$pkgdir/usr/share/doc/metasploit/$pkgname"
 
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
   install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"

--- a/packages/wssip/PKGBUILD
+++ b/packages/wssip/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=wssip
 pkgver=75.56d0d2c
-pkgrel=5
+pkgrel=6
 groups=('blackarch' 'blackarch-webapp' 'blackarch-proxy')
 pkgdesc='Application for capturing, modifying and sending custom WebSocket data from client to server and vice versa.'
 url='https://github.com/nccgroup/wssip'
@@ -30,8 +30,8 @@ package() {
 
   cd $_npmdir
 
-  npm install --user root -g --prefix "$pkgdir/usr" electron@1.7
-  npm install --user root -g --prefix "$pkgdir/usr" wssip@
+  npm install -g --prefix "$pkgdir/usr" electron@1.7
+  npm install -g --prefix "$pkgdir/usr" wssip@
 
   mv "$pkgdir/usr/bin/electron" "$pkgdir/usr/bin/electron-1.7"
 


### PR DESCRIPTION
## Summary

- Add the libsoup 2 compatibility package required by `webkit2gtk`.
- Remove obsolete `npm --user root` arguments that created conflicting `root` modules.
- Stop `viproy-voipkit` from owning paths belonging to `metasploit`.
- Bump affected package release numbers.

## Testing

- Validated all changed PKGBUILDs with `bash -n` and `makepkg --printsrcinfo`.
- Successfully built and inspected `padoracle` and `viproy-voipkit`.
- Verified the libsoup sources and checksums with `makepkg --verifysource`.

Fixes #4960