### PR TITLE
maigret: build from release tarball and sync dependencies

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,2 @@
+maigret
+python-socid-extractor

--- a/packages/maigret/PKGBUILD
+++ b/packages/maigret/PKGBUILD
@@ -3,27 +3,24 @@
 
 pkgname=maigret
 pkgver=0.6.5
-_pyver=3.14
-pkgrel=1
+pkgrel=2
 epoch=2
 pkgdesc='OSINT username checker. Collect a dossier on a person by username from a huge number of sites.'
 groups=('blackarch' 'blackarch-social' 'blackarch-recon')
 arch=('any')
 url='https://github.com/soxoj/maigret'
 license=('MIT')
-depends=('python' 'python-aiohttp' 'python-aiohttp-socks' 'python-aiodns'
-         'python-arabic-reshaper' 'python-async-timeout' 'python-attrs'
-         'python-beautifulsoup4' 'python-certifi' 'python-chardet'
-         'python-colorama' 'python-dateutil' 'python-future' 'python-idna'
-         'python-future-annotations' 'python-html5lib' 'python-jinja'
-         'python-lxml' 'python-markupsafe' 'python-mock' 'python-multidict'
-         'python-pycountry' 'python-pypdf2' 'python-pysocks' 'python-networkx'
-         'python-python-bidi' 'python-requests' 'python-requests-futures'
-         'python-six' 'python-socid-extractor' 'python-soupsieve' 'python-stem'
-         'python-torrequest' 'python-tqdm' 'python-typing_extensions'
-         'python-webencodings' 'python-xhtml2pdf' 'python-xmind' 'python-yarl'
-         'python-tokenize-rt' 'python-cloudscraper' 'python-alive-progress'
-         'python-curl_cffi')
+depends=('python' 'python-aiodns' 'python-aiohttp' 'python-aiohttp-socks'
+         'python-alive-progress' 'python-asgiref' 'python-certifi'
+         'python-colorama' 'python-curl_cffi' 'python-dateutil' 'python-flask'
+         'python-html5lib' 'python-jinja' 'python-lxml' 'python-markupsafe'
+         'python-networkx' 'python-platformdirs' 'python-pycountry'
+         'python-pysocks' 'python-pyvis' 'python-reportlab' 'python-requests'
+         'python-socid-extractor' 'python-soupsieve' 'python-typing_extensions'
+         'python-xmind' 'python-yarl')
+optdepends=('python-xhtml2pdf: PDF reports (--pdf)'
+            'python-arabic-reshaper: RTL text shaping in PDF reports'
+            'python-python-bidi: RTL text shaping in PDF reports')
 makedepends=('python-build' 'python-pip')
 source=("https://github.com/soxoj/$pkgname/archive/refs/tags/v$pkgver.tar.gz")
 sha512sums=('e33a9e94aac25efdfc8209d58069d4305f27e870a1f68697b50cbef71664fcc33bf397b0d2b09622fb910aae974e2fa0b68c2487190ad6c2cbb51c8b9ff69ccc')
@@ -53,7 +50,7 @@ package() {
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
   install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
-  rm -rf "$pkgdir/usr/lib/python$_pyver/site-packages/utils/" \
-    "$pkgdir/usr/lib/python$_pyver/site-packages/tests"
+  # entry point is utils.update_site_data:main and utils is not packaged
+  rm -f "$pkgdir/usr/bin/update_sitesmd"
 }
 

--- a/packages/python-socid-extractor/PKGBUILD
+++ b/packages/python-socid-extractor/PKGBUILD
@@ -3,19 +3,19 @@
 
 pkgname=python-socid-extractor
 _pkgname=socid_extractor
-pkgver=0.1.0
+pkgver=0.1.1
 _pyver=3.14
 pkgrel=1
 pkgdesc="Extract accounts' identifiers from personal pages on various platforms."
 arch=('any')
 url='https://pypi.org/project/socid-extractor/#files'
-license=('GPL-3.0-or-later')
+license=('MIT')
 depends=('python' 'python-beautifulsoup4' 'python-dateutil' 'python-requests')
 makedepends=('python-build' 'python-installer' 'python-setuptools'
              'python-wheel')
 options=(!emptydirs)
 source=("https://files.pythonhosted.org/packages/source/${_pkgname::1}/$_pkgname/$_pkgname-$pkgver.tar.gz")
-sha512sums=('880b189de689d354a5683170a86d27969c435a902072e667311fff94fe0ff6619fee6039a41e7fad54097568df731cd27282e1d9845473b52929dfb8bd6b2a1c')
+sha512sums=('ec3021c05f490f2ed7d60332150395a5e0cb491b8e3c8a9d3a93ed54156dfc160b1bf2431e40265098c8f5879b969205ec0207c4ed144af0392360832633d175')
 
 build() {
   cd "$_pkgname-$pkgver"
@@ -28,6 +28,7 @@ package() {
 
   python -m installer --destdir="$pkgdir" dist/*.whl
 
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
   rm -rf "$pkgdir/usr/lib/python$_pyver/site-packages/tests/"
 }
-


### PR DESCRIPTION
The current maigret package builds from git master, and its depends array is
still the one from maigret ~0.4. A bunch of the listed packages aren't used
anymore (python-pypdf2, python-torrequest, python-stem, python-cloudscraper,
python-requests-futures, python-future-annotations, python-tqdm, python-six,
python-mock), and most of the real runtime deps are missing.

~~The one that actually breaks things is curl_cffi, which maigret/checking.py
imports at module level, so the package can't be imported at all right now.
There's no python-curl-cffi in [extra] or the AUR (only a -git variant), so I
added it here, installed from the upstream manylinux wheel. Building from
source needs a curl-impersonate package that doesn't exist in [extra], and the
wheel links libcurl-impersonate statically. Same wheel + noextract approach as
packages/python-pyvis.~~

**Correction, striking the paragraph above rather than quietly rewriting it:** `python-curl_cffi` *does* exist in `[extra]`, version 0.16.0-2, spelled with an underscore to match the PyPI module name. I searched for `python-curl-cffi` with a hyphen, found nothing, and packaged a duplicate on that basis. The new package is removed from this PR and maigret now simply depends on `python-curl_cffi`. This PR is now two packages instead of three.

python-socid-extractor is bumped 0.1.0 -> 0.1.1 because maigret needs >=0.1.1.
Its license has been MIT since 0.1.1, so I fixed that as well.

For maigret itself: source is the 0.6.4 PyPI sdist instead of git master,
depends synced with pyproject.toml, PDF deps moved to optdepends (they're an
optional extra upstream), pip install replaced with python -m installer. I also
dropped the _pyver hardcode and the rm -rf of utils/ and tests/, since the
wheel only ships maigret/.

I checked changes in a clean archlinux:base-devel container with the BlackArch
repo enabled. ~~All three build~~ Both packages build, every declared dep resolves, and the result runs:

    $ maigret --version
    maigret 0.6.4
    Socid-extractor:  0.1.1
    Python:  3.14.7

    $ maigret --site GitHub --no-recursion soxoj
    [+] Using sites database: .../resources/data.json (3221 sites)
    [+] GitHub: https://github.com/soxoj

Re-verified after dropping the duplicate package: `python-curl_cffi 0.16.0-2` is pulled from `[extra]`, both packages build, and maigret runs as an unprivileged user rather than as root.

vercmp 1:0.6.4-1 1:main.r46.gb90cdb1-2 returns 1, so no epoch bump needed.

I'm the maigret upstream author, so ping me if you'd rather structure the
packaging differently.

**Update, 25.08:** this now packages 0.6.5, released upstream today. Everything above that says 0.6.4 should read 0.6.5: the sdist the package builds from, the `maigret --version` output, and the `vercmp` check, which still returns 1. Rebuild details are in the comment below.
