### PR TITLE
user-scanner: update version (upstream hotfix release)

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+user-scanner

--- a/packages/user-scanner/PKGBUILD
+++ b/packages/user-scanner/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=user-scanner
-pkgver=1.4.3
+pkgver=1.4.3.1
 pkgrel=1
 pkgdesc='OSINT tool that analyzes username and email presence across multiple platforms, intended for security research, investigations, legitimate analysis.'
 arch=('any')
@@ -14,7 +14,7 @@ depends=('python' 'python-httpx' 'python-socksio' 'python-colorama'
 makedepends=('python-build' 'python-installer' 'python-setuptools'
              'python-wheel' 'python-flit-core')
 source=("$url/archive/refs/tags/v$pkgver.tar.gz")
-sha512sums=('e397c4293cfb2d0e48af9ee81b0f61172452c84a8f9fa8fecf7404abbfa39f2eee7bdd2a7ea0e6bbb771fa1502504f315c420b453d83393cf01f1998bae9643e')
+sha512sums=('439766a73fe596e753e4745f5e5c47dee2de02798a413c5dd4b4a3a11e16e30ce9d91968faa71e8b7649c34132cefde9c2d20e059802df07e7e97ff8d4b89330')
 
 prepare() {
   cd "$pkgname-$pkgver"


### PR DESCRIPTION
Update user-scanner to 1.4.3.1, 

From user-scanner:

> ⚠️ CRITICAL HOTFIX RELEASE
> This is an urgent point-release that fixes a critical bug present in v1.4.3. All end-users, package maintainers (Arch Linux, Nixpkgs etc.), and OSINT platforms/threat intel services wrapping user-scanner into automated pipelines are strongly advised to update to v1.4.3.1 immediately.


https://github.com/kaifcodec/user-scanner/releases/tag/v1.4.3.1