### PR TITLE
Pinning github actions to sha hashes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           pacman -Syu --noconfirm --needed git pkgcheck-arch nodejs # 'node' needed to test workflow locally by act
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7 
         with:
           ref: ${{ env.HEAD_REF }}
           repository: ${{ env.HEAD_REPO }}
@@ -50,7 +50,7 @@ jobs:
   build:
      runs-on: ubuntu-latest
      steps:
-       - uses: actions/checkout@v5
+       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
          with:
            ref: ${{ env.HEAD_REF }}
            repository: ${{ env.HEAD_REPO }}


### PR DESCRIPTION
Recommended to use sha hashes instead of versions.
See https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide for more details.