### PR TITLE
medusa-security: initial commit

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+medusa-security

--- a/packages/medusa-security/PKGBUILD
+++ b/packages/medusa-security/PKGBUILD
@@ -1,0 +1,47 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+# Original Maintainer: Behruz <extreme29@proton.me>
+
+pkgname=medusa-security
+_pkgname=medusa
+pkgver=2026.7.0
+pkgrel=1
+pkgdesc='AI-first security scanner for code, AI/ML, LLM agents, MCP and RAG applications.'
+arch=('any')
+groups=('blackarch' 'blackarch-ai' 'blackarch-code-audit'
+        'blackarch-scanner')
+url='https://github.com/Pantheon-Security/medusa'
+license=('AGPL-3.0-or-later')
+depends=('python' 'python-click' 'python-rich' 'python-tqdm' 'python-requests'
+         'python-urllib3' 'python-yaml' 'python-psutil' 'python-defusedxml'
+         'python-tomli-w' 'python-toml' 'python-pathspec')
+makedepends=('python-build' 'python-installer' 'python-setuptools'
+             'python-wheel')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Pantheon-Security/$_pkgname/archive/refs/tags/v$pkgver.tar.gz"
+        'setuptools-compat.patch')
+sha512sums=('dad304c61febc5fc45ee925c3252a400040442df40cc509271eff84b57ec762aed8e17aad1a55ada25523f1716e26b5b43df3223a70881f4c64832b4af7b29f3'
+            '394168d0963584f77c6f2b0a180307369e99ea18a7a8292e94388282fe7ec7d7e20c03894af9a89091c2f1652d79ca3643dabdf67e3702966ccacbd0bb54b425')
+
+prepare() {
+  cd "$_pkgname-$pkgver"
+
+  patch -Np1 -i "$srcdir/setuptools-compat.patch"
+}
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  python -m installer --destdir="$pkgdir" dist/*.whl
+
+  # Avoid collision with Arch's unrelated /usr/bin/medusa package.
+  mv "$pkgdir/usr/bin/medusa" "$pkgdir/usr/bin/medusa-security"
+  sed -i '1s|^#!.*python$|#!/usr/bin/python|' \
+    "$pkgdir/usr/bin/medusa-security"
+}
+

--- a/packages/medusa-security/PKGBUILD
+++ b/packages/medusa-security/PKGBUILD
@@ -42,6 +42,6 @@ package() {
   # Avoid collision with Arch's unrelated /usr/bin/medusa package.
   mv "$pkgdir/usr/bin/medusa" "$pkgdir/usr/bin/medusa-security"
   sed -i '1s|^#!.*python$|#!/usr/bin/python|' \
-    "$pkgdir/usr/bin/medusa-security"
+    "$pkgdir/usr/bin/$pkgname"
 }
 

--- a/packages/medusa-security/PKGBUILD
+++ b/packages/medusa-security/PKGBUILD
@@ -40,7 +40,7 @@ package() {
   python -m installer --destdir="$pkgdir" dist/*.whl
 
   # Avoid collision with Arch's unrelated /usr/bin/medusa package.
-  mv "$pkgdir/usr/bin/medusa" "$pkgdir/usr/bin/medusa-security"
+  mv "$pkgdir/usr/bin/$_pkgname" "$pkgdir/usr/bin/$pkgname"
   sed -i '1s|^#!.*python$|#!/usr/bin/python|' \
     "$pkgdir/usr/bin/$pkgname"
 }

--- a/packages/medusa-security/PKGBUILD
+++ b/packages/medusa-security/PKGBUILD
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 # Original Maintainer: Behruz <extreme29@proton.me>
 
-pkgname=medusa-security
+pkgname=medusa-ai
 _pkgname=medusa
 pkgver=2026.7.0
 pkgrel=1

--- a/packages/medusa-security/setuptools-compat.patch
+++ b/packages/medusa-security/setuptools-compat.patch
@@ -1,0 +1,8 @@
+diff --git a/pyproject.toml b/pyproject.toml
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,3 +1,3 @@
+ [build-system]
+-requires = ["setuptools>=61.0,<75.0", "wheel"]
++requires = ["setuptools>=61.0", "wheel"]
+ build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Before submitting, please select the type of PR you are opening

- [x] 📦 New tool/library submission
- [ ] 🕸️ New mirror submission

---

# 📦 New tool/library submission

### Package name

medusa-security

### Description

AI-first security scanner for code, AI/ML, LLM agents, MCP and RAG applications.

### Source URL

https://github.com/Pantheon-Security/medusa

### License

AGPL-3.0-or-later

### Tool category

code-audit, scanner

### Additional context

Arch already packages an unrelated login brute-forcer as `medusa`. This package installs the Pantheon Security launcher exclusively as `/usr/bin/medusa-security`, so both packages can be installed together without conflicts.

The upstream release pins setuptools below the current Arch version. A minimal patch removes only that obsolete upper bound; the native PEP 517 build otherwise remains unchanged.

Validated with current Arch packages in a clean ephemeral environment: source verification, package build, `pkgcheck`, `namcap`, installation, CLI/version/import checks, installed rule-corpus inspection, an unprivileged offline synthetic scan, coexistence with Arch `medusa`, and removal lifecycle.

### Checklist

- [x] I assert that this tool is not already available in BlackArch or the official [Arch Linux repositories](https://archlinux.org/packages/).
- [x] I assert that this is not a duplicate of an [existing open PR](https://github.com/BlackArch/blackarch/pulls?q=is%3Aopen).
- [x] I assert that I have successfully tested, built and installed the package locally.
- [x] I assert that the PKGBUILD follows the official [BlackArch PKGBUILD templates](https://github.com/BlackArch/blackarch-pkgbuilds).
- [x] I assert that the tool is actively maintained upstream and does not depend on deprecated languages or libraries.
- [x] I assert that I have read the [Arch Linux Code of Conduct](https://terms.archlinux.org/docs/code-of-conduct/) and agree to abide by it.
