### PR TITLE
add aidebug

### DIFF
--- a/packages/aidebug/PKGBUILD
+++ b/packages/aidebug/PKGBUILD
@@ -32,3 +32,4 @@ package() {
 
   python -m installer --destdir="$pkgdir" dist/*.whl
 }
+

--- a/packages/aidebug/PKGBUILD
+++ b/packages/aidebug/PKGBUILD
@@ -1,0 +1,34 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+# Original Maintainer: Behruz <extreme29@proton.me>
+
+pkgname=aidebug
+_pkgname=1200km_aidebug
+_pypiname=1200km-aidebug
+pkgver=1.1.0
+pkgrel=1
+pkgdesc='AI-assisted malware reverse-engineering debugger and triage CLI.'
+arch=('any')
+groups=('blackarch' 'blackarch-debugger' 'blackarch-malware'
+        'blackarch-reversing')
+url='https://github.com/anpa1200/AIDebug'
+license=('MIT')
+depends=('python' 'python-anthropic' 'python-capstone' 'python-pefile'
+         'python-pyelftools' 'python-rich' 'python-textual')
+optdepends=('python-frida: dynamic tracing support')
+makedepends=('python-build' 'python-installer' 'python-setuptools'
+             'python-wheel')
+source=("https://files.pythonhosted.org/packages/source/${_pypiname::1}/$_pypiname/$_pkgname-$pkgver.tar.gz")
+sha512sums=('c98380950739ce122ee3bcd42d9f4eefb46c3523ac72f6f905d5658a5af0e84235513d622f2b388d14fedf9c3d0eae1a80b2ffeecf5fced6f7c628b67bd02deb')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  python -m installer --destdir="$pkgdir" dist/*.whl
+}


### PR DESCRIPTION
Adds AIDebug 1.1.0 from the official PyPI source distribution.

Uses the BlackArch PEP 517 setuptools pattern with an isolated-network-free build and python-installer.

Tested with makepkg --nodeps; the source checksum and package contents were verified. python-textual is available in Arch extra.

Closes #4965.