### PR TITLE
add giskard

### DIFF
--- a/packages/giskard/PKGBUILD
+++ b/packages/giskard/PKGBUILD
@@ -55,3 +55,4 @@ EOF
 
   chmod +x "$pkgdir/usr/bin/$pkgname"
 }
+

--- a/packages/giskard/PKGBUILD
+++ b/packages/giskard/PKGBUILD
@@ -1,0 +1,57 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+# Original Maintainer: Behruz <extreme29@proton.me>
+
+pkgname=giskard
+_pkgname=giskard-oss
+pkgver=2.19.1.r251.g62b07bb
+pkgrel=1
+pkgdesc='Evaluation, testing and vulnerability scanning framework for AI agents.'
+arch=('any')
+groups=('blackarch' 'blackarch-ai')
+url='https://github.com/Giskard-AI/giskard-oss'
+license=('Apache-2.0')
+depends=('python')
+makedepends=('git' 'python-setuptools' 'python-pip')
+source=("git+$url.git")
+sha512sums=('SKIP')
+install="$pkgname.install"
+
+pkgver() {
+  cd "$_pkgname"
+
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 --match 'v*' 2>/dev/null |
+      sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" \
+      "$(git rev-parse --short=7 HEAD)"
+  )
+}
+
+package() {
+  cd "$_pkgname"
+
+  local _lib
+
+  install -dm 755 "$pkgdir/usr/bin" "$pkgdir/usr/share/$pkgname"
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+  install -Dm 644 -t "$pkgdir/usr/share/$pkgname/" \
+    LICENSE README.md pyproject.toml
+  cp -r -- giskard_pypi_shim readme "$pkgdir/usr/share/$pkgname/"
+
+  for _lib in giskard-core giskard-llm giskard-agents giskard-checks \
+    giskard-scan; do
+    install -dm 755 "$pkgdir/usr/share/$pkgname/libs/$_lib"
+    install -Dm 644 -t "$pkgdir/usr/share/$pkgname/libs/$_lib/" \
+      "libs/$_lib/README.md" "libs/$_lib/pyproject.toml"
+    cp -r -- "libs/$_lib/src" "$pkgdir/usr/share/$pkgname/libs/$_lib/"
+  done
+
+  cat > "$pkgdir/usr/bin/$pkgname" << EOF
+#!/bin/sh
+source /usr/share/$pkgname/venv/bin/activate
+exec /usr/share/$pkgname/venv/bin/python "\$@"
+EOF
+
+  chmod +x "$pkgdir/usr/bin/$pkgname"
+}

--- a/packages/giskard/giskard.install
+++ b/packages/giskard/giskard.install
@@ -1,0 +1,35 @@
+post_install() {
+  set -e
+
+  cd /usr/share/giskard
+
+  python -m venv venv
+
+  source venv/bin/activate &&
+    pip install --isolated --root=/usr/share/giskard --prefix=venv \
+      ./libs/giskard-core \
+      ./libs/giskard-llm \
+      ./libs/giskard-agents \
+      ./libs/giskard-checks \
+      ./libs/giskard-scan \
+      .
+}
+
+post_upgrade() {
+  set -e
+
+  cd /usr/share/giskard
+
+  source venv/bin/activate &&
+    pip install --isolated --root=/usr/share/giskard --prefix=venv --upgrade \
+      ./libs/giskard-core \
+      ./libs/giskard-llm \
+      ./libs/giskard-agents \
+      ./libs/giskard-checks \
+      ./libs/giskard-scan \
+      .
+}
+
+post_remove() {
+  rm -rf /usr/share/giskard
+}


### PR DESCRIPTION
Adds Giskard OSS from the upstream git repository.

- Uses tag-filtered git versioning for the monorepo.
- Packages only required installation sources and README assets.
- Tracks the missing v3 beta tag upstream: https://github.com/Giskard-AI/giskard-oss/issues/2717

Tested with makepkg; package contents were inspected.