### PR TITLE
add mailcat

### DIFF
--- a/packages/mailcat/PKGBUILD
+++ b/packages/mailcat/PKGBUILD
@@ -1,0 +1,33 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+pkgname=mailcat
+pkgver=0.1.1
+pkgrel=1
+pkgdesc='The only cat who can find existing email addresses by nickname'
+arch=('any')
+groups=('blackarch' 'blackarch-social' 'blackarch-recon')
+url='https://github.com/sharsil/mailcat/'
+license=('Apache-2.0')
+depends=('python' 'python-aiohttp' 'python-aiohttp-socks' 'python-aiosmtplib'
+         'python-dnspython' 'python-lxml-html-clean' 'python-requests-html'
+         'python-tqdm')
+makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/sharsil/$pkgname/archive/refs/heads/main.tar.gz")
+sha512sums=('a91f3f5adb89b034ff21bb890fd748b3e482286bb189932ddbb58d56e73ad5e9d7e4059363c1d4b41c070582b199343f0a933539db34ff4db60f9a8ff361b6cd')
+
+build() {
+  cd "$pkgname-main"
+
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "$pkgname-main"
+
+  python -m installer --destdir="$pkgdir" dist/*.whl
+
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+


### PR DESCRIPTION
## Before submitting, please select the type of PR you are opening

- [x] 📦 New tool/library submission
- [ ] 🕸️ New mirror submission

---
<!-- Fill in ONLY the section that matches your PR type above. Delete the other sections. -->

# 📦 New tool/library submission

## Before submitting, please read the requirements

> **🚫 Illegal or unethical software:**
> Examples include brute-forcing social media accounts or DoS attack scripts.

> **🚫 Abandoned or extremely outdated software:**
> Especially if it no longer builds, creates dependency conflicts, or has no active upstream maintenance.

> **🚫 Deprecated languages or libraries dependency:**
> For example, Python 2 or other retired technologies that introduce security or compatibility issues.

> **🚫 Wrapper scripts with no unique functionality:**
> Scripts that simply call another tool with preset arguments (e.g., a front-end that just runs `nmap -sV ...`).

> **🚫 Non-portable or broken build systems:**
> Tools tied to a specific non-Arch distribution or that cannot be cleanly built on Arch/BlackArch.

> **🚫 Duplicate functionality:**
> Tools already covered by better-maintained or more widely-used alternatives in the repository.

> **🚫 Unnecessary anonymization helpers:**
> Scripts such as "free VPN launcher" tools. BlackArch already includes **torctl** for legitimate anonymization.

> **🚫 PKGBUILD does not follow official templates:**
> Submissions must follow the official PKGBUILD templates available in the [BlackArch PKGBUILDs repository](https://github.com/BlackArch/blackarch-pkgbuilds). PRs that deviate significantly from the templates will be rejected or sent back for revision.

### Package name
<!-- Indicate the name of the package as it will appear in the BlackArch repository -->
mailcat

### Description
<!-- Clear and concise description of what the tool does and what security use case it addresses -->

CLI OSINT tool to find existing email addresses by nickname.

Supported Services:

Gmail, Yandex, Protonmail, MailRu, Rambler, Yahoo, AOL, Outlook, Zoho, Eclipso, Posteo, Firemail, Fastmail, StartMail, Ukrnet, Runbox, DuckGo, emailn, aikq, Vivaldi, mailDe, int.pl, Interia, t.pl, onet.pl, Mailum
### Source URL
<!-- Link to the tool's upstream source code repository -->
https://github.com/sharsil/mailcat

### License
<!-- Indicate the tool's license, e.g. MIT, GPL-3.0. If there is no license or source is not public, indicate "custom" -->
Apache-2.0

### Tool category
<!-- Indicate the most appropriate category for this tool. Available categories:
anti-forensic, automation, automobile, backdoor, binary, bluetooth, code-audit, cracker,
crypto, database, debugger, decompiler, defensive, disassembler, dos, drone, exploitation,
fingerprint, firmware, forensic, fuzzer, hardware, honeypot, ids, keylogger, malware, misc,
mobile, networking, nfc, packer, proxy, radio, recon, reversing, scanner, sniffer, social,
spoof, stego, tunnel, voip, webapp, windows, wireless -->
recon, social

### Additional context
<!-- Any other relevant information, e.g. known limitations, special dependencies, platform constraints -->


### Checklist

- [x] I assert that this tool is not already available in BlackArch or the official [Arch Linux repositories](https://archlinux.org/packages/).
- [x] I assert that this is not a duplicate of an [existing open PR](https://github.com/BlackArch/blackarch/pulls?q=is%3Aopen).
- [x] I assert that I have successfully tested, built and installed the package locally.
- [x] I assert that the PKGBUILD follows the official [BlackArch PKGBUILD templates](https://github.com/BlackArch/blackarch-pkgbuilds).
- [x] I assert that the tool is actively maintained upstream and does not depend on deprecated languages or libraries.
- [x] I assert that I have read the [Arch Linux Code of Conduct](https://terms.archlinux.org/docs/code-of-conduct/) and agree to abide by it.


