### PR TITLE
barch-rankmirrors: add package

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+barch-rankmirrors

--- a/packages/barch-rankmirrors/PKGBUILD
+++ b/packages/barch-rankmirrors/PKGBUILD
@@ -1,0 +1,44 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=barch-rankmirrors
+pkgver=1.0.0
+pkgrel=1
+pkgdesc='Rank BlackArch pacman mirrors by real reachability and latency'
+arch=('x86_64' 'aarch64')
+groups=('blackarch' 'blackarch-automation')
+url='https://github.com/5pyd3r-labs/blackarch-rankmirrors'
+license=('GPL-3.0-or-later')
+depends=()
+makedepends=('git' 'go')
+source=("blackarch-rankmirrors::git+https://github.com/5pyd3r-labs/blackarch-rankmirrors.git")
+sha512sums=('SKIP')
+
+pkgver() {
+    cd blackarch-rankmirrors
+    ( set -o pipefail
+      git describe --long --tags --abbrev=7 2>/dev/null |
+      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+      printf "%s.%s" "$(git rev-list --count HEAD)" \
+        "$(git rev-parse --short=7 HEAD)"
+    )
+}
+
+build() {
+    cd blackarch-rankmirrors
+    GOPATH="$srcdir" go build \
+        -trimpath \
+        -buildmode=pie \
+        -mod=readonly \
+        -modcacherw \
+        -ldflags "-s -w" \
+        -o $pkgname ./cmd/barch-rankmirrors
+}
+
+package() {
+    cd blackarch-rankmirrors
+    install -Dm 755 $pkgname "$pkgdir/usr/bin/$pkgname"
+    install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README
+    install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+

--- a/packages/barch-rankmirrors/PKGBUILD
+++ b/packages/barch-rankmirrors/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=barch-rankmirrors
-pkgver=1.0.0
+pkgver=1.2.0.r0.g323f9f2
 pkgrel=1
 pkgdesc='Rank BlackArch pacman mirrors by real reachability and latency'
 arch=('x86_64' 'aarch64')

--- a/packages/barch-rankmirrors/PKGBUILD
+++ b/packages/barch-rankmirrors/PKGBUILD
@@ -11,7 +11,7 @@ url='https://github.com/5pyd3r-labs/blackarch-rankmirrors'
 license=('GPL-3.0-or-later')
 depends=()
 makedepends=('git' 'go')
-source=("blackarch-rankmirrors::git+https://github.com/5pyd3r-labs/blackarch-rankmirrors.git")
+source=("git+https://github.com/5pyd3r-labs/blackarch-rankmirrors.git")
 sha512sums=('SKIP')
 
 pkgver() {

--- a/packages/barch-rankmirrors/PKGBUILD
+++ b/packages/barch-rankmirrors/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=barch-rankmirrors
-pkgver=1.3.0.r0.g93adab7
+pkgver=1.4.0.r0.g4ea6a87
 pkgrel=1
 pkgdesc='Rank BlackArch pacman mirrors by real reachability and latency'
 arch=('x86_64' 'aarch64')

--- a/packages/barch-rankmirrors/PKGBUILD
+++ b/packages/barch-rankmirrors/PKGBUILD
@@ -39,6 +39,5 @@ package() {
     cd blackarch-rankmirrors
     install -Dm 755 $pkgname "$pkgdir/usr/bin/$pkgname"
     install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README
-    install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }
 

--- a/packages/barch-rankmirrors/PKGBUILD
+++ b/packages/barch-rankmirrors/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 pkgname=barch-rankmirrors
-pkgver=1.2.0.r0.g323f9f2
+pkgver=1.3.0.r0.g93adab7
 pkgrel=1
 pkgdesc='Rank BlackArch pacman mirrors by real reachability and latency'
 arch=('x86_64' 'aarch64')

--- a/packages/barch-rankmirrors/PKGBUILD
+++ b/packages/barch-rankmirrors/PKGBUILD
@@ -18,7 +18,7 @@ pkgver() {
     cd blackarch-rankmirrors
     ( set -o pipefail
       git describe --long --tags --abbrev=7 2>/dev/null |
-      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+      sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g' ||
       printf "%s.%s" "$(git rev-list --count HEAD)" \
         "$(git rev-parse --short=7 HEAD)"
     )


### PR DESCRIPTION
## Before submitting, please select the type of PR you are opening

- [x] 📦 New tool/library submission
- [ ] 🕸️ New mirror submission

---
<!-- Fill in ONLY the section that matches your PR type above. Delete the other sections. -->

# 📦 New tool/library submission

## Before submitting, please read the requirements

> **🚫 Illegal or unethical software:**
> Examples include brute-forcing social media accounts or DoS attack scripts.

> **🚫 Abandoned or extremely outdated software:**
> Especially if it no longer builds, creates dependency conflicts, or has no active upstream maintenance.

> **🚫 Deprecated languages or libraries dependency:**
> For example, Python 2 or other retired technologies that introduce security or compatibility issues.

> **🚫 Wrapper scripts with no unique functionality:**
> Scripts that simply call another tool with preset arguments (e.g., a front-end that just runs `nmap -sV ...`).

> **🚫 Non-portable or broken build systems:**
> Tools tied to a specific non-Arch distribution or that cannot be cleanly built on Arch/BlackArch.

> **🚫 Duplicate functionality:**
> Tools already covered by better-maintained or more widely-used alternatives in the repository.

> **🚫 Unnecessary anonymization helpers:**
> Scripts such as "free VPN launcher" tools. BlackArch already includes **torctl** for legitimate anonymization.

> **🚫 PKGBUILD does not follow official templates:**
> Submissions must follow the official PKGBUILD templates available in the [BlackArch PKGBUILDs repository](https://github.com/BlackArch/blackarch-pkgbuilds). PRs that deviate significantly from the templates will be rejected or sent back for revision.

### Package name
barch-rankmirrors


### Description
Fetches, tests, and ranks BlackArch pacman mirrors by real reachability and response time, then optionally writes a curated, ranked mirrorlist directly to /etc/pacman.d/blackarch-mirrorlist. Useful for keeping the mirrorlist current and avoiding slow or unreachable mirrors during pacman -Syu.


### Source URL
https://github.com/5pyd3r-labs/blackarch-rankmirrors


### License
GPL-3.0-or-later


### Tool category
automation


### Additional context
Zero runtime dependencies (Go stdlib only, no cgo). Never writes to disk without --update, never self-elevates privileges (must be invoked with sudo), always backs up the existing mirrorlist before overwriting, and prompts for confirmation before any write unless --force is passed. Concurrent probing (20-worker pool, 5s timeout per mirror), https-only by default with --allow-http to widen scope. Full usage and pipeline details in the repository README.


### Checklist

- [x] I assert that this tool is not already available in BlackArch or the official [Arch Linux repositories](https://archlinux.org/packages/).
- [x] I assert that this is not a duplicate of an [existing open PR](https://github.com/BlackArch/blackarch/pulls?q=is%3Aopen).
- [x] I assert that I have successfully tested, built and installed the package locally.
- [x] I assert that the PKGBUILD follows the official [BlackArch PKGBUILD templates](https://github.com/BlackArch/blackarch-pkgbuilds).
- [x] I assert that the tool is actively maintained upstream and does not depend on deprecated languages or libraries.
- [x] I assert that I have read the [Arch Linux Code of Conduct](https://terms.archlinux.org/docs/code-of-conduct/) and agree to abide by it.
