### PR TITLE
Add nimux

### DIFF
--- a/packages/nimux/PKGBUILD
+++ b/packages/nimux/PKGBUILD
@@ -1,0 +1,40 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=nimux
+pkgver=v1.0.2
+pkgrel=1
+pkgdesc='Pure-Nim network enumeration and remote execution toolkit.'
+arch=('x86_64' 'aarch64')
+groups=('blackarch' 'blackarch-scanner' 'blackarch-networking' 'blackarch-windows' 'blackarch-exploitation')
+url='https://github.com/blue0x1/nimux'
+license=('AGPL-3.0-only')
+depends=('openssl' 'krb5' 'zlib' 'zstd')
+makedepends=('git' 'nim')
+source=("git+https://github.com/blue0x1/nimux.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null |
+      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" \
+      "$(git rev-parse --short=7 HEAD)"
+  )
+}
+
+build() {
+  cd $pkgname
+
+  nim c -d:release --opt:speed -o:nimux src/nimux.nim
+}
+
+package() {
+  cd $pkgname
+
+  install -Dm 755 nimux "$pkgdir/usr/bin/nimux"
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm 644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+}


### PR DESCRIPTION
Adds nimux to BlackArch.

Package details:

- Homepage: https://github.com/blue0x1/nimux
- Website: https://nimux.wiki
- Documentation: https://docs.nimux.wiki
- License: AGPL-3.0-only
- Language: Nim
- Groups: blackarch, blackarch-scanner, blackarch-networking, blackarch-windows, blackarch-exploitation

Description:

nimux is a pure-Nim network enumeration and remote execution toolkit for authorized security assessments. It includes protocol enumeration, SMB and LDAP workflows, Kerberos ticket operations, WinRM and other remote execution paths, SOCKS pivoting, GPO workflows, secrets and DCSync functionality.

Validation performed:

- Direct upstream build command succeeds locally:

```bash
nim c -d:release --opt:speed -o:/tmp/nimux-pkgbuild-test /home/katana/nim/src/nimux.nim
```

- PKGBUILD syntax check succeeds:

```bash
bash -n packages/nimux/PKGBUILD
```

- Full package build succeeds in a disposable Arch Linux container:

```bash
makepkg --noconfirm --syncdeps --cleanbuild
```

Arch container result:

- Finished making: nimux v1.0.2.r4.g52c0dbb-1
- Package artifacts created successfully, including nimux and nimux-debug
