### PR TITLE
proxelar: initial commit

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+proxelar

--- a/packages/proxelar/PKGBUILD
+++ b/packages/proxelar/PKGBUILD
@@ -9,8 +9,8 @@ arch=('x86_64' 'aarch64')
 groups=('blackarch' 'blackarch-proxy' 'blackarch-sniffer' 'blackarch-networking')
 url='https://github.com/emanuele-em/proxelar'
 license=('MIT')
-depends=('openssl' 'pkgconf')
-makedepends=('git' 'cargo')
+depends=('gcc-libs' 'glibc')
+makedepends=('git' 'cargo' 'perl')
 source=("git+https://github.com/emanuele-em/$pkgname.git")
 sha512sums=('SKIP')
 

--- a/packages/proxelar/PKGBUILD
+++ b/packages/proxelar/PKGBUILD
@@ -1,0 +1,40 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=proxelar
+pkgver=v0.5.0.r0.g764a162
+pkgrel=1
+pkgdesc='Scriptable MITM proxy to inspect, intercept, replay and rewrite HTTP/HTTPS and WebSocket traffic, with TUI, web GUI and Lua scripting.'
+arch=('x86_64' 'aarch64')
+groups=('blackarch' 'blackarch-proxy' 'blackarch-sniffer' 'blackarch-networking')
+url='https://github.com/emanuele-em/proxelar'
+license=('MIT')
+depends=('openssl' 'pkgconf')
+makedepends=('git' 'cargo')
+source=("git+https://github.com/emanuele-em/$pkgname.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+  cd $pkgname
+
+  # https://archlinux.org/todo/lto-fat-objects/
+  CFLAGS+=" -ffat-lto-objects"
+
+  cargo build --release --locked
+}
+
+package() {
+  cd $pkgname
+
+  install -Dm 755 "target/release/$pkgname" "$pkgdir/usr/bin/$pkgname"
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md CHANGELOG.md
+  install -Dm 644 LICENSE-MIT "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+  cp -a examples/ "$pkgdir/usr/share/doc/$pkgname/"
+}

--- a/packages/proxelar/PKGBUILD
+++ b/packages/proxelar/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=proxelar
-pkgver=v0.5.0.r0.g764a162
+pkgver=0.5.1.r0.gdce799f
 pkgrel=1
 pkgdesc='Scriptable MITM proxy to inspect, intercept, replay and rewrite HTTP/HTTPS and WebSocket traffic, with TUI, web GUI and Lua scripting.'
 arch=('x86_64' 'aarch64')
@@ -17,7 +17,12 @@ sha512sums=('SKIP')
 pkgver() {
   cd $pkgname
 
-  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null |
+      sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" \
+      "$(git rev-parse --short=7 HEAD)"
+  )
 }
 
 build() {


### PR DESCRIPTION
Adds [proxelar](https://github.com/emanuele-em/proxelar), a scriptable MITM proxy to inspect, intercept, replay, and rewrite HTTP/HTTPS and WebSocket traffic. Single Rust binary with TUI, web GUI, headless REST API, and Lua scripting; MIT licensed. Useful for traffic analysis and web app testing workflows (forward/reverse/WireGuard/SOCKS5/DNS/UDP capture modes, HAR import/export, request editing and replay).

- PKGBUILD follows the feroxbuster template (git source with `pkgver()` from `git describe`, cargo build `--locked`)
- `openssl`/`pkgconf` runtime deps come from `openssl-sys` in the dependency tree
- Added `proxelar` to `lists/to-release`
- I am the upstream author; happy to adjust groups or packaging style as you prefer