### PR TITLE
Fix and update multiple Python packages

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,10 @@
+pyinstaller
+python-selenium
+python-blis
+python-catalogue
+python-preshed
+python-spacy
+python-srsly
+python-thinc
+python-confection
+python-weasel

--- a/packages/pyinstaller/PKGBUILD
+++ b/packages/pyinstaller/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=pyinstaller
-pkgver=6.20.0
+pkgver=6.21.0
 pkgrel=1
 epoch=2
 groups=('blackarch' 'blackarch-misc')
@@ -20,7 +20,7 @@ makedepends=(
 )
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz"
         'fortify-source-fix.patch')
-sha512sums=('dfee9c5a7a126d0eedd7cca82df83a9939f99c5fdfb86e64346fe4850869c89cbc16430665c678c458f3d2d4a1bbe6d1a8fa80bb31e166d06251e7b500dce878'
+sha512sums=('025329d562f73215fbdf7dcb1873a2493657accd6ffadaf590f734ae430cf84cd0372490513a25a3475566c762596d8c05669d375c63d4b670eb6a3c355ec7a6'
             '765a2f0c984d966c27309194e73a50b325309c5e65253c92a7140d8b179f94394dd0e01aa1b46b3777a1a06da33ce92919070dd70fde87bf5d81eb750d73f5ed')
 options=('!strip' '!emptydirs')
 

--- a/packages/python-blis/PKGBUILD
+++ b/packages/python-blis/PKGBUILD
@@ -4,25 +4,28 @@
 pkgname=python-blis
 _pkgname=blis
 pkgver=1.3.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Blis linear algebra routines as a self-contained Python C-extension.'
 arch=('x86_64' 'aarch64')
 url='https://pypi.org/project/blis/'
 license=('MIT')
 depends=('python' 'python-pytest' 'python-hypothesis')
-makedepends=('python-setuptools' 'cython' 'python-numpy')
+makedepends=('python-setuptools' 'python-build' 'python-wheel'
+             'python-installer' 'cython' 'python-numpy')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
 sha512sums=('a65baa02cc07da67f11006e37a4a0571042dab959215a5019627d3f96cf81e27f12aa8f33a2999e962bc978d83c0f78c947437af0db501dec5f57de9c0d93d7b')
 
 build() {
   cd "$_pkgname-$pkgver"
 
-  python setup.py build
+  export BLIS_ARCH="generic"
+
+  python -m build --wheel --no-isolation
 }
 
 package() {
   cd "$_pkgname-$pkgver"
 
-  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+  python -m installer --destdir="$pkgdir" dist/*.whl
 }
 

--- a/packages/python-catalogue/PKGBUILD
+++ b/packages/python-catalogue/PKGBUILD
@@ -3,28 +3,30 @@
 
 pkgname=python-catalogue
 _pkgname=catalogue
-pkgver=2.1.0
-pkgrel=8
+pkgver=2.0.10
+pkgrel=1
+epoch=1
 pkgdesc='Library that makes it easy to add function (or object) registries to your code.'
 arch=('any')
 url='https://pypi.org/project/catalogue/'
 license=('MIT')
 depends=('python' 'python-pytest' 'python-zipp' 'python-typing_extensions'
          'mypy')
-makedepends=('python-setuptools')
+makedepends=('python-setuptools' 'python-build' 'python-wheel'
+             'python-installer')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('d12b02d626d04c4be771b9160555506096e8101d0903f40b9ae363726ad699f2700225a8dc9ab58f955e14d322ba91af6a83e71f6d23ebd5a314db262d2d8c46')
+sha512sums=('5c22d0c907cef3d0282ee625b76cc6d49129c65cdf8d8750647a35a9c593746854f9697302d274c468be1f593405ad1bc51be638f3168daac627f3f246c17b8d')
 
 build() {
   cd "$_pkgname-$pkgver"
 
-  python setup.py build
+  python -m build --wheel --no-isolation
 }
 
 package() {
   cd "$_pkgname-$pkgver"
 
-  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+  python -m installer --destdir="$pkgdir" dist/*.whl
 
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
 }

--- a/packages/python-confection/PKGBUILD
+++ b/packages/python-confection/PKGBUILD
@@ -1,0 +1,29 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=python-confection
+_pkgname=confection
+pkgver=1.3.3
+pkgrel=1
+pkgdesc='The sweetest config system for Python.'
+arch=('x86_64' 'aarch64')
+url='https://github.com/explosion/confection'
+license=('MIT')
+depends=('python')
+makedepends=('python-build' 'python-installer' 'python-setuptools'
+             'python-wheel')
+source=("https://github.com/explosion/confection/archive/refs/tags/release-v$pkgver.tar.gz")
+sha512sums=('7d7b2496fc73428636e626c2b544eb8f88c327fded632502e98b4a326dc6f396cfbf9de5f9a4939abd94d30b8cb625d9a0dce45a667fd25b38988ccb1ad3192a')
+
+build() {
+  cd "$_pkgname-release-v$pkgver"
+
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "$_pkgname-release-v$pkgver"
+
+  python -m installer --destdir="$pkgdir" dist/*.whl
+}
+

--- a/packages/python-preshed/PKGBUILD
+++ b/packages/python-preshed/PKGBUILD
@@ -3,26 +3,28 @@
 
 pkgname=python-preshed
 _pkgname=preshed
-pkgver=4.0.0
-pkgrel=5
+pkgver=3.0.13
+pkgrel=1
+epoch=1
 pkgdesc='Simple but high performance Cython hash table mapping pre-randomized keys to void* values.'
 arch=('x86_64' 'aarch64')
 url='https://pypi.org/project/preshed/'
 license=('MIT')
 depends=('python' 'python-cymem' 'python-murmurhash' 'cython')
-makedepends=('python-setuptools' 'python-wheel' 'python-pip')
+makedepends=('python-setuptools' 'python-wheel' 'python-installer'
+             'python-build')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('51383b0417660cfdf843bbce968434e9be2401b6dd32f430c11dade8fd76288afc648098896da856cf75d72af91053a7d796fe9c5451e166deb8a7db65e1caf3')
+sha512sums=('27568dc2d77fd58e0a85e6d276ca6752a3c2f331d1e5c9899e4304ccc05e6bfaeb608c92ca328c4e8a66b59a29e57e3291953ce43d7e3e70d28c1718138d42f2')
 
 build() {
   cd "$_pkgname-$pkgver"
 
-  python setup.py build
+  python -m build --wheel --no-isolation
 }
 
 package() {
   cd "$_pkgname-$pkgver"
 
-  python setup.py install --root="$pkgdir" --prefix=/usr -O1 --skip-build
+  python -m installer --destdir="$pkgdir" dist/*.whl
 }
 

--- a/packages/python-selenium/PKGBUILD
+++ b/packages/python-selenium/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=python-selenium
 _pkgname=selenium
-pkgver=4.44.0
+pkgver=4.45.0
 pkgrel=1
 pkgdesc='Official Python bindings for Selenium WebDriver.'
 arch=('x86_64' 'aarch64')
@@ -18,7 +18,7 @@ makedepends=('python-setuptools' 'python-build' 'python-wheel'
              'python-installer' 'python-setuptools-rust')
 optdepends=('geckodriver: Firefox driver support')
 source=("https://pypi.io/packages/source/s/selenium/selenium-$pkgver.tar.gz")
-sha512sums=('72dabe202620ed29c9f66936827c257adf44d2f7c98a39724b1d2ef99fd7819875877f2d3cd2b1086f9e544a1f29bb3df6aa516ff8670f3701469b2ce75f5856')
+sha512sums=('e67a731e93d172c0e1029656fdb06d4af808ccae3649fee85ba94f519da2407799b5d4a344c7334e0ce419031017493f83fd5fe82583d41060aeba49c369ff7a')
 
 build() {
   cd "$_pkgname-$pkgver"

--- a/packages/python-spacy/PKGBUILD
+++ b/packages/python-spacy/PKGBUILD
@@ -2,41 +2,32 @@
 # See COPYING for license details.
 
 pkgname=python-spacy
-_pkgname=spacy
-pkgver=3.8.11
+_pkgname=spaCy
+pkgver=3.8.14
 pkgrel=1
 pkgdesc='Industrial-strength Natural Language Processing (NLP) in Python.'
 arch=('x86_64' 'aarch64')
-url='https://pypi.org/project/spacy/#files'
+url='https://github.com/explosion/spaCy'
 license=('MIT')
 depends=('python-catalogue' 'python-cymem' 'python-jinja' 'python-murmurhash'
          'python-numpy' 'python-pathlib' 'python-plac' 'python-preshed'
          'python-regex' 'python-requests' 'python-srsly' 'python-thinc'
-         'python-tqdm' 'python-typer' 'python-ujson' 'python-wasabi')
-makedepends=('python-pip' 'python-build' 'python-wheel' 'cython')
-source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('a63ae83b8c880354974fc935f529627cf599e30c6b7cafa4faac627177bd30df12c1768303f0795947cbefe1bcc4c0edd60ae2bbeaf7fc367d8e89f4aec46edf')
+         'python-tqdm' 'python-typer' 'python-ujson' 'python-wasabi'
+         'python-weasel')
+makedepends=('python-installer' 'python-build' 'python-wheel' 'cython'
+             'python-setuptools' 'python-confection')
+source=("https://github.com/explosion/spaCy/archive/refs/tags/release-v$pkgver.tar.gz")
+sha512sums=('25fdc6b39d24cde41ee7165a4d32c339227c23a6488ff8718329a64a4e1b24da567f87899b027737537dbd072dd731c0d3183469f2cc513f00274d9824f89fd5')
 
 build() {
-  cd "$_pkgname-$pkgver"
+  cd "$_pkgname-release-v$pkgver"
 
-  python -m build --wheel --outdir="$startdir/dist"
+  python -m build --wheel --no-isolation
 }
 
 package() {
-  cd "$_pkgname-$pkgver"
+  cd "$_pkgname-release-v$pkgver"
 
-  pip install \
-    --verbose \
-    --disable-pip-version-check \
-    --no-warn-script-location \
-    --ignore-installed \
-    --no-compile \
-    --no-deps \
-    --root="$pkgdir" \
-    --prefix=/usr \
-    --no-index \
-    --find-links="file://$startdir/dist" \
-    $_pkgname
+  python -m installer --destdir="$pkgdir" dist/*.whl
 }
 

--- a/packages/python-srsly/PKGBUILD
+++ b/packages/python-srsly/PKGBUILD
@@ -3,8 +3,9 @@
 
 pkgname=python-srsly
 _pkgname=srsly
-pkgver=3.0.0
+pkgver=2.5.3
 pkgrel=1
+epoch=1
 pkgdesc='Modern high-performance serialization utilities for Python.'
 arch=('x86_64' 'aarch64')
 url='https://pypi.org/project/srsly/'
@@ -13,28 +14,17 @@ depends=('python' 'cython' 'python-catalogue' 'python-pytest'
          'python-pytest-timeout' 'python-pytz' 'python-mock' 'python-numpy')
 makedepends=('python-build' 'python-pip')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('8fb67e460aba393b2510bf45278479914721010ccb3a3b400caa2578d776895e319d412387d148e2c32500be55de1c0fc550c9eb53d8fc95aaf09a2de4585bf8')
+sha512sums=('5f8ef2645cd3f8d777165cb73432ce273d0ea9b96d36d116c212660bd1bab426aeb1a9cb55e35a80cfb8ed02e48333f1b8c4b45aa9180d6b9ac7d5bc5049516e')
 
 build() {
   cd "$_pkgname-$pkgver"
 
-  python -m build --wheel --outdir="$startdir/dist"
+  python -m build --wheel --no-isolation
 }
 
 package() {
   cd "$_pkgname-$pkgver"
 
-	pip install \
-    --verbose \
-    --disable-pip-version-check \
-    --no-warn-script-location \
-    --ignore-installed \
-    --no-compile \
-    --no-deps \
-    --root="$pkgdir" \
-    --prefix=/usr \
-    --no-index \
-    --find-links="file://$startdir/dist" \
-    $_pkgname
+  python -m installer --destdir="$pkgdir" dist/*.whl
 }
 

--- a/packages/python-thinc/PKGBUILD
+++ b/packages/python-thinc/PKGBUILD
@@ -3,8 +3,9 @@
 
 pkgname=python-thinc
 _pkgname=thinc
-pkgver=9.1.1
-pkgrel=4
+pkgver=8.3.13
+pkgrel=1
+epoch=1
 pkgdesc='Practical Machine Learning for NLP.'
 arch=('x86_64' 'aarch64')
 url='https://pypi.org/project/thinc/'
@@ -13,30 +14,20 @@ depends=('python' 'python-cymem' 'python-blis' 'python-catalogue'
          'python-hypothesis' 'python-mock' 'python-murmurhash' 'python-numpy'
          'python-pathlib' 'python-plac' 'python-preshed' 'python-pydantic'
          'python-six' 'python-srsly' 'python-tqdm' 'python-wasabi')
-makedepends=('python-pip' 'python-build' 'python-wheel')
+makedepends=('python-installer' 'python-build' 'python-wheel'
+             'python-setuptools')
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('098b344c424235c0e790bb7058dc4b3cb92e160f24488209c8b852b04e630488168ea052e3749b14c039f3618d47ec59a5e24f03e73062c342f720b3dc191768')
+sha512sums=('21bc07a37a9f7581fd1be9de09b64f9194b08018af86a06f397f93aa18f93504c249ff87db9aee8d9f8bc593604e37befa5fba4a0d608fd0c38f2ca7cf76c2e2')
 
 build() {
   cd "$_pkgname-$pkgver"
 
-  python -m build --wheel --outdir="$startdir/dist"
+  python -m build --wheel --no-isolation
 }
 
 package() {
   cd "$_pkgname-$pkgver"
 
-  pip install \
-    --verbose \
-    --disable-pip-version-check \
-    --no-warn-script-location \
-    --ignore-installed \
-    --no-compile \
-    --no-deps \
-    --root="$pkgdir" \
-    --prefix=/usr \
-    --no-index \
-    --find-links="file://$startdir/dist" \
-    $_pkgname
+  python -m installer --destdir="$pkgdir" dist/*.whl
 }
 

--- a/packages/python-weasel/PKGBUILD
+++ b/packages/python-weasel/PKGBUILD
@@ -1,0 +1,27 @@
+pkgname=python-weasel
+_pkgname=weasel
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="A small and easy workflow system"
+url="https://github.com/explosion/weasel/"
+depends=('python-confection' 'python-wasabi' 'python-srsly' 'python-typer'
+         'python-httpx' 'python-pydantic')
+makedepends=('python-build' 'python-installer' 'python-setuptools'
+             'python-wheel')
+license=('MIT')
+arch=('any')
+source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('3160e6b33dd82d81c7f84528ac47f6d89e87448575c6d445daa8acb96be09f1509a404068bacf5a66f2f7df2afcb133ee90475fdf1a6c32f7ea5b53231af1278')
+
+build() {
+    cd $_pkgname-$pkgver
+
+    python -m build --wheel --no-isolation
+}
+
+package() {
+    cd $_pkgname-$pkgver
+
+    python -m installer --destdir="$pkgdir" dist/*.whl
+}
+


### PR DESCRIPTION
- Update pyinstaller, python-selenium and python-spacy
- Fix python-blis using BLIS_ARCH
- Regression: Downgrade python-catalogue, python-preshed, python-srsly and python-thinc
- Add python-confection and python-weasel
- Fix multiple depends and makedepends
- Migrating from pip or setup.py to python-installer

The downgrades are justified by the fact that the versions used were removed from PyPi and GitHub because they contained multiple bugs, and the Explosion team decided to continue using the previous branches and release new versions even as late as 2026.

## Before submitting, please select the type of PR you are opening

- [x] 📦 New tool/library submission

# 📦 New tool/library submission

## Before submitting, please read the requirements

> **🚫 Illegal or unethical software:**
> Examples include brute-forcing social media accounts or DoS attack scripts.

> **🚫 Abandoned or extremely outdated software:**
> Especially if it no longer builds, creates dependency conflicts, or has no active upstream maintenance.

> **🚫 Deprecated languages or libraries dependency:**
> For example, Python 2 or other retired technologies that introduce security or compatibility issues.

> **🚫 Wrapper scripts with no unique functionality:**
> Scripts that simply call another tool with preset arguments (e.g., a front-end that just runs `nmap -sV ...`).

> **🚫 Non-portable or broken build systems:**
> Tools tied to a specific non-Arch distribution or that cannot be cleanly built on Arch/BlackArch.

> **🚫 Duplicate functionality:**
> Tools already covered by better-maintained or more widely-used alternatives in the repository.

> **🚫 Unnecessary anonymization helpers:**
> Scripts such as "free VPN launcher" tools. BlackArch already includes **torctl** for legitimate anonymization.

> **🚫 PKGBUILD does not follow official templates:**
> Submissions must follow the official PKGBUILD templates available in the [BlackArch PKGBUILDs repository](https://github.com/BlackArch/blackarch-pkgbuilds). PRs that deviate significantly from the templates will be rejected or sent back for revision.

### Package name
<!-- Indicate the name of the package as it will appear in the BlackArch repository -->
python-confection
python-weasel

### Description
<!-- Clear and concise description of what the tool does and what security use case it addresses -->
Confection: the sweetest config system for Python 
weasel: A small and easy workflow system 

### Source URL
<!-- Link to the tool's upstream source code repository -->
https://github.com/explosion/confection
https://github.com/explosion/weasel

### License
<!-- Indicate the tool's license, e.g. MIT, GPL-3.0. If there is no license or source is not public, indicate "custom" -->
MIT


### Checklist

- [x] I assert that this tool is not already available in BlackArch or the official [Arch Linux repositories](https://archlinux.org/packages/).
- [x] I assert that this is not a duplicate of an [existing open PR](https://github.com/BlackArch/blackarch/pulls?q=is%3Aopen).
- [x] I assert that I have successfully tested, built and installed the package locally.
- [x] I assert that the PKGBUILD follows the official [BlackArch PKGBUILD templates](https://github.com/BlackArch/blackarch-pkgbuilds).
- [x] I assert that the tool is actively maintained upstream and does not depend on deprecated languages or libraries.
- [x] I assert that I have read the [Arch Linux Code of Conduct](https://terms.archlinux.org/docs/code-of-conduct/) and agree to abide by it.

