### PR TITLE
fix(webkit2gtk): switch to libsoup3 and remove USE_SOUP2

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,1 +1,2 @@
 x3270
+webkit2gtk

--- a/packages/webkit2gtk/PKGBUILD
+++ b/packages/webkit2gtk/PKGBUILD
@@ -9,7 +9,7 @@
 pkgbase=webkit2gtk
 pkgname=('webkit2gtk' 'webkit2gtk-docs')
 pkgver=2.50.6
-pkgrel=2
+pkgrel=3
 pkgdesc='Web content engine for GTK.'
 url='https://webkitgtk.org/'
 arch=('x86_64' 'aarch64')
@@ -26,7 +26,7 @@ depends=('at-spi2-core' 'atk' 'bubblewrap' 'cairo' 'enchant' 'expat'
          'harfbuzz' 'harfbuzz-icu' 'hyphen' 'icu' 'lcms2' 'libatomic' 'libavif'
          'libdrm' 'libegl' 'libepoxy' 'libgcc' 'libgcrypt' 'libgl' 'libgles'
          'libjpeg-turbo' 'libjxl' 'libmanette' 'libpng' 'libseccomp' 'libsecret'
-         'libsoup' 'libstdc++' 'libsystemd' 'libtasn1' 'libwebp' 'libx11'
+         'libsoup3' 'libstdc++' 'libsystemd' 'libtasn1' 'libwebp' 'libx11'
          'libxml2' 'libxslt' 'mesa' 'openjpeg2' 'pango' 'sqlite' 'ttf-font'
          'wayland' 'woff2' 'xdg-dbus-proxy' 'zlib')
 makedepends=('clang' 'cmake' 'gi-docgen' 'glib2-devel' 'gobject-introspection'
@@ -49,7 +49,6 @@ build() {
     -D USE_FLITE=OFF
     -D USE_GTK4=OFF
     -D USE_LIBBACKTRACE=OFF
-    -D USE_SOUP2=ON
   )
 
   # Upstream prefers Clang


### PR DESCRIPTION
- [ ] 📦 New tool/library submission
- [ ] 🕸️ New mirror submission

## Summary

This PR updates the `webkit2gtk` PKGBUILD to reflect the current Arch Linux
packaging.

### Changes

- replace the `libsoup` dependency with `libsoup3`
- remove the obsolete `USE_SOUP2` CMake option
- bump `pkgrel` from `2` to `3`
- add `webkit2gtk` to `lists/to-release`

`pkgver` remains `2.50.6` as this is only a packaging update.

The previous dependency on `libsoup` is no longer valid on current Arch
systems, and the `USE_SOUP2` build option is no longer needed after the
transition to `libsoup3`.