### PR TITLE
boltclaw: add package (request #4890)

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+boltclaw

--- a/packages/boltclaw/PKGBUILD
+++ b/packages/boltclaw/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Diogo Damasceno <mitszukyo@gmail.com>
+
+pkgname=boltclaw
+_pkgname=BoltClaw
+pkgver=1.1.0
+pkgrel=1
+pkgdesc='Security control panel for AI-agent skills and MCP servers: config hardening, skill scanning, risk scoring'
+arch=('any')
+groups=('blackarch' 'blackarch-misc')
+url='https://github.com/Sonofg0tham/BoltClaw'
+license=('MIT')
+depends=('nodejs')
+makedepends=('npm' 'git')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Sonofg0tham/$_pkgname/archive/refs/tags/v$pkgver.tar.gz")
+sha512sums=('eb4f4f83f2bc689edacbb92b6fef6dd20731f4b2f39207b45cd66038e4443c8024ab4bfde293472dfb704e5d250198000cdeae8cb75c5c2250af77af73800814')
+
+build() {
+  cd "$_pkgname-$pkgver"
+
+  # Monorepo with private workspaces; the published pkg is broken via
+  # `npm install -g` because @boltclaw/* deps live in devDependencies.
+  # Build all workspaces and vendor node_modules.
+  npm install
+  npm run build --workspaces
+}
+
+package() {
+  cd "$_pkgname-$pkgver"
+
+  install -dm 755 "$pkgdir/usr/bin"
+  install -dm 755 "$pkgdir/usr/share/$pkgname"
+  install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md CHANGELOG.md
+  install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+  # Ship the full built tree (node_modules + dist) so the bin can resolve
+  # the private @boltclaw/* workspace deps at runtime.
+  cp -a . "$pkgdir/usr/share/$pkgname/"
+
+  cat > "$pkgdir/usr/bin/$pkgname" << EOF
+#!/bin/sh
+exec node /usr/share/$pkgname/packages/mcp-server/dist/index.js "\$@"
+EOF
+
+  chmod +x "$pkgdir/usr/bin/$pkgname"
+}
+


### PR DESCRIPTION
# boltclaw: add package (request #4890)

Adds **boltclaw** (BoltClaw), a security control panel for AI-agent skills and MCP servers — config hardening, skill scanning, and risk scoring for OpenClaw / NanoClaw / NemoClaw. MIT licensed.

Closes #4890.

## Source URL
https://github.com/Sonofg0tham/BoltClaw

## License
MIT

## Important packaging note (upstream differs from the issue skeleton)
The package request #4890 contained a temp skeleton that treated BoltClaw as a plain Node script with `npm install -g`. In reality it is a **TypeScript monorepo with private workspaces**: the `boltclaw` bin lives in `packages/mcp-server`, but it depends on `@boltclaw/config-engine` and `@boltclaw/skill-scanner`, which are declared only in `devDependencies`. A published `npm install -g boltclaw` is therefore broken (the workspace deps do not resolve). I built from source instead:

- `npm install` at the repo root (resolves the workspaces),
- `npm run build --workspaces` (tsup builds `packages/mcp-server/dist/index.js`),
- the full built tree (including the vendored `node_modules` with the `@boltclaw/*` workspace symlinks) is shipped to `/usr/share/boltclaw`, and `usr/bin/boltclaw` execs `node /usr/share/boltclaw/packages/mcp-server/dist/index.js`.

## Build notes
- Node `>=22` is required (`engines` in package.json); the host runs Node 22.23.2, which satisfies it.
- `arch=('any')` (pure JS/TS).
- `license=('MIT')` — verified against the upstream LICENSE file.
- `pkgver=1.1.0`, matching the `v1.1.0` tag (latest tag; the `v1.0.0` release tag is older).

## Verification
- `makepkg -f` completes cleanly (the `gdb-add-index` / `hipblaslt` messages are host noise, not package errors).
- Package contains `usr/bin/boltclaw` and the upstream built tree under `usr/share/boltclaw/` (including `node_modules`, `dist/index.js`, LICENSE, README/CHANGELOG).
- Installed and run: `boltclaw --help` starts the MCP server on stdio (`BoltClaw MCP server running on stdio`, exit 0); package removed cleanly afterward.
- `pkgcheck PKGBUILD` exits 0 (no warnings).
