### PR TITLE
Add package pico-sdk

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+pico-sdk

--- a/packages/pico-sdk/PKGBUILD
+++ b/packages/pico-sdk/PKGBUILD
@@ -1,0 +1,31 @@
+pkgname=pico-sdk
+pkgver=2.3.0
+pkgrel=1
+pkgdesc='Headers, libraries and build system necessary to write programs for the RP-series microcontroller-based devices.'
+arch=('any')
+groups=('blackarch' 'blackarch-hardware')
+url='https://github.com/raspberrypi/pico-sdk'
+license=('BSD-3-Clause')
+depends=()
+makedepends=('git')
+source=("git+https://github.com/raspberrypi/$pkgname.git")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null |
+      sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "%s.%s" "$(git rev-list --count HEAD)" \
+      "$(git rev-parse --short=7 HEAD)"
+  )
+}
+
+package() {
+  cd $pkgname
+  install -dm 755 "$pkgdir/usr/lib/$pkgname"
+  find . -type f -not -path "./.git**" -exec install -D "{}" "$pkgdir/usr/lib/$pkgname/{}" \;
+  install -d "$pkgname" "$pkgdir/usr/lib/$pkgname"
+}
+

--- a/packages/pico-sdk/PKGBUILD
+++ b/packages/pico-sdk/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=pico-sdk
-pkgver=2.3.0
+pkgver=2.3.0.r0.g98a542c
 pkgrel=1
 pkgdesc='Headers, libraries and build system necessary to write programs for the RP-series microcontroller-based devices.'
 arch=('any')


### PR DESCRIPTION
## Before submitting, please select the type of PR you are opening

- [x] 📦 New tool/library submission
- [ ] 🕸️ New mirror submission

---
<!-- Fill in ONLY the section that matches your PR type above. Delete the other sections. -->

# 📦 New tool/library submission

### Package name
<!-- Indicate the name of the package as it will appear in the BlackArch repository -->
pico-sdk

### Description
<!-- Clear and concise description of what the tool does and what security use case it addresses -->
Official headers, libraries, and build system for developing for some raspberry pi devices

### Source URL
<!-- Link to the tool's upstream source code repository -->
https://github.com/raspberrypi/pico-sdk

### License
<!-- Indicate the tool's license, e.g. MIT, GPL-3.0. If there is no license or source is not public, indicate "custom" -->
BSD-3-Clause

### Tool category
<!-- Indicate the most appropriate category for this tool. Available categories:
anti-forensic, automation, automobile, backdoor, binary, bluetooth, code-audit, cracker,
crypto, database, debugger, decompiler, defensive, disassembler, dos, drone, exploitation,
fingerprint, firmware, forensic, fuzzer, hardware, honeypot, ids, keylogger, malware, misc,
mobile, networking, nfc, packer, proxy, radio, recon, reversing, scanner, sniffer, social,
spoof, stego, tunnel, voip, webapp, windows, wireless -->
hardware

### Additional context
<!-- Any other relevant information, e.g. known limitations, special dependencies, platform constraints -->
This is a dependency for my other pull request to add picotool #5031

### Checklist

- [x] I assert that this tool is not already available in BlackArch or the official [Arch Linux repositories](https://archlinux.org/packages/).
- [x] I assert that this is not a duplicate of an [existing open PR](https://github.com/BlackArch/blackarch/pulls?q=is%3Aopen).
- [x] I assert that I have successfully tested, built and installed the package locally.
- [x] I assert that the PKGBUILD follows the official [BlackArch PKGBUILD templates](https://github.com/BlackArch/blackarch-pkgbuilds).
- [x] I assert that the tool is actively maintained upstream and does not depend on deprecated languages or libraries.
- [x] I assert that I have read the [Arch Linux Code of Conduct](https://terms.archlinux.org/docs/code-of-conduct/) and agree to abide by it.