### PR TITLE
wayparam: update to 0.4.0

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+wayparam

--- a/packages/wayparam/PKGBUILD
+++ b/packages/wayparam/PKGBUILD
@@ -2,8 +2,8 @@
 # See COPYING for license details.
 
 pkgname=wayparam
-pkgver=0.3.0
-pkgrel=2
+pkgver=0.4.0
+pkgrel=1
 pkgdesc='Fetch and normalize parameterized URLs from the Wayback CDX API.'
 arch=('any')
 groups=('blackarch' 'blackarch-webapp' 'blackarch-recon')
@@ -11,8 +11,8 @@ url='https://github.com/aleff-github/wayparam'
 license=('GPL-3.0-or-later')
 depends=('python' 'python-httpx')
 makedepends=('python-build' 'python-pip')
-source=("https://github.com/aleff-github/wayparam/archive/refs/tags/v$pkgver.tar.gz")
-sha512sums=('4739985f564ca3daaea6a2ef56acfe1cfaeb1858985b1fa84f470a2ae203b4de35063a30950172490a8345e877b6ae6d0bd04988771f89cd440a677b27ca8092')
+source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz")
+sha256sums=('0b785341ed5efa69e881e82d620a92e3a70aa4ba1f8d7088f499b90021988f50')
 
 build() {
   cd "$pkgname-$pkgver"
@@ -36,4 +36,3 @@ package() {
     --find-links="file://$startdir/dist" \
     $pkgname
 }
-


### PR DESCRIPTION
Update wayparam from 0.3.0 to 0.4.0.

Changes:

* bump `pkgver` from 0.3.0 to 0.4.0;
* reset `pkgrel` to 1;
* update the package source and checksum;
* add `wayparam` to `lists/to-release`.

The package was successfully built, installed and tested in an Arch Linux environment.

Tests included:

* `wayparam --help`
* a passive Wayback CDX query

Upstream:
https://github.com/aleff-github/wayparam

This supersedes package request #5035, which was opened before noticing that wayparam was already available in BlackArch.
