### PR TITLE
statsprocessor: fix url https

### DIFF
--- a/lists/to-release
+++ b/lists/to-release
@@ -1,0 +1,1 @@
+statsprocessor

--- a/packages/statsprocessor/PKGBUILD
+++ b/packages/statsprocessor/PKGBUILD
@@ -3,13 +3,13 @@
 
 pkgname=statsprocessor
 pkgver=0.11
-pkgrel=2
+pkgrel=3
 epoch=5
-groups=('blackarch' 'blackarch-automation')
 pkgdesc='A high-performance word-generator based on per-position Markov-attack.'
 arch=('x86_64' 'aarch64')
-url='http://hashcat.net/wiki/doku.php?id=statsprocessor'
-license=('custom:unknown')
+groups=('blackarch' 'blackarch-automation')
+url='https://hashcat.net/wiki/doku.php?id=statsprocessor'
+license=('MIT')
 makedepends=('p7zip')
 source=("https://github.com/jsteube/statsprocessor/releases/download/v$pkgver/statsprocessor-$pkgver.7z")
 sha512sums=('b98bd6a35916da611160b536836163e0af887b58ddc489120396081b18e7fb6f5ba2a3fe51f0e9304df75ebc3e3f7f9608bfa5a79d2ce517ac8322eb63c7c4a6')


### PR DESCRIPTION
This PR and similar are intended to align the PKGBUILD info and for rebuilding in order to solve the warning `unknown key 'makepkgopt' in package description`.