### PR TITLE
Rebuild packages to fix makepkgopt key warning

### DIFF
--- a/packages/airpwn/PKGBUILD
+++ b/packages/airpwn/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=airpwn
 pkgver=1.4
-pkgrel=4
+pkgrel=3
 pkgdesc='A tool for generic packet injection on an 802.11 network.'
 arch=('x86_64' 'aarch64')
 url='http://airpwn.sourceforge.net/'

--- a/packages/airpwn/PKGBUILD
+++ b/packages/airpwn/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=airpwn
 pkgver=1.4
-pkgrel=3
+pkgrel=4
 pkgdesc='A tool for generic packet injection on an 802.11 network.'
 arch=('x86_64' 'aarch64')
 url='http://airpwn.sourceforge.net/'

--- a/packages/arpalert/PKGBUILD
+++ b/packages/arpalert/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=arpalert
 pkgver=2.0.12
-pkgrel=1
+pkgrel=2
 epoch=1
 pkgdesc='Monitor ARP changes in ethernet networks.'
 arch=('x86_64' 'aarch64')

--- a/packages/arpoison/PKGBUILD
+++ b/packages/arpoison/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=arpoison
 pkgver=0.7
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-exploitation' 'blackarch-spoof')
 pkgdesc='The UNIX arp cache update utility.'
 arch=('x86_64' 'aarch64')

--- a/packages/balbuzard/PKGBUILD
+++ b/packages/balbuzard/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=balbuzard
 pkgver=67.d6349ef1bc55
-pkgrel=4
+pkgrel=5
 pkgdesc='A package of malware analysis tools in python to extract patterns of interest from suspicious files (IP addresses, domain names, known file headers, interesting strings, etc).'
 arch=('any')
 groups=('blackarch' 'blackarch-malware' 'blackarch-cracker'

--- a/packages/beholder/PKGBUILD
+++ b/packages/beholder/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=beholder
 pkgver=0.8.10
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-wireless' 'blackarch-defensive')
 pkgdesc='A wireless intrusion detection tool that looks for anomalies in a wifi environment.'
 arch=('x86_64' 'aarch64')

--- a/packages/beleth/PKGBUILD
+++ b/packages/beleth/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=beleth
 pkgver=36.0963699
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-cracker')
 pkgdesc='A Multi-threaded Dictionary based SSH cracker.'
 url='https://github.com/chokepoint/Beleth'

--- a/packages/bittwist/PKGBUILD
+++ b/packages/bittwist/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=bittwist
 pkgver=2.0
-pkgrel=2
+pkgrel=3
 pkgdesc='A simple yet powerful libpcap-based Ethernet packet generator. It is designed to complement tcpdump, which by itself has done a great job at capturing network traffic.'
 arch=('x86_64' 'aarch64')
 groups=('blackarch' 'blackarch-sniffer' 'blackarch-networking')

--- a/packages/blindelephant/PKGBUILD
+++ b/packages/blindelephant/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=blindelephant
 pkgver=8
-pkgrel=4
+pkgrel=5
 groups=('blackarch' 'blackarch-fingerprint' 'blackarch-webapp')
 pkgdesc='A web application fingerprinter. Attempts to discover the version of a (known) web application by comparing static files at known locations'
 url='http://blindelephant.sourceforge.net/'

--- a/packages/bluelog/PKGBUILD
+++ b/packages/bluelog/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=bluelog
 pkgver=1.1.2
-pkgrel=1
+pkgrel=2
 groups=('blackarch' 'blackarch-bluetooth' 'blackarch-scanner')
 pkgdesc='A Bluetooth scanner and sniffer written to do a single task, log devices that are in discoverable mode.'
 url='http://www.digifail.com/software/bluelog.shtml'

--- a/packages/dirb/PKGBUILD
+++ b/packages/dirb/PKGBUILD
@@ -3,12 +3,12 @@
 
 pkgname=dirb
 pkgver=2.22
-pkgrel=3
+pkgrel=4
 groups=('blackarch' 'blackarch-scanner' 'blackarch-webapp')
 pkgdesc='A web content scanner, brute forcing for hidden files.'
 url='http://dirb.sourceforge.net/'
 arch=('x86_64' 'aarch64')
-license=('GPL2')
+license=('GPL-2.0-or-later')
 depends=('curl')
 source=("http://downloads.sourceforge.net/project/dirb/dirb/$pkgver/${pkgname}${pkgver//./}.tar.gz")
 sha512sums=('57305160b11be9d48b44ece5848a102ab7a493a7ac30a44c31339fd7ca659866521ba621dc0639dc28bf21c3b5315390b934441590dac7d5b463e68df4b80b81')


### PR DESCRIPTION
Fix the warning:
```
warning: <pkgname>: unknown key 'makepkgopt' in package description
```